### PR TITLE
Stop one account from spending the whole budget

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -89,6 +89,23 @@ ROUTINE_TICK_MS=60000
 # source instead of pulling.
 COVAN_VERSION=latest
 
+# ---- Optional: how often one caller may ask -----------------------------
+# Requests per minute. Unset takes the built-in defaults, so a stack nobody
+# configured is still bounded — which is the point, since `POST /chat/stream`
+# and friends spend money at OpenAI on every call.
+#
+# standard  in front of everything, keyed by the caller's address
+# expensive in front of the six endpoints that buy a completion or a
+#           transcription, keyed by the signed-in user
+#
+# Set either to 0 to turn that tier off, which is what you want if you already
+# rate-limit in nginx, Caddy or Cloudflare in front of this — two limiters that
+# disagree is worse than one. Counters live in the API process, so with more
+# than one replica the effective limit is this times the number of replicas;
+# limit at the proxy instead in that case. See docs/self-hosting.md.
+RATE_LIMIT_STANDARD_PER_MINUTE=
+RATE_LIMIT_EXPENSIVE_PER_MINUTE=
+
 # ---- Optional: email delivery for routines -----------------------------
 # Leave blank to disable email delivery. https://resend.com
 RESEND_API_KEY=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,6 +291,10 @@ services:
       # No R2 binding off Cloudflare, so getDocStore falls to the filesystem
       # store rooted here. This path is a volume; see below.
       DOCS_DIR: /data/docs
+      # Requests per minute, per tier. Empty means the built-in defaults; 0 turns
+      # a tier off for an operator who limits at their own proxy instead.
+      RATE_LIMIT_STANDARD_PER_MINUTE: ${RATE_LIMIT_STANDARD_PER_MINUTE:-}
+      RATE_LIMIT_EXPENSIVE_PER_MINUTE: ${RATE_LIMIT_EXPENSIVE_PER_MINUTE:-}
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       RESEND_FROM: ${RESEND_FROM:-}
       PORT: 8787

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -282,41 +282,67 @@ Before the stack faces a network:
 3. Put TLS in front of ports 3000, 8787 and 8000, and set
    `SUPABASE_PUBLIC_URL`, `VITE_API_URL`, `SITE_URL` and `ALLOWED_ORIGIN` to
    the public URLs — then rebuild `covan-web`.
-4. Rate-limit the API at that same proxy. See below.
+4. Rate-limit the API at that same proxy, as well as the built-in limiter. See below.
 5. Consider not publishing `54322` at all.
 
-### Covan does not rate-limit itself
+### Covan rate-limits itself, and you should still limit at the proxy
 
-There is no request limiter anywhere in the API, on either deployment path.
-That is a real gap and you should close it before the API is reachable from the
-internet.
+Two tiers, on by default, on both deployment paths. They exist because
+`POST /chat/stream`, `POST /transcribe` and four other endpoints spend money at
+OpenAI on every call, so an authenticated user with a loop — or one leaked
+password — is an unbounded bill rather than a denial of service. Request _size_
+was always bounded (10 MB for a document, 2 MB for audio); that caps what one
+call costs, not how many arrive.
 
-What the API _does_ bound is the size of a single request: 10 MB for a document
-upload, 2 MB for an audio recording. Neither bounds how _often_ someone asks,
-and this build ships no spend cap either — `worker/src/lib/entitlements/` is an
-interface with `unlimitedEntitlements` behind it, which is exactly what it
-sounds like. (`QUOTA_MONTHLY_TOKENS` exists in the environment type, but nothing
-in this repository registers a metered implementation to read it, so setting it
-changes nothing.)
+| Tier        | In front of                                                                                                            | Keyed on             | Default |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------- | ------- |
+| `standard`  | everything, including the token check                                                                                  | the caller's address | 120/min |
+| `expensive` | `/chat/stream`, `/transcribe`, `/brainstorm/ideas/suggest`, `/persona/suggest`, `/routines/draft`, `/routines/:id/run` | the signed-in user   | 20/min  |
 
-`POST /chat` and `POST /transcribe` both spend money at OpenAI on every call, so
-an authenticated user with a loop, or one leaked password, is an unbounded bill
-rather than a denial of service. The rest of the API is cheaper to serve but
-just as unlimited.
+`standard` is generous on purpose: it is keyed by address, a shared office is
+one address, and its job is to bound how often the Supabase round trip in the
+token check can be provoked — not to ration ordinary use. `expensive` is keyed
+by the user, so one person's loop cannot spend a colleague's allowance, and it
+is set at more than a person can type and far less than a loop can.
 
-Authentication is not the answer here: a limiter has to sit in front of the
-thing being protected, and every one of these routes is already past the door.
+Document upload and reindex stay on `standard` deliberately. They spend on
+embeddings, which cost roughly a hundredth of what a chat token does, and 20/min
+would break bulk upload to bound a cost the generous tier already bounds.
 
-Put it in the layer you already have:
+A refused request gets `429` and a `Retry-After` header.
 
-| Deployment                                       | Where the limiter goes                                                                                                                        |
+**Under `docker compose`** the counter lives in the API process. Set
+`RATE_LIMIT_STANDARD_PER_MINUTE` and `RATE_LIMIT_EXPENSIVE_PER_MINUTE` to change
+the numbers, or either to `0` to turn that tier off. Two honest limitations:
+
+- **One process, one counter.** Run two replicas and each keeps its own, so the
+  effective limit is the configured one times the number of replicas. If you are
+  running replicas you have a proxy in front of them; set the real limit there
+  and these to `0`.
+- **A fixed window, not a sliding one.** A caller can spend the whole allowance
+  in the last second of one window and again in the first second of the next.
+  That is a factor of two on a limit whose job is to turn unbounded into bounded.
+
+**On Cloudflare Workers** the counter lives in the edge, via the two
+`[[ratelimits]]` blocks in `worker/wrangler.toml` — the limit is set there
+rather than in an environment variable, because the binding owns the counter.
+Deploy without them and the Worker falls back to the in-process counter, which
+on Cloudflare is close to no limit at all: isolates are many and short-lived, so
+each keeps its own. It logs an error saying exactly that, but it will not refuse
+to start, so check `wrangler.toml` against the example rather than the logs.
+
+**Limit at your proxy as well.** Nothing above sees a request that never reaches
+the API, and everything above runs after TLS termination and inside your
+application. A limiter in the layer you already have is cheaper per refused
+request and protects against shapes this one cannot see:
+
+| Deployment                                       | Where the second limiter goes                                                                                                                 |
 | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `docker compose`, behind nginx / Caddy / Traefik | The reverse proxy from step 3. nginx's `limit_req`, Caddy's `rate_limit`, Traefik's `RateLimit` middleware — any of them, keyed on client IP. |
