### PR TITLE
Pin the two columns the last pass left open

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,25 @@
 name: covan
 
 services:
+  # --------------------------------------------------------------- Guardrail
+  secrets-check:
+    container_name: covan-secrets-check
+    # postgres:17.6-alpine, not a new image — `migrate` below already pulls
+    # this one, so a fresh `docker compose up` gains no extra download.
+    image: postgres:17.6-alpine
+    volumes:
+      - ./docker/check-secrets.sh:/check-secrets.sh:ro
+    environment:
+      ALLOWED_ORIGIN: ${ALLOWED_ORIGIN:-http://localhost:3000}
+      JWT_SECRET: ${JWT_SECRET}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      ANON_KEY: ${ANON_KEY}
+      SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
+      ROUTINE_SECRET_KEY: ${ROUTINE_SECRET_KEY}
+    entrypoint: ["/bin/sh", "/check-secrets.sh"]
+    restart: "no"
+
   # ---------------------------------------------------------------- Supabase
   db:
     container_name: covan-db
@@ -27,6 +46,18 @@ services:
     # ships both plus the roles GoTrue, PostgREST and Realtime log in as.
     image: supabase/postgres:17.6.1.136
     restart: unless-stopped
+    # Every other service in this file descends from db — auth, rest and
+    # realtime directly; kong from auth+rest; migrate from db+auth; covan-api
+    # from migrate+kong; covan-web from covan-api. Gating db therefore gates
+    # the entire stack. Kong looks like the obvious choke point (it fronts
+    # every request supabase-js makes) but db publishes its own port
+    # (54322) and sits upstream of Kong, so that placement would leave
+    # Postgres itself unguarded. Making db depend on covan-api instead is not
+    # an option: covan-api depends on kong, which depends on auth, which
+    # depends on db — that would be circular.
+    depends_on:
+      secrets-check:
+        condition: service_completed_successfully
     volumes:
       - covan-db-data:/var/lib/postgresql/data
       # Persist the pgsodium root key across restarts.

--- a/docker/check-secrets.sh
+++ b/docker/check-secrets.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Refuse to bring the stack up while it is configured to face a network and
+# still holds the credentials this public repository ships.
+#
+# worker/src/lib/env.ts's loadEnv already does this for covan-api: at boot, if
+# ALLOWED_ORIGIN is not localhost-only, it refuses to start on a handful of
+# published defaults. But JWT_SECRET and POSTGRES_PASSWORD are consumed by
+# Kong, GoTrue, PostgREST and Postgres — none of which run loadEnv, so that
+# guard never sees them. This script is the equivalent check for the rest of
+# the stack, wired in docker-compose.yml as a `secrets-check` service that
+# `db` depends on with `condition: service_completed_successfully`. Every
+# other service descends from `db` (auth, rest, realtime directly; kong from
+# auth+rest; migrate from db+auth; covan-api from migrate+kong; covan-web from
+# covan-api), so failing here blocks the entire stack, not just one container.
+#
+# Keep this in sync with env.ts's servesLocalhostOnly() and
+# PUBLISHED_DEFAULTS — same semantics, same literals, so an operator only has
+# to satisfy one set of rules to clear both checks.
+#
+# Deliberately NOT duplicated here: ROUTINE_SECRET_KEY's base64-length check.
+# covan-api already fails on that at boot, and re-deriving byte lengths from
+# base64 in POSIX sh would just be a worse copy of a check that already
+# exists. This script only covers the values that never reach loadEnv at all.
+#
+# POSIX sh, not bash: this runs in postgres:17.6-alpine, which has no bash.
+set -eu
+
+# A stack whose frontend is on localhost is a laptop, not a deployment — the
+# same carve-out env.ts's servesLocalhostOnly() makes. It splits on commas,
+# trims each entry, drops empties, and requires *every* remaining entry to
+# match ^https?://(localhost|127\.0\.0\.1)(:\d+)?/?$ — so one public origin
+# alongside a local one still fails the check. Mirrored here entry by entry
+# rather than with one combined regex, so that semantics is easy to see.
+localhost_only() {
+  origin_list=$1
+  old_ifs=$IFS
+  IFS=','
+  # Splitting on IFS can also glob-expand entries containing *, ?, [ — turn
+  # that off for the duration of the split.
+  set -f
+  # shellcheck disable=SC2086
+  set -- $origin_list
+  set +f
+  IFS=$old_ifs
+  for entry in "$@"; do
+    trimmed=$(printf '%s' "$entry" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    [ -z "$trimmed" ] && continue
+    if ! printf '%s' "$trimmed" | grep -Eq '^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?/?$'; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+if localhost_only "${ALLOWED_ORIGIN:-}"; then
+  echo "check-secrets: ALLOWED_ORIGIN is localhost-only — this is a laptop, skipping."
+  exit 0
+fi
+
+# The exact literals .env.docker.example ships, character for character. A
+# near match here (a trailing newline, a re-wrapped JWT) means this guard
+# silently never fires, so these must be copy-pasted from that file, not
+# retyped.
+offenders=""
+add_offender() {
+  if [ -z "$offenders" ]; then
+    offenders=$1
+  else
+    offenders="$offenders, $1"
+  fi
+}
+
+[ "${JWT_SECRET:-}" = "your-super-secret-jwt-token-with-at-least-32-characters-long" ] &&
+  add_offender JWT_SECRET
+[ "${POSTGRES_PASSWORD:-}" = "covan-local-dev-password" ] &&
+  add_offender POSTGRES_PASSWORD
+[ "${SECRET_KEY_BASE:-}" = "UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq" ] &&
+  add_offender SECRET_KEY_BASE
+[ "${ANON_KEY:-}" = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE" ] &&
+  add_offender ANON_KEY
+[ "${SERVICE_ROLE_KEY:-}" = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q" ] &&
+  add_offender SERVICE_ROLE_KEY
+[ "${ROUTINE_SECRET_KEY:-}" = "Y292YW4tbG9jYWwtZGV2LXJvdXRpbmUta2V5LTAwMDE=" ] &&
+  add_offender ROUTINE_SECRET_KEY
+
+if [ -n "$offenders" ]; then
+  echo "check-secrets: refusing to start: $offenders still hold the values" >&2
+  echo ".env.docker.example ships. That file is in a public repository, so" >&2
+  echo "these are not secrets — see docs/self-hosting.md. Regenerate them," >&2
+  echo "or set ALLOWED_ORIGIN to a localhost URL if this really is a local" >&2
+  echo "stack." >&2
+  exit 1
+fi
+
+echo "check-secrets: ALLOWED_ORIGIN is not localhost-only, and no published defaults remain — continuing."

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -304,16 +304,23 @@ error. It also refuses to start on any `ROUTINE_SECRET_KEY` that does not
 decode to 16, 24 or 32 bytes, so a bad key is caught at boot instead of the
 first time a delivery channel is saved.
 
-What it cannot enforce is the rest of step 1. `JWT_SECRET` and
-`POSTGRES_PASSWORD` are consumed by Kong, GoTrue, PostgREST and Postgres —
-none of which run `loadEnv`, and none of which this repository can add a
-startup check to. Regenerating `SUPABASE_ANON_KEY` and
-`SUPABASE_SERVICE_ROLE_KEY` while leaving `JWT_SECRET` at its published
-default achieves nothing: those two keys are JWTs signed with `JWT_SECRET`,
-and anyone who has read this repository already knows that secret and can
-mint their own `{"role":"service_role"}` token, bypassing row level security
-the same way the shipped key would have. Regenerate `JWT_SECRET` first, then
-the two keys it signs.
+`loadEnv` cannot see `JWT_SECRET` and `POSTGRES_PASSWORD` — they are consumed
+by Kong, GoTrue, PostgREST and Postgres, none of which run it — so
+`docker-compose.yml` carries a second, independent guard for the rest of
+step 1: a `secrets-check` service that runs `docker/check-secrets.sh` and
+that `db` depends on with `condition: service_completed_successfully`. Every
+other service descends from `db`, so this one check gates the whole stack.
+Its logic mirrors `loadEnv`'s — same localhost carve-out, same "still holds
+the published default" test — but over `JWT_SECRET`, `POSTGRES_PASSWORD`,
+`SECRET_KEY_BASE`, `ANON_KEY`, `SERVICE_ROLE_KEY` and `ROUTINE_SECRET_KEY`,
+naming every offending variable the same way. Regenerating
+`SUPABASE_ANON_KEY` and `SUPABASE_SERVICE_ROLE_KEY` while leaving
+`JWT_SECRET` at its published default still achieves nothing, and both
+checks will say so: those two keys are JWTs signed with `JWT_SECRET`, and
+anyone who has read this repository already knows that secret and can mint
+their own `{"role":"service_role"}` token, bypassing row level security the
+same way the shipped key would have. Regenerate `JWT_SECRET` first, then the
+two keys it signs.
 
 ### Covan rate-limits itself, and you should still limit at the proxy
 

--- a/supabase/migrations/0030_a_card_stays_on_its_board.sql
+++ b/supabase/migrations/0030_a_card_stays_on_its_board.sql
@@ -1,0 +1,55 @@
+-- 0030_a_card_stays_on_its_board.sql
+--
+-- The whole-branch review of 0028 found a third column nobody reconciled.
+-- 0028 pinned `workspace_id` to the parent session's and made `created_by`
+-- immutable, but left `ideas.session_id` itself unpinned. PostgREST is
+-- reachable with the anon key, so PATCH /rest/v1/ideas?id=eq.<theirs> with a
+-- new session_id was always accepted: it re-parents the card onto a different
+-- brainstorm board outright.
+--
+-- 0028's WITH CHECK does not catch this, and cannot by construction — it
+-- compares workspace_id against `(select cs.workspace_id from chat_sessions cs
+-- where cs.id = ideas.session_id)`, and that subquery runs against the *new*
+-- row. After a re-parent, the new session is the parent, so the check is
+-- satisfied against the very row that just moved. A WITH CHECK predicate has
+-- no way to compare the new session_id against the old one, because it never
+-- sees the old row — the same reason 0027 reached for a trigger over a policy
+-- predicate for `routines.source_config`.
+--
+-- The consequence is contained rather than cross-tenant: the subquery still
+-- runs under the caller's own RLS, so a non-member of the target session's
+-- workspace gets NULL there and 0028's WITH CHECK still fails the write. But a
+-- viewer — "Uses the agents. Changes none of them." per src/lib/roles.ts — can
+-- move their own card onto a *shared* board they are only supposed to read,
+-- which is the same class of bug 0028 exists to close.
+--
+-- The route is not the boundary either: updateIdeaSchema in
+-- worker/src/routes/ideas.ts never accepts session_id, so the app has no
+-- legitimate reason to change it after the card is created.
+--
+-- A separate trigger function rather than widening 0028's
+-- ideas_created_by_is_immutable, because the two guard unrelated invariants
+-- (who wrote the card vs. which board it lives on) with independent error
+-- messages, and 0028 is an applied migration — this one only needs
+-- `create or replace` on it if folding were the better shape, and here it
+-- is not.
+
+create or replace function public.ideas_session_id_is_immutable()
+returns trigger
+language plpgsql
+security invoker
+set search_path = pg_catalog, public
+as $$
+begin
+  if new.session_id is distinct from old.session_id then
+    raise exception 'a card cannot be moved to a different session'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+create trigger trg_ideas_session_id_immutable
+  before update on public.ideas
+  for each row
+  execute function public.ideas_session_id_is_immutable();

--- a/tests/rls/viewer.test.ts
+++ b/tests/rls/viewer.test.ts
@@ -245,3 +245,69 @@ describe("ideas: your own card is yours to change, not anyone's", () => {
     expect(data!.created_by).toBe(member.id);
   });
 });
+
+/**
+ * 0028's WITH CHECK pins workspace_id to the parent session's, but that
+ * subquery runs against the NEW row — after a re-parent the new session is
+ * the parent, so the check passes against the very row that just moved.
+ * ideas.session_id itself was left unpinned by any policy. 0030 closes it
+ * with a trigger, since a WITH CHECK predicate never sees the old row and so
+ * cannot compare the new session_id against it.
+ */
+describe("ideas: a card cannot be moved to a different board", () => {
+  it("refuses to re-parent a card to another session, but a normal edit still works", async () => {
+    const { data: otherSession } = await owner.db
+      .from("chat_sessions")
+      .insert({
+        agent_id: seeded.agentId,
+        user_id: owner.id,
+        workspace_id: owner.workspaceId,
+        visibility: "shared",
+        title: "A different board",
+      })
+      .select("id")
+      .single();
+
+    const { data: card } = await member.db
+      .from("ideas")
+      .insert({
+        session_id: seeded.sessionId,
+        workspace_id: owner.workspaceId,
+        title: "stay put",
+        created_by: member.id,
+      })
+      .select("id")
+      .single();
+
+    const { error: moveError } = await member.db
+      .from("ideas")
+      .update({ session_id: otherSession!.id })
+      .eq("id", card!.id);
+    expect(moveError, "a card was re-parented to a different session").not.toBeNull();
+
+    // Read back through the service role: RLS and the trigger refuse in
+    // different ways, and an error alone does not prove the column held.
+    const { data: afterMove } = await serviceClient()
+      .from("ideas")
+      .select("session_id")
+      .eq("id", card!.id)
+      .single();
+    expect(afterMove!.session_id).toBe(seeded.sessionId);
+
+    // The trigger's `is distinct from` must not catch an ordinary edit that
+    // leaves session_id untouched.
+    const { error: editError } = await member.db
+      .from("ideas")
+      .update({ title: "still stays put" })
+      .eq("id", card!.id);
+    expect(editError, "a normal card edit was blocked").toBeNull();
+
+    const { data: afterEdit } = await serviceClient()
+      .from("ideas")
+      .select("title, session_id")
+      .eq("id", card!.id)
+      .single();
+    expect(afterEdit!.title).toBe("still stays put");
+    expect(afterEdit!.session_id).toBe(seeded.sessionId);
+  });
+});


### PR DESCRIPTION
The two findings #29's final review turned up and deliberately left open. Both are the same shape as things that PR already fixed — which is the point: its closing note said the general form was worth one deliberate sweep, and these are what the sweep found.

## A card stays on its board

`0028` closed two `ideas` findings and missed a third column. It pinned `workspace_id` with a `WITH CHECK` and froze `created_by` with a trigger, but `ideas.session_id` is pinned by nothing — and PostgREST is reachable with the anon key that ships in the browser bundle, so `PATCH /rest/v1/ideas?id=eq.<mine>` moves a card onto a different brainstorm board.

`0028`'s own `WITH CHECK` does not stop it, and the reason is worth stating because it is easy to misread as covered: the check compares `workspace_id` against *the parent session's*. After the move the new session **is** the parent, so it is satisfied against the very row that just changed.

The effect is a `viewer` — whose contract in `src/lib/roles.ts` is "Uses the agents. Changes none of them." — putting a card on a shared board they are only supposed to read. It is contained: the subquery runs under the caller's own RLS, so a non-member gets `NULL` and fails. Nothing crosses a tenant boundary.

`0030` adds a `before update` trigger holding `session_id` immutable, in the same shape as the two `0028` already carries. A separate function rather than widening `0028`'s, because the two invariants are unrelated and each deserves its own error message. The route agrees with the database now: `updateIdeaSchema` has never had a `session_id` field, so nothing legitimate wanted to change it — the same argument `0027` made for a routine's `source_config`.

## The whole stack, not just covan-api

#29 made `covan-api` refuse to boot on the credentials `.env.docker.example` ships when `ALLOWED_ORIGIN` is not localhost. That left a real gap, and `docs/self-hosting.md` said so plainly rather than implying otherwise: `JWT_SECRET` and `POSTGRES_PASSWORD` are consumed by Kong, GoTrue, PostgREST and Postgres, none of which run `loadEnv`. So an operator who sets `BIND_ADDR=0.0.0.0` without regenerating those two still exposes a superuser Postgres and a Kong whose JWTs anyone can forge, while `covan-api` crash-loops beside them. Those values are in this repository; the demo JWTs verify against the shipped secret and are valid until 2027-01-09.

The fix is a `secrets-check` init container, not a guard in `docker/kong-entrypoint.sh`. Kong is the wrong choke point — it leaves Postgres on `54322` open. Every service here descends from `db`:

```
auth <- db      rest <- db      realtime <- db
kong <- auth rest               migrate <- db auth
covan-api <- migrate kong       covan-web <- covan-api
```

so one container that `db` waits on gates the entire stack. It also has to be this direction: making `db` depend on `covan-api` is circular, since `covan-api -> kong -> auth -> db`.

`docker/check-secrets.sh` mirrors `loadEnv`'s shape deliberately, so the two cannot drift into disagreeing. Localhost-only `ALLOWED_ORIGIN` allows everything — that is a laptop, and the demo values are what it is for — with the same every-entry semantics `env.ts` uses, so one non-local origin in a comma-separated list defeats the exemption. Otherwise it refuses on `JWT_SECRET`, `POSTGRES_PASSWORD`, `SECRET_KEY_BASE`, `ANON_KEY`, `SERVICE_ROLE_KEY` or `ROUTINE_SECRET_KEY`, naming every offender in one message rather than making an operator fix them one restart at a time. It does not re-check `ROUTINE_SECRET_KEY`'s decoded length — `loadEnv` already owns that, and a second copy in shell would only be a worse one.

It runs on `postgres:17.6-alpine`, which `migrate` already pulls, so a fresh `docker compose up` downloads nothing new.

`docs/self-hosting.md`'s "What it cannot enforce is the rest of step 1" paragraph is now wrong, so it is replaced rather than left standing next to a contradiction.

## Verifying this

**The RLS job is the gate for `0030`.** The Docker daemon on the machine this was written on went unhealthy partway through — zero containers, hanging on `docker info` — so the RLS suite could not run locally and the `secrets-check` script could not be exercised inside its real BusyBox image. The script's logic was verified instead by running it directly under `sh` and `dash` with hand-set environments, including the two adversarial cases worth naming: `ALLOWED_ORIGIN="http://localhost:3000,https://evil.com"` must refuse, and `http://localhost.evil.com` must not count as local. Both behave correctly.

The six literals were compared byte-for-byte against `.env.docker.example` rather than by eye — a single character of drift would make the guard silently never fire, which is the failure mode that matters most here.

Unit tests, typechecks and lint are green locally (261 frontend, 483 worker, 0 lint errors).

## Two cosmetic notes, deliberately not fixed

`check-secrets.sh`'s `localhost_only()` uses `set --` to word-split the origin list, which permanently overwrites the script's own positional parameters. It cannot bite today — compose invokes the script with no arguments and nothing after that call reads `$@` — but it is a trap if anyone later adds argument handling. And the file carries a `755` bit that goes unused, since compose runs it as `/bin/sh /check-secrets.sh`.

## After merging

`0030` needs applying by hand alongside `0026`–`0029`. CI does not apply migrations. Confirm the project ref first — a retired Supabase project stays reachable and answers exactly like the live one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
