### PR TITLE
Tell nitro the substituted files are the size they now are

### DIFF
--- a/scripts/web-runtime-config.mjs
+++ b/scripts/web-runtime-config.mjs
@@ -30,7 +30,8 @@
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative, sep } from "node:path";
+import { createHash } from "node:crypto";
 
 /** Build-time placeholder for each variable the browser bundle needs. */
 export const SENTINELS = {
@@ -96,6 +97,76 @@ export function assertNothingLeftOver(text, file) {
   }
 }
 
+/**
+ * The etag nitro records for a public asset.
+ *
+ * Reproduces the `etag` package's format exactly — `"<hex length>-<27 chars of
+ * base64 sha1>"` — because the value has to match what nitro would have written
+ * for the substituted bytes, not merely be a valid etag. Verified against an
+ * untouched entry in a real build.
+ */
+export function assetEtag(bytes) {
+  const hash = createHash("sha1").update(bytes).digest("base64").substring(0, 27);
+  return `"${bytes.length.toString(16)}-${hash}"`;
+}
+
+/**
+ * Tell nitro the substituted files are the size they now are.
+ *
+ * This is the bug that made the whole idea not work, and it was invisible from
+ * everything anyone would think to check. Nitro bakes a manifest of every public
+ * asset — type, etag, mtime, **size** — into `.output/server/index.mjs` at build
+ * time, and serves `Content-Length` from it. Substituting a 38-character
+ * sentinel for a 21-character URL leaves the file 17 bytes shorter than the
+ * manifest claims, so the browser receives fewer bytes than it was promised and
+ * aborts the response with `ERR_CONTENT_LENGTH_MISMATCH`.
+ *
+ * The HTML document is unaffected — it holds no sentinels — so the page renders,
+ * the health check passes, and the container is green. What fails is the
+ * JavaScript: React never hydrates, and every button on the page does nothing.
+ * A container that starts, serves pages and cannot sign anyone in, which is the
+ * exact failure this script's header says it exists to prevent.
+ *
+ * Throwing when an entry is missing is the point. If a future nitro keeps this
+ * manifest somewhere else, that has to fail loudly here rather than ship another
+ * image that looks fine until somebody clicks something.
+ */
+export function updateAssetManifest(manifestText, entries) {
+  let out = manifestText;
+
+  for (const [urlPath, bytes] of entries) {
+    const key = JSON.stringify(urlPath);
+    const start = out.indexOf(`${key}: {`);
+    if (start === -1) {
+      throw new Error(
+        `Cannot start: no manifest entry for ${urlPath}.\n` +
+          "The server bundle records a size for every public asset and serves\n" +
+          "Content-Length from it. Rewriting the file without correcting that\n" +
+          "size produces a bundle the browser refuses to finish downloading, so\n" +
+          "the page renders and nothing on it works. If nitro has moved this\n" +
+          "manifest, this script has to move with it.",
+      );
+    }
+    const end = out.indexOf("}", start);
+    const before = out.slice(start, end);
+
+    const updated = before
+      .replace(/"size":\s*\d+/, `"size": ${bytes.length}`)
+      .replace(/"etag":\s*"(?:[^"\\]|\\.)*"/, `"etag": ${JSON.stringify(assetEtag(bytes))}`);
+
+    if (updated === before) {
+      throw new Error(
+        `Cannot start: manifest entry for ${urlPath} has no size or etag to correct.\n` +
+          "Its shape is not what this script expects, and guessing would ship a\n" +
+          "bundle that fails in the browser rather than here.",
+      );
+    }
+    out = out.slice(0, start) + updated + out.slice(end);
+  }
+
+  return out;
+}
+
 function* walk(dir) {
   for (const entry of readdirSync(dir)) {
     const path = join(dir, entry);
@@ -145,14 +216,31 @@ function main() {
   const root = process.argv[2] ?? ".output";
   const values = resolveValues(process.env);
 
+  const publicRoot = join(root, "public");
+  const manifestPath = join(root, "server", "index.mjs");
+  /** Public assets whose recorded size is now wrong. See updateAssetManifest. */
+  const resized = [];
+
   let count = 0;
   for (const template of walk(root)) {
     if (!template.endsWith(TEMPLATE_SUFFIX)) continue;
     const target = template.slice(0, -TEMPLATE_SUFFIX.length);
     const rendered = substitute(readFileSync(template, "utf8"), values);
     assertNothingLeftOver(rendered, target);
-    writeFileSync(target, rendered);
+    const bytes = Buffer.from(rendered, "utf8");
+    writeFileSync(target, bytes);
+    if (target.startsWith(publicRoot + sep)) {
+      resized.push(["/" + relative(publicRoot, target).split(sep).join("/"), bytes]);
+    }
     count += 1;
+  }
+
+  // After every substitution, never during: the manifest lives in the server
+  // bundle, which may itself be one of the templates above and be restored from
+  // pristine partway through the loop.
+  if (resized.length > 0) {
+    writeFileSync(manifestPath, updateAssetManifest(readFileSync(manifestPath, "utf8"), resized));
+    console.log(`covan: corrected the recorded size of ${resized.length} asset(s)`);
   }
 
   // Zero is not "nothing needed doing", it is "the templates are not in this

--- a/scripts/web-runtime-config.test.mjs
+++ b/scripts/web-runtime-config.test.mjs
@@ -6,6 +6,8 @@ import {
   resolveValues,
   substitute,
   assertNothingLeftOver,
+  assetEtag,
+  updateAssetManifest,
 } from "./web-runtime-config.mjs";
 
 /*
@@ -93,5 +95,97 @@ describe("the check that runs after substituting", () => {
     expect(() => assertNothingLeftOver(`x="${SENTINELS.VITE_API_URL}"`, "client.js")).toThrow(
       /client\.js/,
     );
+  });
+});
+
+/*
+ * The bug that made the whole idea not work, and which every check anyone would
+ * think to run missed. Nitro bakes a manifest of every public asset — including
+ * its size — into the server bundle and serves Content-Length from it.
+ * Substituting a 38-character sentinel for a 21-character URL leaves the file
+ * shorter than the manifest promises, the browser aborts the response with
+ * ERR_CONTENT_LENGTH_MISMATCH, and React never hydrates. The page renders. The
+ * health check passes. Every button does nothing.
+ */
+
+/**
+ * Shaped like the real thing. Nitro writes this as JavaScript source, and the
+ * etag *value* itself contains quotes — `"etag": "\"9c3-hash\""` — so the
+ * fixture builds it the same way the code does rather than by hand-escaping,
+ * which is how the first version of this test managed to be wrong.
+ */
+const manifest = (size, etag) => `
+const assets = {
+  "/assets/index-AbC123.js": {
+    "type": "text/javascript; charset=utf-8",
+    "etag": ${JSON.stringify('"9c3-otherhashotherhashotherh"')},
+    "mtime": "2026-08-26T09:01:08.854Z",
+    "size": 2499,
+    "path": "../public/assets/index-AbC123.js"
+  },
+  "/assets/api-client-XyZ.js": {
+    "type": "text/javascript; charset=utf-8",
+    "etag": ${JSON.stringify(etag)},
+    "mtime": "2026-08-26T09:01:08.854Z",
+    "size": ${size},
+    "path": "../public/assets/api-client-XyZ.js"
+  }
+};
+`;
+
+describe("the recorded size of a substituted asset", () => {
+  const bytes = Buffer.from("const API='https://api.example.com';", "utf8");
+
+  it("is corrected to what the file now weighs", () => {
+    const out = updateAssetManifest(manifest(9999, '"270f-stalehashstalehashstaleh"'), [
+      ["/assets/api-client-XyZ.js", bytes],
+    ]);
+    expect(out).toContain(`"size": ${bytes.length}`);
+    expect(out).not.toContain('"size": 9999');
+  });
+
+  it("gets a matching etag, not merely a valid one", () => {
+    // A stale etag serves a 304 for content that changed, which is the same
+    // class of failure arriving a day later through a cache.
+    const out = updateAssetManifest(manifest(9999, '"270f-stalehashstalehashstaleh"'), [
+      ["/assets/api-client-XyZ.js", bytes],
+    ]);
+    // The manifest holds the etag as a JS string whose value carries quotes, so
+    // compare against the same encoding the file actually contains.
+    expect(out).toContain(JSON.stringify(assetEtag(bytes)));
+    expect(out).not.toContain("stalehashstalehashstaleh");
+  });
+
+  it("leaves every other entry alone", () => {
+    const out = updateAssetManifest(manifest(9999, '"270f-stalehashstalehashstaleh"'), [
+      ["/assets/api-client-XyZ.js", bytes],
+    ]);
+    expect(out).toContain('"size": 2499');
+    expect(out).toContain("otherhashotherhashotherh");
+  });
+
+  it("refuses to start when an asset has no entry, rather than shipping the bug again", () => {
+    // If a future nitro keeps this manifest somewhere else, that has to fail
+    // here — loudly — instead of producing another image that looks fine until
+    // somebody clicks something.
+    expect(() =>
+      updateAssetManifest(manifest(9999, '"270f-x"'), [["/assets/not-there.js", bytes]]),
+    ).toThrow(/no manifest entry/);
+  });
+
+  it("refuses when the entry has no size to correct", () => {
+    const shapeless = `const assets = { "/assets/api-client-XyZ.js": { "type": "text/javascript" } };`;
+    expect(() => updateAssetManifest(shapeless, [["/assets/api-client-XyZ.js", bytes]])).toThrow(
+      /no size or etag/,
+    );
+  });
+});
+
+describe("assetEtag", () => {
+  it("reproduces the format nitro records", () => {
+    // "<length in hex>-<27 chars of base64 sha1>", verified against an
+    // untouched entry in a real build.
+    const etag = assetEtag(Buffer.alloc(646, 0x61));
+    expect(etag).toMatch(/^"286-[A-Za-z0-9+/]{27}"$/);
   });
 });


### PR DESCRIPTION
**The published images have never worked in a browser**, and every check anyone would think to run said they did.

Nitro bakes a manifest of every public asset into the server bundle — type, etag, mtime and **size** — and serves `Content-Length` from it. Substituting a 38-character sentinel for a 21-character URL leaves the file 17 bytes shorter than the manifest promises. The browser is told to expect more bytes than arrive and aborts with `ERR_CONTENT_LENGTH_MISMATCH`.

What makes it nasty is *which* files carry sentinels:

| | |
|---|---|
| the HTML document | no sentinels → renders fine |
| the health check | fetches that document → container is green |
| `api-client-*.js`, `legal-anchor-*.js` | carry sentinels → **abort** |

So React never hydrates and every button on the page does nothing. A container that starts, serves pages and cannot sign anyone in — the exact failure `Dockerfile.web`'s header says this design exists to prevent.

### How it got through

The original verification checked that the substitution happened, that no sentinel survived, that a restart re-rendered from pristine, and that the compose stack came up healthy. All true, all still passing, and not one of them loads a script tag. I found it by pointing a browser at `localhost:3000` and noticing a checkbox would not tick.

### The fix

The substitution corrects `size` and `etag` for every public asset it rewrites. The etag is recomputed rather than dropped — a stale one serves a `304` for content that changed, which is the same failure arriving a day later through a cache. Its format is the `etag` package's, `"<hex length>-<27 chars of base64 sha1>"`, verified against an untouched entry in a real build rather than assumed.

`updateAssetManifest` throws when an asset has no entry, or when an entry has no size to correct. That is deliberate: if a future nitro keeps this manifest somewhere else, it has to fail at container start rather than ship another image that looks fine until somebody clicks something.

### Verification

Rebuilt the real image, restarted it, and confirmed with a browser that no response mismatches its declared length and that the page is interactive. Merging republishes `edge`, which is currently broken for anyone who pulled it.

Ported to covan-ai/covan-cloud#84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)