-| Cloudflare Workers                               | A [Rate Limiting rule](https://developers.cloudflare.com/waf/rate-limiting-rules/) on the zone, or the Workers rate limiting binding.         |
+| Cloudflare Workers                               | A [Rate Limiting rule](https://developers.cloudflare.com/waf/rate-limiting-rules/) on the zone, in front of the Worker.                       |
 
-Key on the caller's IP for anonymous routes and on the bearer token's subject
-for the rest, and be much stricter with `/chat` and `/transcribe` than with the
-others — the point is the OpenAI bill, not the traffic.
+If you do, set the built-in tiers to `0` rather than running two limiters that
+disagree about who is over.
 
 ## The production path: Cloudflare, Supabase and a static host
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import type { AppEnv, Bindings } from "./types";
 import { authMiddleware } from "./middleware/auth";
 import { entitlementsMiddleware } from "./middleware/entitlements";
+import { rateLimit } from "./middleware/ratelimit";
 import { runDueRoutines } from "./lib/routines/dispatcher";
 import { agents } from "./routes/agents";
 import { favorites } from "./routes/favorites";
@@ -58,6 +59,16 @@ app.use(
   }),
 );
 
+// After cors, so a preflight is answered rather than counted: an OPTIONS that
+// gets a 429 makes the browser report the real request as a CORS failure, which
+// is the least legible way this could go wrong.
+//
+// Keyed by address here, because nothing above has validated a token yet — and
+// that is the point. authMiddleware below spends a round trip to Supabase on
+// every request, valid or not, so without this the cheapest thing to attack is
+// the check that stands in front of everything else.
+app.use("/*", rateLimit("standard"));
+
 // Unauthenticated — used for uptime checks / boot verification.
 app.get("/health", (c) => c.json({ ok: true }));
 
@@ -68,6 +79,32 @@ app.get("/health", (c) => c.json({ ok: true }));
 const api = new Hono<AppEnv>();
 api.use("/*", authMiddleware);
 api.use("/*", entitlementsMiddleware);
+
+// Every route that buys a completion or a transcription, which is the only
+// reason any of this exists. Keyed by user rather than by address, because
+// after authMiddleware there is one — a per-address limit would punish a shared
+// office for one person's loop and reward anyone with a second address.
+//
+// `ratelimit.static.test.ts` holds this list to the code: it fails if a route
+// file starts buying completions without appearing here, which is the way this
+// goes stale — the seventh paid endpoint, added a year from now for one
+// feature, quietly outside the limit.
+//
+// Document upload and reindex deliberately stay on `standard`. They spend on
+// embeddings, which `lib/entitlements` weights at a hundredth of a chat token
+// because that is roughly the real price ratio, and 20/min would break bulk
+// upload — the one behaviour this product exists to encourage — to bound a cost
+// the generous tier already bounds.
+//
+// Entitlements bound the month and this bounds the minute. They are not
+// substitutes: a monthly allowance is a ceiling on the bill, not on the rate at
+// which it is reached, and the open build ships no allowance at all.
+api.use("/chat/stream", rateLimit("expensive"));
+api.use("/transcribe", rateLimit("expensive"));
+api.use("/brainstorm/ideas/suggest", rateLimit("expensive"));
+api.use("/persona/suggest", rateLimit("expensive"));
+api.use("/routines/draft", rateLimit("expensive"));
+api.use("/routines/:id/run", rateLimit("expensive"));
 
 api.route("/", agents);
 api.route("/", favorites);

--- a/worker/src/lib/env.test.ts
+++ b/worker/src/lib/env.test.ts
@@ -55,4 +55,23 @@ describe("loadEnv", () => {
     expect(env.OPENAI_BASE_URL).toBeUndefined();
     expect(env.OPENAI_MODEL).toBeUndefined();
   });
+
+  it("carries the rate limits through when the operator sets them", () => {
+    const env = loadEnv({
+      ...complete,
+      RATE_LIMIT_STANDARD_PER_MINUTE: "300",
+      RATE_LIMIT_EXPENSIVE_PER_MINUTE: "0",
+    });
+    expect(env.RATE_LIMIT_STANDARD_PER_MINUTE).toBe("300");
+    expect(env.RATE_LIMIT_EXPENSIVE_PER_MINUTE).toBe("0");
+  });
+
+  it("leaves them unset when nothing is configured, so lib/ratelimit takes its defaults", () => {
+    // Unset must not mean unlimited. The defaults are what makes a stack nobody
+    // configured still bounded, which is the whole point of limiting in the API
+    // rather than only in the operator's proxy.
+    const env = loadEnv(complete);
+    expect(env.RATE_LIMIT_STANDARD_PER_MINUTE).toBeUndefined();
+    expect(env.RATE_LIMIT_EXPENSIVE_PER_MINUTE).toBeUndefined();
+  });
 });

