### PR TITLE
Reach the policies from inside the app

### DIFF
--- a/src/components/legal-anchor.test.tsx
+++ b/src/components/legal-anchor.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import {
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  createMemoryHistory,
+} from "@tanstack/react-router";
+
+import { LegalAnchor } from "./legal-anchor";
+
+function renderInRouter(ui: ReactNode) {
+  const rootRoute = createRootRoute();
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: () => ui,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+  return render(<RouterProvider router={router} />);
+}
+
+describe("LegalAnchor", () => {
+  it("routes to a built-in page without leaving the app", async () => {
+    renderInRouter(<LegalAnchor link={{ href: "/terms", external: false }}>Terms</LegalAnchor>);
+    const link = await screen.findByRole("link", { name: "Terms" });
+    expect(link).toHaveAttribute("href", "/terms");
+    expect(link).not.toHaveAttribute("target");
+  });
+
+  it("sends an operator's own document out as a plain anchor", async () => {
+    renderInRouter(
+      <LegalAnchor link={{ href: "https://example.com/terms", external: true }} newTab>
+        Terms
+      </LegalAnchor>,
+    );
+    const link = await screen.findByRole("link", { name: "Terms" });
+    expect(link).toHaveAttribute("href", "https://example.com/terms");
+    expect(link).toHaveAttribute("target", "_blank");
+    // An external document is somebody else's page, and referrers leak which
+    // deployment its readers came from.
+    expect(link).toHaveAttribute("rel", "noreferrer");
+  });
+
+  it("opens in a new tab only when asked, on either kind of link", async () => {
+    const { unmount } = renderInRouter(
+      <LegalAnchor link={{ href: "/privacy", external: false }} newTab>
+        Privacy
+      </LegalAnchor>,
+    );
+    expect(await screen.findByRole("link", { name: "Privacy" })).toHaveAttribute(
+      "target",
+      "_blank",
+    );
+    unmount();
+
+    renderInRouter(
+      <LegalAnchor link={{ href: "https://example.com/privacy", external: true }}>
+        Privacy
+      </LegalAnchor>,
+    );
+    expect(await screen.findByRole("link", { name: "Privacy" })).not.toHaveAttribute("target");
+  });
+
+  it("carries no styling of its own when the surrounding surface owns it", async () => {
+    // The landing footer styles its links through `.footer__bottom a`; an
+    // inline underline class there would be the only underlined thing in the
+    // bar.
+    renderInRouter(
+      <LegalAnchor link={{ href: "/terms", external: false }} variant="plain">
+        Terms
+      </LegalAnchor>,
+    );
+    expect(await screen.findByRole("link", { name: "Terms" })).not.toHaveAttribute("class");
+  });
+});

