### PR TITLE
Write down what the registry actually needs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,55 @@ name: Release
 # `edge`, so there is always something current to pull between releases.
 #
 # ---------------------------------------------------------------------------
-# ONE MANUAL STEP, ONCE PER PACKAGE, and nothing here can do it.
+# MANUAL STEPS, and nothing here can do any of them. Two are policy, once per
+# organisation; one is per package. All three were learned the hard way, so
+# the order below is the order that works.
 #
-# GitHub creates container packages **private**, whatever the repository's
-# visibility. Until each is switched to public, an anonymous `docker pull`
-# answers `401 Unauthorized` — so the quickstart in the README does not work,
-# and it fails in a way that looks like the image was never published.
+# 1. ORG: allow public packages at all.
 #
-#   https://github.com/orgs/covan-ai/packages/container/covan-api/settings
-#   https://github.com/orgs/covan-ai/packages/container/covan-web/settings
+#    https://github.com/organizations/covan-ai/settings/packages
 #
-# Danger zone -> Change visibility -> Public. There is no workflow permission
-# that grants this and no supported API call for org container packages, which
-# is why it is written here rather than automated.
+#    Package creation -> Public -> Enabled. While this is off, step 3 exists
+#    but is greyed out with "Setting is disabled by organization
+#    administrators", which reads like a bug in the package page rather than
+#    a policy two menus away.
+#
+# 2. A PACKAGE BELONGS TO THE REPOSITORY THAT FIRST PUSHED IT, by numeric id
+#    rather than by name. Rename that repository, or replace it with a fresh
+#    one of the same name, and the package stays with the old id — this
+#    workflow then fails every run with
+#
+#      denied: permission_denied: read_package
+#
+#    which sounds like a missing scope and is not one. `packages: write` below
+#    is correct and cannot help: the registry is refusing on ownership, not on
+#    permission. No access list on the new repository fixes it either. The fix
+#    is to DELETE the package and let this repository create it again.
+#
+#    This is exactly what happened when covan-ai/covan was rebuilt from
+#    scratch on 2026-08-25 and the original became covan-archive. Five green
+#    runs there, then every run here red, while the README went on telling
+#    people to `docker compose pull`.
+#
+# 3. PER PACKAGE: GitHub creates container packages **private**, whatever the
+#    repository's visibility. Until each is switched to public, an anonymous
+#    `docker pull` answers `401 Unauthorized` — so the quickstart in the README
+#    does not work, and it fails in a way that looks like the image was never
+#    published.
+#
+#      https://github.com/orgs/covan-ai/packages/container/covan-api/settings
+#      https://github.com/orgs/covan-ai/packages/container/covan-web/settings
+#
+#    Danger zone -> Change visibility -> Public. There is no workflow
+#    permission that grants this and no supported API call for org container
+#    packages, which is why it is written here rather than automated.
+#
+# Verify from somewhere unauthenticated, not from a shell that is logged in.
+# A green run and a pull that works for a maintainer are both compatible with
+# a package nobody else can reach:
+#
+#   curl -s "https://ghcr.io/token?scope=repository:covan-ai/covan-api:pull&service=ghcr.io"
+#   # then GET https://ghcr.io/v2/covan-ai/covan-api/tags/list with that token
 # ---------------------------------------------------------------------------
 
 on:


### PR DESCRIPTION
Comments only — `git diff` touches no YAML. The header documented one manual step and there are three, and the two it was missing are the two that cost a day in #23.

**A package belongs to the repository that first pushed it, by numeric id rather than by name.** This repository was rebuilt from scratch on 2026-08-25 and the original became `covan-archive`; the packages stayed with the old id, so every run here failed with `permission_denied: read_package` while the README went on telling people to `docker compose pull`. That error reads like a missing scope and is not one — `packages: write` is correct and cannot help, because the registry is refusing on ownership rather than permission. Deleting the package is the fix, and nothing about that is guessable from the message.

**An organisation can forbid public packages outright**, in which case the per-package visibility switch is greyed out with *"Setting is disabled by organization administrators"* — a policy two menus away, described in a way that reads like a broken page.

Also added the unauthenticated check. A green run and a pull that works for a maintainer are both compatible with a package nobody else can reach, which is the failure this note exists to prevent and the one thing you cannot see from a logged-in shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)