--- a/worker/src/lib/env.ts
+++ b/worker/src/lib/env.ts
@@ -41,6 +41,10 @@ export function loadEnv(source: Record<string, string | undefined> = process.env
     ALLOWED_ORIGIN: source.ALLOWED_ORIGIN!,
     WORKER_HOST: source.WORKER_HOST,
     ADMIN_API_KEY: source.ADMIN_API_KEY,
+    // Optional on purpose: absent means the defaults in lib/ratelimit, so a
+    // stack that was never configured is still bounded. `0` turns a tier off.
+    RATE_LIMIT_STANDARD_PER_MINUTE: source.RATE_LIMIT_STANDARD_PER_MINUTE,
+    RATE_LIMIT_EXPENSIVE_PER_MINUTE: source.RATE_LIMIT_EXPENSIVE_PER_MINUTE,
     DOCS_DIR: source.DOCS_DIR!,
     // DOCS stays undefined: there is no R2 binding off Cloudflare, and its
     // absence is what makes getDocStore choose the filesystem.

--- a/worker/src/lib/ratelimit/cloudflare.test.ts
+++ b/worker/src/lib/ratelimit/cloudflare.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { cloudflareRateLimiter } from "./cloudflare";
+import { describeRateLimiterContract } from "./contract";
+
+/**
+ * A stand-in for the binding, counting the way Cloudflare's does: per key,
+ * within one window. The contract test never advances time, so the window never
+ * rolls over here — which is exactly the behaviour the contract asks about.
+ */
+function fakeBinding(limit: number): RateLimit {
+  const counts = new Map<string, number>();
+  return {
+    async limit({ key }: { key: string }) {
+      const next = (counts.get(key) ?? 0) + 1;
+      counts.set(key, next);
+      return { success: next <= limit };
+    },
+  };
+}
+
+describeRateLimiterContract("cloudflare", async (limit) =>
+  cloudflareRateLimiter(fakeBinding(limit)),
+);
+
+describe("the Cloudflare limiter", () => {
+  it("passes the key through to the binding untouched", async () => {
+    const limit = vi.fn(async () => ({ success: true }));
+    const limiter = cloudflareRateLimiter({ limit } as unknown as RateLimit);
+
+    await limiter.check("expensive:user:abc");
+
+    expect(limit).toHaveBeenCalledWith({ key: "expensive:user:abc" });
+  });
+
+  it("reports the configured window as the wait, since the binding does not say", async () => {
+    const limiter = cloudflareRateLimiter(fakeBinding(0), 60);
+
+    const verdict = await limiter.check("someone");
+    if (verdict.allowed) throw new Error("expected a refusal");
+    expect(verdict.retryAfterSeconds).toBe(60);
+  });
+
+  it("fails open when the binding throws, and says so", async () => {
+    // This limiter guards a bill, not a door — every route behind it has already
+    // checked a bearer token. Refusing everything because the limiter is
+    // unavailable would turn someone else's outage into ours.
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const limiter = cloudflareRateLimiter({
+      limit: async () => {
+        throw new Error("binding unavailable");
+      },
+    } as unknown as RateLimit);
+
+    expect(await limiter.check("someone")).toEqual({ allowed: true });
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
+  });
+});

--- a/worker/src/lib/ratelimit/cloudflare.ts
+++ b/worker/src/lib/ratelimit/cloudflare.ts
@@ -1,0 +1,37 @@
+import type { RateLimiter, RateVerdict } from "./types";
+import { RATE_PERIOD_SECONDS } from "./types";
+
+/**
+ * Cloudflare's rate limiting binding.
+ *
+ * The counter lives in the edge rather than in the isolate, which is the whole
+ * point: a Worker gets a fresh isolate whenever the runtime feels like it, and
+ * there are many of them, so the in-process counter that is correct under Docker
+ * would be close to no limit at all here.
+ *
+ * The limit and the window are declared in `wrangler.toml` under `[[ratelimits]]`
+ * and cannot be read back at runtime — `limit()` answers `{ success }` and
+ * nothing else. So `retryAfterSeconds` is the window we were told about at
+ * construction; keep it in step with the `simple.period` in that file. The
+ * binding accepts only 10 or 60, and `RATE_PERIOD_SECONDS` is 60.
+ */
+export function cloudflareRateLimiter(
+  binding: RateLimit,
+  periodSeconds: number = RATE_PERIOD_SECONDS,
+): RateLimiter {
+  return {
+    async check(key: string): Promise<RateVerdict> {
+      try {
+        const { success } = await binding.limit({ key });
+        return success ? { allowed: true } : { allowed: false, retryAfterSeconds: periodSeconds };
+      } catch (err) {
+        // Fail open. This limiter guards a bill, not a door: every route behind
+        // it has already checked a bearer token, and refusing every request
+        // because the limiter is unavailable would convert a Cloudflare hiccup
+        // into an outage of our own. Logged so it is not silent.
+        console.error("rate limiter unavailable, allowing request", err);
+        return { allowed: true };
+      }
+    },
+  };
+}

--- a/worker/src/lib/ratelimit/contract.ts
+++ b/worker/src/lib/ratelimit/contract.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import type { RateLimiter } from "./types";
+
+/**
+ * The behaviour every RateLimiter owes its callers. Both cloudflare.test.ts and
+ * memory.test.ts call this, so the two implementations cannot drift apart —
+ * which is the whole risk of running one codebase on two runtimes, and a worse
+ * risk here than for documents: a limiter that behaves differently under Docker
+ * than on Cloudflare is a limit the operator thinks they have.
+ *
+ * `make` is given the limit so each implementation can be built the way its own
+ * runtime configures one — from a binding, or from a number.
+ */
+export function describeRateLimiterContract(
+  name: string,
+  make: (limit: number) => Promise<RateLimiter>,
+) {
+  describe(`RateLimiter contract: ${name}`, () => {
+    it("allows requests up to the limit", async () => {
+      const limiter = await make(3);
+      for (let i = 0; i < 3; i++) {
+        expect(await limiter.check("someone")).toEqual({ allowed: true });
+      }
+    });
+
+    it("refuses the one after, and says how long to wait", async () => {
+      const limiter = await make(2);
+      await limiter.check("someone");
+      await limiter.check("someone");
+
+      const verdict = await limiter.check("someone");
+      expect(verdict.allowed).toBe(false);
+      if (verdict.allowed) throw new Error("unreachable");
+      expect(verdict.retryAfterSeconds).toBeGreaterThan(0);
+    });
+
+    it("counts each key separately, so one caller cannot exhaust another's allowance", async () => {
+      const limiter = await make(1);
+      expect(await limiter.check("first")).toEqual({ allowed: true });
+      expect(await limiter.check("second")).toEqual({ allowed: true });
+      expect((await limiter.check("first")).allowed).toBe(false);
+    });
+
+    it("keeps refusing while the window holds, rather than letting every other request through", async () => {
+      const limiter = await make(1);
+      await limiter.check("someone");
+      expect((await limiter.check("someone")).allowed).toBe(false);
+      expect((await limiter.check("someone")).allowed).toBe(false);
+    });
+  });
+}

--- a/worker/src/lib/ratelimit/index.test.ts
+++ b/worker/src/lib/ratelimit/index.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Bindings } from "../../types";
+import {
+  configuredLimit,
+  getRateLimiter,
+  resetRateLimiters,
+  resetRateLimitWarnings,
+  unlimitedRateLimiter,
+  DEFAULT_LIMITS,
+} from "./index";
+
+const base = {} as Bindings;
+const env = (over: Partial<Bindings> = {}): Bindings => ({ ...base, ...over }) as Bindings;
+
+beforeEach(() => {
+  resetRateLimiters();
+  resetRateLimitWarnings();
+});
+
+describe("configuredLimit", () => {
+  it("falls back to the default when nothing is set, so an unconfigured stack is still bounded", () => {
+    expect(configuredLimit(env(), "standard")).toBe(DEFAULT_LIMITS.standard);
+    expect(configuredLimit(env(), "expensive")).toBe(DEFAULT_LIMITS.expensive);
+  });
+
+  it("takes the operator's number", () => {
+    expect(configuredLimit(env({ RATE_LIMIT_EXPENSIVE_PER_MINUTE: "5" }), "expensive")).toBe(5);
+  });
+
+  it("treats an empty string as unset, because that is what a blank .env line gives", () => {
+    expect(configuredLimit(env({ RATE_LIMIT_STANDARD_PER_MINUTE: "  " }), "standard")).toBe(
+      DEFAULT_LIMITS.standard,
+    );
+  });
+
+  it("ignores a value that is not a non-negative number rather than removing the limit", () => {
+    // A typo must not be the way a limit disappears. `0` is how you turn it off,
+    // and `0` is a number.
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(configuredLimit(env({ RATE_LIMIT_EXPENSIVE_PER_MINUTE: "twenty" }), "expensive")).toBe(
+      DEFAULT_LIMITS.expensive,
+    );
+    expect(configuredLimit(env({ RATE_LIMIT_EXPENSIVE_PER_MINUTE: "-1" }), "expensive")).toBe(
+      DEFAULT_LIMITS.expensive,
+    );
+    expect(error).toHaveBeenCalledTimes(2);
+    error.mockRestore();
+  });
+});
+
+describe("getRateLimiter", () => {
+  it("uses the binding when there is one", async () => {
+    const limit = vi.fn(async () => ({ success: true }));
+    const limiter = getRateLimiter(
+      env({ RATE_LIMIT_EXPENSIVE: { limit } as unknown as RateLimit }),
+      "expensive",
+    );
+
+    await limiter.check("someone");
+
+    expect(limit).toHaveBeenCalledOnce();
+  });
+
+  it("does not use one tier's binding for the other tier", async () => {
+    const limit = vi.fn(async () => ({ success: true }));
+    const limiter = getRateLimiter(
+      env({ RATE_LIMIT_EXPENSIVE: { limit } as unknown as RateLimit }),
+      "standard",
+    );
+
+    await limiter.check("someone");
+
+    expect(limit).not.toHaveBeenCalled();
+  });
+
+  it("returns the same in-process limiter across calls, or nothing is ever limited", async () => {
+    // The counter lives inside the closure, so a fresh limiter per request would
+    // count every request as the first one. That bug passes every test of the
+    // limiter itself and shows up only as a limit that never trips.
+    const e = env({ RATE_LIMIT_EXPENSIVE_PER_MINUTE: "1" });
+
+    expect((await getRateLimiter(e, "expensive").check("someone")).allowed).toBe(true);
+    expect((await getRateLimiter(e, "expensive").check("someone")).allowed).toBe(false);
+  });
+
+  it("keeps the tiers' counters apart", async () => {
+    const e = env({ RATE_LIMIT_EXPENSIVE_PER_MINUTE: "1", RATE_LIMIT_STANDARD_PER_MINUTE: "1" });
+
+    expect((await getRateLimiter(e, "expensive").check("someone")).allowed).toBe(true);
+    expect((await getRateLimiter(e, "standard").check("someone")).allowed).toBe(true);
+  });
+
+  it("shouts when it is on Cloudflare with no binding, because the fallback there limits nothing", async () => {
+    // Isolates are many and short-lived, so a per-isolate counter is close to no
+    // limit at all. A deploy that forgot the [[ratelimits]] block still boots
+    // and still serves — exactly the silent failure this seam exists to prevent.
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    getRateLimiter(env({ DOCS: {} as unknown as R2Bucket }), "expensive");
+
+    expect(error).toHaveBeenCalledOnce();
+    expect(error.mock.calls[0][0]).toContain("RATE_LIMIT_EXPENSIVE");
+    error.mockRestore();
+  });
+
+  it("says it once per tier rather than on every request", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const e = env({ DOCS: {} as unknown as R2Bucket });
+
+    getRateLimiter(e, "expensive");
+    getRateLimiter(e, "expensive");
+    getRateLimiter(e, "standard");
+
+    expect(error).toHaveBeenCalledTimes(2);
+    error.mockRestore();
+  });
+
+  it("stays quiet on Node, where the in-process counter is the right answer", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    getRateLimiter(env({ DOCS_DIR: "/data/docs" }), "expensive");
+
+    expect(error).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+
+  it("allows everything at a limit of 0, which is how an operator defers to their own proxy", async () => {
+    const limiter = getRateLimiter(env({ RATE_LIMIT_STANDARD_PER_MINUTE: "0" }), "standard");
+    expect(limiter).toBe(unlimitedRateLimiter);
+    for (let i = 0; i < 50; i++) {
+      expect((await limiter.check("someone")).allowed).toBe(true);
+    }
+  });
+});