--- a/src/components/legal-anchor.tsx
+++ b/src/components/legal-anchor.tsx
@@ -1,0 +1,49 @@
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+import type { LegalLink } from "@/lib/legal";
+
+/**
+ * One link to a legal document, wherever `lib/legal.ts` says that document is.
+ *
+ * The two halves of a legal link are owned by different modules — `lib/legal.ts`
+ * decides the destination, the caller decides how it looks — and that seam is
+ * where a dead link hides. This exists so the third caller did not become a
+ * third copy of the internal/external branch: an operator's configured URL
+ * needs `<a rel="noreferrer">`, a built-in page needs `<Link>`, and confusing
+ * the two shows up as a route that silently full-page reloads.
+ *
+ * `newTab` is a decision about what is behind the link rather than about the
+ * link. The sign-up form and the app both have state a reader would lose;
+ * the landing page's footer has nothing to lose.
+ */
+export function LegalAnchor({
+  link,
+  children,
+  variant = "inline",
+  newTab = false,
+}: {
+  link: LegalLink;
+  children: ReactNode;
+  /** `inline` underlines for running text; `plain` inherits its surroundings. */
+  variant?: "inline" | "plain";
+  newTab?: boolean;
+}) {
+  const className =
+    variant === "inline"
+      ? "text-foreground underline underline-offset-4 hover:no-underline"
+      : undefined;
+  const target = newTab ? "_blank" : undefined;
+
+  if (link.external) {
+    return (
+      <a href={link.href} target={target} rel="noreferrer" className={className}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link to={link.href} target={target} className={className}>
+      {children}
+    </Link>
+  );
+}

--- a/src/routes/_authed.settings.tsx
+++ b/src/routes/_authed.settings.tsx
@@ -14,6 +14,8 @@ import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api-client";
 import { isAdminRole } from "@/lib/roles";
+import { privacyLink, termsLink } from "@/lib/legal";
+import { LegalAnchor } from "@/components/legal-anchor";
 
 export const Route = createFileRoute("/_authed/settings")({
   component: SettingsPage,
@@ -207,6 +209,22 @@ function SettingsPage() {
         <UsageSection />
 
         <DeliveryChannelsCard />
+
+        {/* Both documents were reachable from exactly one place — the "I agree"
+            checkbox on the sign-up form — so the moment somebody had an account
+            they had no way back to what they had agreed to. Settings is where a
+            reader looks, and it is what both entries in the sidebar's account
+            menu lead to. New tab: nobody should lose a workspace to read a
+            policy. */}
+        <p className="mt-16 border-t border-hairline pt-6 text-xs text-muted-foreground">
+          <LegalAnchor link={termsLink()} newTab>
+            Terms
+          </LegalAnchor>{" "}
+          ·{" "}
+          <LegalAnchor link={privacyLink()} newTab>
+            Privacy Policy
+          </LegalAnchor>
+        </p>
       </PageContainer>
     </AppShell>
   );

--- a/src/routes/routes.test.ts
+++ b/src/routes/routes.test.ts
@@ -46,4 +46,19 @@ describe("route files", () => {
     expect(builtIn).not.toEqual([]);
     expect(routeFiles()).toEqual(expect.arrayContaining(builtIn));
   });
+
+  // Having the pages is not the same as being able to reach them. This build
+  // has no landing page, so for the whole beta the only link to either document
+  // anywhere was the sign-up form's "I agree" checkbox — the one surface a
+  // person passes through exactly once. This walks the source rather than
+  // rendering Settings, because the regression to catch is a deletion, and a
+  // deleted link fails no render test.
+  it("links to both documents from somewhere inside the signed-in app", () => {
+    const authed = routeFiles()
+      .filter((f) => f.startsWith("_authed"))
+      .map((f) => readFileSync(`${ROUTES_DIR}${f}`, "utf8"));
+
+    expect(authed.some((src) => src.includes("termsLink"))).toBe(true);
+    expect(authed.some((src) => src.includes("privacyLink"))).toBe(true);
+  });
 });

--- a/src/routes/sign-up.tsx
+++ b/src/routes/sign-up.tsx
@@ -7,32 +7,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { supabase } from "@/lib/supabase/client";
-import { privacyLink, termsLink, type LegalLink } from "@/lib/legal";
+import { privacyLink, termsLink } from "@/lib/legal";
+import { LegalAnchor } from "@/components/legal-anchor";
 
 export const Route = createFileRoute("/sign-up")({
   component: SignUp,
 });
-
-/**
- * A built-in page is a router link; an operator's own document is an ordinary
- * anchor that opens in a new tab — leaving a half-filled signup form to read
- * the terms and losing it would be its own small cruelty.
- */
-function LegalAnchor({ link, children }: { link: LegalLink; children: ReactNode }) {
-  const className = "text-foreground underline underline-offset-4 hover:no-underline";
-  if (link.external) {
-    return (
-      <a href={link.href} target="_blank" rel="noreferrer" className={className}>
-        {children}
-      </a>
-    );
-  }
-  return (
-    <Link to={link.href} target="_blank" className={className}>
-      {children}
-    </Link>
-  );
-}
 
 function SignUp() {
   const navigate = useNavigate();
@@ -201,8 +181,15 @@ function SignUp() {
         <label className="flex flex-wrap items-start gap-x-1 gap-y-2 text-sm text-muted-foreground">
           <Checkbox id="terms" required className="mt-0.5" />
           <span>
-            I agree to the <LegalAnchor link={termsLink()}>Terms</LegalAnchor> and{" "}
-            <LegalAnchor link={privacyLink()}>Privacy Policy</LegalAnchor>.
+            I agree to the{" "}
+            <LegalAnchor link={termsLink()} newTab>
+              Terms
+            </LegalAnchor>{" "}
+            and{" "}
+            <LegalAnchor link={privacyLink()} newTab>
+              Privacy Policy
+            </LegalAnchor>
+            .
           </span>
         </label>
 


### PR DESCRIPTION
This build has no landing page, so until now the only link to the Terms or the Privacy Policy anywhere in it was the "I agree" checkbox on the sign-up form — the one surface a person passes through exactly once. Anybody who already had an account had no route back to what they had agreed to, and no way to read either document without guessing the URL.

A quiet line at the foot of Settings, which is where a reader looks and is what both entries in the sidebar's account menu already lead to. It opens in a new tab — nobody should have to leave a workspace to read a policy.

Three callers was the point at which the internal/external branch stopped being worth copying, so `LegalAnchor` moves to `src/components/` with its own test. That branch is the seam where a dead link hides: `lib/legal.ts` owns the destination and the caller owns the styling, so neither side looks wrong on its own.

`routes.test.ts` gains the invariant this was missing — some route under `_authed` links to both. It walks the source rather than rendering Settings, because the regression to catch is a deletion, and a deleted link fails no render test.

For an operator who has set `VITE_TERMS_URL` / `VITE_PRIVACY_URL`, all of this points at their documents rather than the built-in pages; nothing here assumes the built-in ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)