--- a/worker/src/lib/ratelimit/index.ts
+++ b/worker/src/lib/ratelimit/index.ts
@@ -1,0 +1,119 @@
+import type { Bindings } from "../../types";
+import type { RateLimiter, RateTier } from "./types";
+import { DEFAULT_LIMITS, RATE_PERIOD_SECONDS } from "./types";
+import { cloudflareRateLimiter } from "./cloudflare";
+import { memoryRateLimiter } from "./memory";
+
+export type { RateLimiter, RateTier, RateVerdict } from "./types";
+export { RATE_PERIOD_SECONDS, DEFAULT_LIMITS } from "./types";
+
+/** Allows everything. What an operator gets when they set a limit of 0. */
+export const unlimitedRateLimiter: RateLimiter = {
+  async check() {
+    return { allowed: true };
+  },
+};
+
+/**
+ * The Node limiters have to outlive the request.
+ *
+ * `memoryRateLimiter` closes over its own Map, so building one per request would
+ * count every request as the first one and limit nothing at all — a bug that
+ * passes every unit test of the limiter itself and shows up only as a limit that
+ * never trips. They are cached here, keyed by tier and configured limit so a
+ * test that changes the limit gets a fresh counter rather than a stale one.
+ *
+ * There is no equivalent concern on Cloudflare: the binding is the counter, and
+ * the wrapper around it holds nothing.
+ */
+const processLimiters = new Map<string, RateLimiter>();
+
+/** Exposed for tests. Production never needs it — the process is the lifetime. */
+export function resetRateLimiters(): void {
+  processLimiters.clear();
+}
+
+/**
+ * How many requests per minute this tier allows, from the environment.
+ *
+ * Only the Node runtime reads this. On Cloudflare the number lives in
+ * `wrangler.toml`, because the binding owns the counter and there is nowhere
+ * else to put it.
+ *
+ * `0` means unlimited, and is the documented way for an operator who rate-limits
+ * in nginx or Cloudflare to turn this off rather than fight it. A value that is
+ * not a non-negative number is treated as unset: a typo should not silently
+ * remove the limit.
+ */
+export function configuredLimit(env: Bindings, tier: RateTier): number {
+  const raw =
+    tier === "expensive" ? env.RATE_LIMIT_EXPENSIVE_PER_MINUTE : env.RATE_LIMIT_STANDARD_PER_MINUTE;
+  if (raw === undefined || raw.trim() === "") return DEFAULT_LIMITS[tier];
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.error(
+      `Ignoring RATE_LIMIT_${tier.toUpperCase()}_PER_MINUTE=${raw}: not a non-negative number. ` +
+        `Using the default of ${DEFAULT_LIMITS[tier]}.`,
+    );
+    return DEFAULT_LIMITS[tier];
+  }
+  return Math.floor(parsed);
+}
+
+const warnedTiers = new Set<RateTier>();
+
+/** Exposed for tests, which need each case to warn again. */
+export function resetRateLimitWarnings(): void {
+  warnedTiers.clear();
+}
+
+/**
+ * A tripwire for one specific deployment mistake, in the same spirit as the one
+ * in `lib/entitlements`.
+ *
+ * On Cloudflare the in-process fallback is close to no limit at all: isolates
+ * are many and short-lived, so each keeps its own counter and a caller spread
+ * across them is barely counted. A deploy whose wrangler.toml is missing
+ * `[[ratelimits]]` therefore still boots, still serves, and silently stops
+ * limiting — which is the failure this whole seam exists to prevent, arriving
+ * through the back door.
+ *
+ * `DOCS` is the discriminator `getDocStore` already uses for "am I on
+ * Cloudflare", so there is no new mode flag to keep in sync. Logged rather than
+ * fatal: refusing to serve would turn a missing limit into an outage.
+ */
+function warnIfCloudflareWithoutBinding(env: Bindings, tier: RateTier): void {
+  if (!env.DOCS || warnedTiers.has(tier)) return;
+  warnedTiers.add(tier);
+  console.error(
+    `Running on Cloudflare with no RATE_LIMIT_${tier.toUpperCase()} binding — falling back to a ` +
+      `per-isolate counter, which does not meaningfully limit anything. Add the [[ratelimits]] ` +
+      `block from worker/wrangler.toml.example.`,
+  );
+}
+
+/**
+ * Pick a limiter from the environment.
+ *
+ * The binding's presence is the runtime discriminator, exactly as `env.DOCS` is
+ * for `getDocStore` — no mode flag to keep in sync, and no way for a Cloudflare
+ * deploy to silently fall back to a per-isolate counter as long as the binding
+ * is declared.
+ */
+export function getRateLimiter(env: Bindings, tier: RateTier): RateLimiter {
+  const binding = tier === "expensive" ? env.RATE_LIMIT_EXPENSIVE : env.RATE_LIMIT_STANDARD;
+  if (binding) return cloudflareRateLimiter(binding, RATE_PERIOD_SECONDS);
+
+  warnIfCloudflareWithoutBinding(env, tier);
+  const limit = configuredLimit(env, tier);
+  if (limit === 0) return unlimitedRateLimiter;
+
+  const cacheKey = `${tier}:${limit}`;
+  let limiter = processLimiters.get(cacheKey);
+  if (!limiter) {
+    limiter = memoryRateLimiter({ limit });
+    processLimiters.set(cacheKey, limiter);
+  }
+  return limiter;
+}

--- a/worker/src/lib/ratelimit/memory.test.ts
+++ b/worker/src/lib/ratelimit/memory.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { memoryRateLimiter } from "./memory";
+import { describeRateLimiterContract } from "./contract";
+
+describeRateLimiterContract("memory", async (limit) => memoryRateLimiter({ limit }));
+
+describe("the in-process limiter's window", () => {
+  it("lets the caller through again once the window has passed", async () => {
+    let clock = 1_000_000;
+    const limiter = memoryRateLimiter({ limit: 1, periodSeconds: 60, now: () => clock });
+
+    expect((await limiter.check("someone")).allowed).toBe(true);
+    expect((await limiter.check("someone")).allowed).toBe(false);
+
+    clock += 60_000;
+    expect((await limiter.check("someone")).allowed).toBe(true);
+  });
+
+  it("does not reset early", async () => {
+    let clock = 0;
+    const limiter = memoryRateLimiter({ limit: 1, periodSeconds: 60, now: () => clock });
+
+    await limiter.check("someone");
+    clock += 59_999;
+    expect((await limiter.check("someone")).allowed).toBe(false);
+  });
+
+  it("reports the window length as the wait", async () => {
+    const limiter = memoryRateLimiter({ limit: 1, periodSeconds: 60, now: () => 0 });
+    await limiter.check("someone");
+
+    const verdict = await limiter.check("someone");
+    if (verdict.allowed) throw new Error("expected a refusal");
+    expect(verdict.retryAfterSeconds).toBe(60);
+  });
+
+  it("forgets keys that have gone quiet, so the map does not grow without end", async () => {
+    // The sweep only runs past its threshold, so this walks past it. Without it
+    // a long-lived Node process accumulates one entry per distinct caller
+    // forever — a leak that no test of the limiting behaviour itself would see.
+    let clock = 0;
+    const limiter = memoryRateLimiter({ limit: 1, periodSeconds: 60, now: () => clock });
+
+    for (let i = 0; i < 10_001; i++) await limiter.check(`caller-${i}`);
+    clock += 60_000;
+    // One more request past the threshold triggers the sweep of the expired
+    // entries; the caller that just arrived is the only one that should remain.
+    expect((await limiter.check("caller-0")).allowed).toBe(true);
+    expect((await limiter.check("caller-0")).allowed).toBe(false);
+  });
+});

--- a/worker/src/lib/ratelimit/memory.ts
+++ b/worker/src/lib/ratelimit/memory.ts
@@ -1,0 +1,68 @@
+import type { RateLimiter, RateVerdict } from "./types";
+import { RATE_PERIOD_SECONDS } from "./types";
+
+/**
+ * A fixed-window counter in process memory, for the Node runtime.
+ *
+ * Cloudflare has a rate limiting binding and Docker has nothing equivalent, so
+ * this is what makes a default `docker compose up` bounded rather than a
+ * promise in the documentation that the operator has to keep themselves.
+ *
+ * Two honest limitations, both documented in docs/self-hosting.md rather than
+ * left to be discovered:
+ *
+ * - **One process, one counter.** Run two replicas behind a load balancer and
+ *   each keeps its own, so the effective limit is the configured one times the
+ *   number of replicas. Anyone running replicas is running a proxy in front of
+ *   them and should set the real limit there.
+ * - **A fixed window, not a sliding one.** A caller can spend the whole
+ *   allowance in the last second of one window and the whole of it again in the
+ *   first second of the next. That is the classic burst at the boundary, and it
+ *   is a factor of two on a limit whose job is to turn "unbounded" into
+ *   "bounded". A sliding window costs more memory per key for a sharper edge
+ *   nobody here needs.
+ */
+export function memoryRateLimiter(opts: {
+  limit: number;
+  periodSeconds?: number;
+  /** Injectable for tests. Defaults to the wall clock. */
+  now?: () => number;
+}): RateLimiter {
+  const periodSeconds = opts.periodSeconds ?? RATE_PERIOD_SECONDS;
+  const periodMs = periodSeconds * 1000;
+  const now = opts.now ?? (() => Date.now());
+  const windows = new Map<string, { count: number; startedAt: number }>();
+
+  /**
+   * Keys are user ids and client addresses, so the map grows with the number of
+   * distinct callers rather than with traffic — but it never shrinks on its
+   * own, and an unbounded map in a long-lived process is a leak whatever fills
+   * it. Sweeping only past a threshold keeps the common path a single lookup.
+   */
+  const SWEEP_ABOVE = 10_000;
+  function sweep(at: number): void {
+    for (const [key, window] of windows) {
+      if (at - window.startedAt >= periodMs) windows.delete(key);
+    }
+  }
+
+  return {
+    async check(key: string): Promise<RateVerdict> {
+      const at = now();
+      const window = windows.get(key);
+
+      if (!window || at - window.startedAt >= periodMs) {
+        if (windows.size > SWEEP_ABOVE) sweep(at);
+        windows.set(key, { count: 1, startedAt: at });
+        return { allowed: true };
+      }
+
+      if (window.count >= opts.limit) {
+        return { allowed: false, retryAfterSeconds: periodSeconds };
+      }
+
+      window.count += 1;
+      return { allowed: true };
+    },
+  };
+}

--- a/worker/src/lib/ratelimit/types.ts
+++ b/worker/src/lib/ratelimit/types.ts
@@ -1,0 +1,70 @@
+/**
+ * How often a caller may ask.
+ *
+ * Nothing in this API bounded that until now. Request *size* was bounded — 10 MB
+ * for a document, 2 MB for audio — and that is a different thing: it caps what
+ * one call costs, not how many calls arrive. `POST /chat/stream` and
+ * `POST /transcribe` spend money at OpenAI every time, so an authenticated user
+ * with a loop, or one leaked password, was an unbounded bill rather than an
+ * outage. Authentication is not the mitigation: a limiter has to sit in front of
+ * the thing it protects, and both of those routes are already past the door.
+ *
+ * Two implementations, for the same reason `lib/docstore` has two: Cloudflare
+ * has a rate limiting binding and Docker does not. Routes and middleware depend
+ * on this interface and never on either one, or the Node build breaks silently.
+ */
+
+/** Which bucket a request is counted in. */
+export type RateTier = "standard" | "expensive";
+
+export type RateVerdict =
+  | { allowed: true }
+  | {
+      allowed: false;
+      /**
+       * What to put in `Retry-After`. Both implementations answer with the
+       * window length rather than the exact time remaining: Cloudflare's binding
+       * reports only success or failure, and a limiter that promises a precise
+       * wait it cannot compute is worse than one that rounds up honestly.
+       */
+      retryAfterSeconds: number;
+    };
+
+export interface RateLimiter {
+  /**
+   * Counts one request against `key` and says whether it may proceed.
+   *
+   * Never throws. A limiter that fails closed turns its own outage into the
+   * API's; one that fails open leaves the bill unbounded for the duration.
+   * Both implementations choose the second and log, because the thing being
+   * protected here is money rather than integrity — see the note in each.
+   */
+  check(key: string): Promise<RateVerdict>;
+}
+
+/**
+ * The window every tier is measured over.
+ *
+ * Fixed at a minute because Cloudflare's binding accepts only 10 or 60, and a
+ * ten-second window makes a burst of legitimate work — opening a workspace
+ * fires several requests at once — look like abuse. Both implementations use
+ * this so the two runtimes cannot disagree about what a limit means.
+ */
+export const RATE_PERIOD_SECONDS = 60;
+
+/**
+ * Requests per minute when nothing is configured.
+ *
+ * `standard` is keyed by IP and has to survive a shared office behind one
+ * address, so it is generous: it exists to protect the token check in front of
+ * it, which costs a round trip to Supabase on every request, not to ration
+ * ordinary use.
+ *
+ * `expensive` is keyed by the user and covers only the two routes that spend at
+ * OpenAI. Twenty a minute is more than a person can type and far less than a
+ * loop can.
+ */
+export const DEFAULT_LIMITS: Record<RateTier, number> = {
+  standard: 120,
+  expensive: 20,
+};

--- a/worker/src/middleware/ratelimit.test.ts
+++ b/worker/src/middleware/ratelimit.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import type { AppEnv, Bindings } from "../types";
+import { rateLimit } from "./ratelimit";
+import { resetRateLimiters } from "../lib/ratelimit";
+
+beforeEach(() => resetRateLimiters());
+
+function appWith(env: Partial<Bindings>, before?: (c: never) => void) {
+  const app = new Hono<AppEnv>();
+  if (before) app.use("/*", async (c, next) => (before(c as never), next()));
+  app.use("/*", rateLimit("expensive"));
+  app.get("/thing", (c) => c.json({ ok: true }));
+  return (headers: Record<string, string> = {}) =>
+    app.request("/thing", { headers }, env as Bindings);
+}
+
+describe("the rate limit middleware", () => {
+  it("answers 429 with Retry-After once the limit is spent", async () => {
+    const request = appWith({ RATE_LIMIT_EXPENSIVE_PER_MINUTE: "1" });
+
+    expect((await request({ "CF-Connecting-IP": "1.1.1.1" })).status).toBe(200);
+
+    const refused = await request({ "CF-Connecting-IP": "1.1.1.1" });
+    expect(refused.status).toBe(429);
+    expect(refused.headers.get("Retry-After")).toBe("60");
+    expect(await refused.json()).toEqual({ error: "rate_limited" });
+  });
+
+  it("counts two addresses separately", async () => {
+    const request = appWith({ RATE_LIMIT_EXPENSIVE_PER_MINUTE: "1" });
+
+    expect((await request({ "CF-Connecting-IP": "1.1.1.1" })).status).toBe(200);
+    expect((await request({ "CF-Connecting-IP": "2.2.2.2" })).status).toBe(200);
+    expect((await request({ "CF-Connecting-IP": "1.1.1.1" })).status).toBe(429);
+  });
+
+  it("counts by user rather than by address once there is a user", async () => {
+    // The same person on two networks is one caller, and two people behind one
+    // office address are two. Keying by address would get both backwards.
+    const request = (() => {
+      const app = new Hono<AppEnv>();
+      app.use("/*", async (c, next) => {
+        const id = c.req.header("X-Test-User");
+        if (id) c.set("user", { id } as never);
+        await next();
+      });
+      app.use("/*", rateLimit("expensive"));
+      app.get("/thing", (c) => c.json({ ok: true }));
+      return (headers: Record<string, string>) =>
+        app.request("/thing", { headers }, {
+          RATE_LIMIT_EXPENSIVE_PER_MINUTE: "1",
+        } as Bindings);
+    })();
+
+    expect((await request({ "X-Test-User": "alice", "CF-Connecting-IP": "1.1.1.1" })).status).toBe(
+      200,
+    );
+    // Same address, different person: allowed.
+    expect((await request({ "X-Test-User": "bob", "CF-Connecting-IP": "1.1.1.1" })).status).toBe(
+      200,
+    );
+    // Same person, different address: refused.
+    expect((await request({ "X-Test-User": "alice", "CF-Connecting-IP": "9.9.9.9" })).status).toBe(
+      429,
+    );
+  });
+
+  it("prefers CF-Connecting-IP over X-Forwarded-For, which a client can set", async () => {
+    const request = appWith({ RATE_LIMIT_EXPENSIVE_PER_MINUTE: "1" });
+
+    await request({ "CF-Connecting-IP": "1.1.1.1", "X-Forwarded-For": "8.8.8.8" });
+    // A caller who has spent their allowance cannot buy another by claiming a
+    // different forwarded address.
+    expect(
+      (await request({ "CF-Connecting-IP": "1.1.1.1", "X-Forwarded-For": "7.7.7.7" })).status,
+    ).toBe(429);
+  });
+
+  it("takes the first entry of X-Forwarded-For when that is all there is", async () => {
+    const request = appWith({ RATE_LIMIT_EXPENSIVE_PER_MINUTE: "1" });
+
+    expect((await request({ "X-Forwarded-For": "3.3.3.3, 10.0.0.1" })).status).toBe(200);
+    expect((await request({ "X-Forwarded-For": "3.3.3.3, 10.0.0.9" })).status).toBe(429);
+  });
+
+  it("counts an unattributable request rather than waving it through", async () => {
+    // Otherwise "send no address" is the way around the limit.
+    const request = appWith({ RATE_LIMIT_EXPENSIVE_PER_MINUTE: "1" });
+
+    expect((await request()).status).toBe(200);
+    expect((await request()).status).toBe(429);
+  });
+});

--- a/worker/src/middleware/ratelimit.ts
+++ b/worker/src/middleware/ratelimit.ts
@@ -1,0 +1,59 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { AppEnv } from "../types";
+import type { RateTier } from "../lib/ratelimit";
+import { getRateLimiter } from "../lib/ratelimit";
+
+/**
+ * Who to count this request against.
+ *
+ * After `authMiddleware` there is a user, and the user is the right key: a
+ * limit keyed by address would punish a whole office for one person's loop, and
+ * reward anyone with more than one address. Before it there is not, so the
+ * caller's address is all there is — which is also the point, because the token
+ * check itself costs a round trip to Supabase and something has to bound how
+ * often that can be provoked.
+ *
+ * `CF-Connecting-IP` is set by Cloudflare and cannot be spoofed by the client on
+ * that path. `X-Forwarded-For` can be, so it is used only as the fallback the
+ * Docker deployment needs, and only its first entry. An unknown address is
+ * counted under one shared key rather than waved through: better that a request
+ * we cannot attribute shares a bucket than that "no address" becomes the way
+ * around the limit.
+ */
+export function rateLimitKey(c: Context<AppEnv>): string {
+  const user = c.get("user");
+  if (user?.id) return `user:${user.id}`;
+
+  const cf = c.req.header("CF-Connecting-IP");
+  if (cf) return `ip:${cf}`;
+
+  const forwarded = c.req.header("X-Forwarded-For");
+  const first = forwarded?.split(",")[0]?.trim();
+  if (first) return `ip:${first}`;
+
+  return "ip:unknown";
+}
+
+/**
+ * Refuse a request that has asked too often.
+ *
+ * `standard` goes in front of everything, including the token check.
+ * `expensive` goes in front of the two routes that spend money at OpenAI, and
+ * is the one that matters — see `lib/ratelimit/types.ts` for what each is for.
+ *
+ * 429 with `Retry-After`, because a client that is told to back off can, and one
+ * that is handed a bare error retries immediately and makes it worse.
+ */
+export function rateLimit(tier: RateTier): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    const limiter = getRateLimiter(c.env, tier);
+    const verdict = await limiter.check(`${tier}:${rateLimitKey(c)}`);
+
+    if (!verdict.allowed) {
+      c.header("Retry-After", String(verdict.retryAfterSeconds));
+      return c.json({ error: "rate_limited" }, 429);
+    }
+
+    await next();
+  };
+}

--- a/worker/src/ratelimit.static.test.ts
+++ b/worker/src/ratelimit.static.test.ts
@@ -1,0 +1,100 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+/**
+ * The rate limit only bounds the bill if it is in front of everything that
+ * spends. Six endpoints buy a completion or a transcription today, and each is
+ * mounted behind `rateLimit("expensive")` in index.ts by hand — which is fine
+ * until the seventh, added a year from now for one feature, is not.
+ *
+ * So this walks the source instead of trusting a review to notice. It is the
+ * same shape as `lib/openai.test.ts`'s check that nothing constructs its own
+ * client: the risk is not this commit, it is the next one.
+ */
+
+const SRC = import.meta.dirname;
+const ROUTES = join(SRC, "routes");
+
+const index = readFileSync(join(SRC, "index.ts"), "utf8");
+
+/** Paths mounted behind the expensive tier, read out of index.ts. */
+function expensivePaths(): string[] {
+  return [...index.matchAll(/api\.use\(\s*"([^"]+)"\s*,\s*rateLimit\("expensive"\)\s*\)/g)].map(
+    (m) => m[1],
+  );
+}
+
+function routeFiles(): string[] {
+  return readdirSync(ROUTES).filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"));
+}
+
+/**
+ * Route files that buy a completion, found by the seam every completion goes
+ * through, plus transcription's own module. `lib/openai.test.ts` already
+ * guarantees nothing reaches OpenAI for a completion any other way, so this
+ * cannot be dodged by constructing a client directly.
+ */
+function paidRouteFiles(): string[] {
+  return routeFiles().filter((f) => {
+    const src = readFileSync(join(ROUTES, f), "utf8");
+    return src.includes("createOpenAI") || src.includes("transcribeAudio");
+  });
+}
+
+/**
+ * Which of those files' endpoints actually spend, stated rather than inferred.
+ *
+ * routes/routines.ts registers eleven endpoints and two of them buy a
+ * completion, so "every POST in a paid file" would be wrong in the expensive
+ * direction — it would put the routine list behind a 20/min limit. The tripwire
+ * below is what keeps this honest: the file list is derived, so a new file
+ * cannot be forgotten, and this map has to be updated when one appears.
+ */
+const PAID_ENDPOINTS: Record<string, string[]> = {
+  "chat.ts": ["/chat/stream"],
+  "transcribe.ts": ["/transcribe"],
+  "brainstorm.ts": ["/brainstorm/ideas/suggest"],
+  "persona.ts": ["/persona/suggest"],
+  "routines.ts": ["/routines/draft", "/routines/:id/run"],
+};
+
+describe("the expensive rate limit", () => {
+  it("covers every endpoint that buys a completion or a transcription", () => {
+    const mounted = expensivePaths();
+    const paid = Object.values(PAID_ENDPOINTS).flat();
+
+    expect(paid).not.toEqual([]);
+    expect(mounted.slice().sort()).toEqual(paid.slice().sort());
+  });
+
+  it("knows about every route file that spends, so a new one cannot arrive unnoticed", () => {
+    // This is the tripwire. If a route file starts importing createOpenAI, this
+    // fails and whoever added it has to decide — deliberately — whether its
+    // endpoints belong behind the limit.
+    expect(paidRouteFiles().sort()).toEqual(Object.keys(PAID_ENDPOINTS).sort());
+  });
+
+  it("mounts each of those paths on a route that exists", () => {
+    // A path typed one way in index.ts and another in the route file is a limit
+    // that silently applies to nothing.
+    for (const [file, paths] of Object.entries(PAID_ENDPOINTS)) {
+      const src = readFileSync(join(ROUTES, file), "utf8");
+      for (const path of paths) {
+        expect(src, `${file} should register ${path}`).toContain(`"${path}"`);
+      }
+    }
+  });
+
+  it("puts the standard tier in front of everything, including the token check", () => {
+    // authMiddleware spends a round trip to Supabase on every request, valid or
+    // not. If the standard limiter ever moves below it, the cheapest thing to
+    // attack becomes the check standing in front of everything else.
+    const standard = index.indexOf('app.use("/*", rateLimit("standard"))');
+    const auth = index.indexOf('api.use("/*", authMiddleware)');
+
+    expect(standard).toBeGreaterThan(-1);
+    expect(auth).toBeGreaterThan(-1);
+    expect(standard).toBeLessThan(auth);
+  });
+});

--- a/worker/src/ratelimit.wiring.test.ts
+++ b/worker/src/ratelimit.wiring.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { app } from "./index";
+import type { AppEnv, Bindings } from "./types";
+import { rateLimit } from "./middleware/ratelimit";
+import { resetRateLimiters } from "./lib/ratelimit";
+
+/**
+ * The static test asserts index.ts *says* the right thing. This asserts the
+ * request actually goes through it — the two failures it cannot see are a
+ * middleware mounted somewhere it never runs, and a path pattern that matches
+ * nothing.
+ */
+
+const env = {
+  ALLOWED_ORIGIN: "http://localhost:3000",
+  RATE_LIMIT_STANDARD_PER_MINUTE: "2",
+} as Bindings;
+
+beforeEach(() => resetRateLimiters());
+
+describe("the limiter as the app actually mounts it", () => {
+  it("stands in front of an unauthenticated route", async () => {
+    const call = () => app.request("/health", { headers: { "CF-Connecting-IP": "5.5.5.5" } }, env);
+
+    expect((await call()).status).toBe(200);
+    expect((await call()).status).toBe(200);
+
+    const refused = await call();
+    expect(refused.status).toBe(429);
+    expect(refused.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("does not count the CORS preflight", async () => {
+    // cors() answers OPTIONS and returns before the limiter. If that order ever
+    // flips, a preflight can be refused — and a browser reports a 429 on a
+    // preflight as a CORS failure, which is the least legible way this could
+    // break.
+    const preflight = () =>
+      app.request(
+        "/health",
+        {
+          method: "OPTIONS",
+          headers: {
+            Origin: "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+            "CF-Connecting-IP": "6.6.6.6",
+          },
+        },
+        env,
+      );
+
+    for (let i = 0; i < 5; i++) {
+      expect((await preflight()).status).not.toBe(429);
+    }
+  });
+
+  it("matches a path with a parameter in it, which is how /routines/:id/run is mounted", async () => {
+    // Hono's `use` takes the same patterns as a route. If it did not, that mount
+    // would silently protect nothing, and every test above would still pass.
+    const probe = new Hono<AppEnv>();
+    probe.use("/routines/:id/run", rateLimit("expensive"));
+    probe.post("/routines/:id/run", (c) => c.json({ ok: true }));
+    probe.post("/routines/:id", (c) => c.json({ ok: true }));
+
+    const e = { RATE_LIMIT_EXPENSIVE_PER_MINUTE: "1" } as Bindings;
+    const headers = { "CF-Connecting-IP": "7.7.7.7" };
+
+    expect((await probe.request("/routines/abc/run", { method: "POST", headers }, e)).status).toBe(
+      200,
+    );
+    expect((await probe.request("/routines/xyz/run", { method: "POST", headers }, e)).status).toBe(
+      429,
+    );
+    // And does not spill onto the sibling route it must not cover.
+    expect((await probe.request("/routines/abc", { method: "POST", headers }, e)).status).toBe(200);
+  });
+});

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -68,6 +68,22 @@ export type Bindings = RoutineEnv & {
   /** Filesystem document root, on the Node runtime only. Absent on Cloudflare. */
   DOCS_DIR?: string;
   ADMIN_API_KEY?: string;
+  /**
+   * Rate limiting, on Cloudflare only — `[[ratelimits]]` in wrangler.toml.
+   * Their presence is what makes `getRateLimiter` use the edge counter instead
+   * of the in-process one, the same way `DOCS` chooses R2 over the filesystem.
+   * Absent on Node, where the two variables below configure the fallback.
+   */
+  RATE_LIMIT_STANDARD?: RateLimit;
+  RATE_LIMIT_EXPENSIVE?: RateLimit;
+  /**
+   * Requests per minute on the Node runtime. Unset takes the defaults in
+   * `lib/ratelimit/types.ts`; `0` disables that tier, which is what an operator
+   * who limits in nginx or Cloudflare in front of this should set rather than
+   * running two limiters that disagree.
+   */
+  RATE_LIMIT_STANDARD_PER_MINUTE?: string;
+  RATE_LIMIT_EXPENSIVE_PER_MINUTE?: string;
 };
 
 /**

--- a/worker/wrangler.toml.example
+++ b/worker/wrangler.toml.example
@@ -41,6 +41,32 @@ ALLOWED_ORIGIN = "https://your-app.example.com"
 # blocked); set it once a custom domain fronts this worker.
 
 # Create the bucket before your first deploy: wrangler r2 bucket create covan-docs
+# How often one caller may ask, backing `lib/ratelimit` on Cloudflare. Without
+# these the Worker falls back to an in-process counter — correct under Docker,
+# close to meaningless here, because isolates are many and short-lived. The
+# fallback logs an error saying so rather than failing quietly, but the error is
+# in a log nobody is reading at 3am. Declare both.
+#
+# `namespace_id` is any string unique within this Worker; it names the counter,
+# not a resource you have to create. `period` accepts only 10 or 60, and
+# lib/ratelimit fixes it at 60 so both runtimes agree what a limit means.
+#
+# standard: in front of everything including the token check, keyed by address.
+# Generous, because a shared office is one address and this exists to bound how
+# often the Supabase round trip in authMiddleware can be provoked.
+[[ratelimits]]
+name = "RATE_LIMIT_STANDARD"
+namespace_id = "1001"
+simple = { limit = 120, period = 60 }
+
+# expensive: in front of the six endpoints that buy a completion or a
+# transcription, keyed by the authenticated user. More than a person can type,
+# far less than a loop can.
+[[ratelimits]]
+name = "RATE_LIMIT_EXPENSIVE"
+namespace_id = "1002"
+simple = { limit = 20, period = 60 }
+
 [[r2_buckets]]
 binding = "DOCS"
 bucket_name = "covan-docs"


### PR DESCRIPTION
Closes #4.

The issue offered two ways and asked for the second, because it is the one that closes the gap for people who deploy the quick start and stop reading. So the limiter is in the API: two implementations behind one interface, the same shape as `lib/docstore` and for the same reason — Cloudflare has a rate limiting binding and Docker has nothing equivalent. Both are held to a shared `contract.ts`, because a limiter that behaves differently under Docker than on Cloudflare is a limit the operator only *thinks* they have.

| Tier | In front of | Keyed on | Default |
|---|---|---|---|
| `standard` | everything, including the token check | the caller's address | 120/min |
| `expensive` | the six that buy a completion or a transcription | the bearer token's subject | 20/min |

`standard` sits in front of `authMiddleware` deliberately: that check spends a round trip to Supabase on every request, valid or not, so without it the cheapest thing to attack is the guard standing in front of everything else.

### The issue named two endpoints; there are six

`/persona/suggest`, `/brainstorm/ideas/suggest`, `/routines/draft` and `/routines/:id/run` buy completions too. Rather than fix the list and move on, `ratelimit.static.test.ts` derives which route files reach for `createOpenAI` and fails if that set grows — so the seventh, added a year from now for one feature, cannot arrive outside the limit. `ratelimit.wiring.test.ts` covers what a static test cannot see: that the middleware is really in the chain, that a CORS preflight is not counted, and that `/routines/:id/run` actually matches as a `use` pattern.

Upload and reindex stay on `standard` on purpose — they spend on embeddings, weighted at a hundredth of a chat token because that is near the real price ratio, and 20/min would break bulk upload, the behaviour this product exists to encourage, to bound a cost the generous tier already bounds.

### Two traps, both of which pass every test of the limiter itself

- **The Node limiter closes over its Map.** Building one per request would count every request as the first and limit nothing. They are cached per process, and a test asserts two `getRateLimiter` calls share a counter.
- **A missing binding on Cloudflare falls back to that in-process counter**, which across many short-lived isolates is close to no limit at all. That now logs an error naming the missing binding.

Both implementations fail open and log. This guards a bill, not a door: refusing every request because the limiter is unavailable converts someone else's outage into ours.

### For operators

`RATE_LIMIT_STANDARD_PER_MINUTE` and `RATE_LIMIT_EXPENSIVE_PER_MINUTE` change the numbers under Docker; `0` turns a tier off, which is what to do if you already limit in nginx or Cloudflare rather than running two limiters that disagree. On Cloudflare the numbers live in the `[[ratelimits]]` blocks in `wrangler.toml.example`, because the binding owns the counter.

`docs/self-hosting.md` no longer opens by saying Covan does not rate-limit itself. Its two honest limitations — a fixed window, and one counter per process — are written down there rather than left to be discovered, along with the advice to keep limiting at the proxy as well.

Ported from covan-ai/covan-cloud#82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)