### PR TITLE
Make reading a conversation follow membership of its workspace

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -176,13 +176,20 @@ does the work here is `chat_sessions_select_owner_or_shared`:
 create policy "chat_sessions_select_owner_or_shared"
   on public.chat_sessions for select
   using (
-    user_id = auth.uid()
-    or (visibility = 'shared' and public.is_workspace_member(workspace_id))
+    public.is_workspace_member(workspace_id)
+    and (user_id = auth.uid() or visibility = 'shared')
   );
 ```
 
-Messages do not repeat that rule; `messages_select_session_visible` defers to the
-parent session, so a message is readable exactly when its session is.
+Read it in that order, because the order is the rule: membership first and
+unconditionally, then ownership to decide which member. Being the person who
+opened a session is not on its own a reason to be shown it — the answers in it
+came from the workspace's knowledge, so access to it ends when membership does.
+Until `0031` the first branch stood alone and it did not.
+
+Messages do not repeat that rule and neither do idea cards; both defer to
+`session_is_visible`, which holds the expression above once, so a message is
+readable exactly when its session is.
 
 What this guarantees is narrow and worth stating exactly: a `select` carrying
 another person's token returns no row for a private session that is not theirs,

--- a/docs/team.md
+++ b/docs/team.md
@@ -298,26 +298,29 @@ More than the word "remove" suggests:
   the select policy tests the _reader's_ membership, not the owner's, so a
   conversation somebody shared before they left goes on being visible to everyone
   who is still there.
-- **Their own sessions and routines still exist, are still theirs, and are still
-  reachable.** Both tables key off `auth.users` and carry no membership foreign
-  key, so nothing about them cascades — and the owner branch of each select
-  policy tests only `user_id = auth.uid()`, with no membership check beside it.
-  What removal takes away is the _list_: `GET /sessions` is scoped to the
-  caller's active workspace, and a workspace they have been removed from cannot
-  be made active, so the conversation stops appearing. It does not stop
-  existing. Reading a session's messages is filtered on the session id alone,
-  and the insert policy admits its owner on the same terms, so somebody who
-  still has the id — a bookmark, an open tab, a URL in their history — can read
-  the whole transcript back and append to it. What they cannot do is get an
-  answer: the reply path loads the agent first, that read is membership-gated,
-  and it returns a 404. Treat removal as ending their access to the workspace,
-  not as sealing the conversations they had in it.
+- **Their own sessions still exist, and stop being readable.** `chat_sessions`
+  keys off `auth.users` and carries no membership foreign key, so nothing about
+  it cascades and the rows survive removal untouched. Reaching them is another
+  matter: since `0031` every policy on `chat_sessions`, `messages` and `ideas`
+  requires membership of the workspace before it asks who owns the row, so a
+  conversation in a workspace somebody has left is refused however they come at
+  it — the workspace-scoped list, a bookmarked session id, an open tab, or a
+  PATCH straight to PostgREST. The questions in it were theirs; the answers were
+  grounded in the workspace's knowledge bundles, and leaving the transcript
+  readable would leave a readable copy of what those documents said. Nothing is
+  destroyed, and re-inviting them brings all of it back.
 - **Their routines stop at the next tick, not at the moment of removal.** The
   engine holds a service-role client that row level security does not constrain,
   so it re-checks the owner's membership before every single run and pauses the
   routine with a recorded reason when it has gone. Until that tick arrives the
   routine is still scheduled. The owner is deliberately not notified — see
-  [runs that send nothing](routines.md#runs-that-send-nothing).
+  [runs that send nothing](routines.md#runs-that-send-nothing). The routine row
+  itself stays readable to its owner: `routines_select_visible` keeps the plain
+  owner branch that `0031` closed on sessions, because the recorded pause reason
+  is the only explanation they will ever be given, and a routine that vanished
+  would be indistinguishable from one that quietly stopped working. There is
+  nothing of the workspace's in it — the instruction is theirs, and
+  `routine_runs` records counts and status, never content.
 - **Their delivery channels survive** — they were never the workspace's to take.
 
 Re-inviting the person gives all of it back, because none of it was destroyed.

--- a/src/routes/_authed.team.tsx
+++ b/src/routes/_authed.team.tsx
@@ -246,7 +246,9 @@ function TeamPage() {
                                 <AlertDialogTitle>Remove member?</AlertDialogTitle>
                                 <AlertDialogDescription>
                                   {m.name ?? m.email ?? "This member"} will lose access to this
-                                  workspace and its agents. You can re-invite them later.
+                                  workspace, its agents, and their own conversations here —
+                                  including what the agents answered from your knowledge. Nothing is
+                                  deleted: invite them back and it all returns.
                                 </AlertDialogDescription>
                               </AlertDialogHeader>
                               <AlertDialogFooter>
@@ -285,7 +287,7 @@ function TeamPage() {
                                   </AlertDialogTitle>
                                   <AlertDialogDescription>
                                     {cannotLeave ??
-                                      "You will lose access to this workspace's agents, knowledge and shared conversations. What you made stays here, and an admin can invite you back."}
+                                      "You will lose access to this workspace's agents and knowledge, and to the conversations you had with them here — your own private ones included. Nothing is deleted: what you made stays, and it all comes back if an admin invites you back."}
                                   </AlertDialogDescription>
                                 </AlertDialogHeader>
                                 <AlertDialogFooter>

--- a/supabase/migrations/0031_access_follows_membership.sql
+++ b/supabase/migrations/0031_access_follows_membership.sql
@@ -1,0 +1,230 @@
+-- 0031_access_follows_membership.sql
+--
+-- The last of the nine gaps found on 2026-08-21 by reading /docs against the
+-- code. The other eight shipped in 0018-0022; this one waited because the fix
+-- was a product decision rather than a patch, and the decision is now made:
+-- access to a workspace's rows follows membership of that workspace.
+--
+-- Eleven policies across chat_sessions, messages and ideas gate on the same
+-- copied predicate:
+--
+--   cs.user_id = auth.uid()
+--   or (cs.visibility = 'shared' and is_workspace_member(cs.workspace_id))
+--
+-- The second branch checks membership. The first does not, and never did — a
+-- session genuinely belongs to the person who opened it, so RLS returns it
+-- however the route is written. Remove somebody from a workspace and they keep
+-- reading the private conversations they had with its agents.
+--
+-- What that costs is not their own questions, which are arguably theirs to
+-- keep. It is the other half of the transcript: every assistant reply was
+-- grounded in the workspace's knowledge bundles, so the thread is a readable
+-- copy of what those documents said. The agent itself is already unreachable —
+-- POST /chat/stream loads it through the caller's own client and 404s — which
+-- is exactly what made this easy to miss. Removal ended their access to the
+-- documents and left the answers behind.
+--
+-- The predicate is rewritten so membership is unconditional and ownership only
+-- decides which member sees it:
+--
+--   is_workspace_member(cs.workspace_id)
+--   and (cs.user_id = auth.uid() or cs.visibility = 'shared')
+--
+-- Nothing is deleted. The rows sit where they are and come back the moment the
+-- person is invited back, which is what the removal dialog on the team page now
+-- says, and what tests/rls/membership.test.ts asserts in both directions.
+--
+-- ---- Not changed, deliberately -------------------------------------------
+--
+-- `routines_select_visible` carries the same open branch and keeps it. The harm
+-- there is already closed further up: the executor checks membership before
+-- every run and pauses the routine with "the routine's owner is no longer a
+-- member of this workspace" (worker/src/lib/routines/executor.ts), and
+-- routine_runs records counts and status, never content. Leaving the row
+-- readable is the point — it is the only place that pause reason is shown, and
+-- hiding it would replace an explanation with a routine that silently stopped.
+--
+-- GET /sessions/:id/messages still filters on session_id alone. It leans on
+-- messages_select_session_visible below, which is the arrangement the whole
+-- suite is built on; a workspace scope in the route would be a second query
+-- guarding what the database already refuses.
+
+-- ---- the predicate, once -------------------------------------------------
+-- Seven of the eleven policies gate on the parent session rather than on their
+-- own columns, and each had its own copy of the expression. That is how the
+-- open branch came to exist in five places at once, and why fixing it in one
+-- would have been indistinguishable from fixing it everywhere. They now name
+-- this function and nothing else, the way 0021 collapsed every write policy on
+-- a shared table onto can_write_in_workspace.
+--
+-- SECURITY DEFINER, matching is_workspace_member and can_write_in_workspace:
+-- the predicate is complete on its own rather than resting on whatever
+-- chat_sessions' own select policy happens to say next year. STABLE so the
+-- planner may call it once per row.
+create or replace function public.session_is_visible(p_session_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = pg_catalog, public
+as $$
+  select exists (
+    select 1
+    from public.chat_sessions cs
+    where cs.id = p_session_id
+      and public.is_workspace_member(cs.workspace_id)
+      and (cs.user_id = auth.uid() or cs.visibility = 'shared')
+  );
+$$;
+
+-- NO REVOKE, for the reason 0021 spells out: this is evaluated inside a policy
+-- by the invoking role, so `authenticated` needs EXECUTE or every read it
+-- guards fails with "permission denied for function". Only functions reached
+-- through PostgREST — claim_due_routines — are revoked from PUBLIC.
+
+-- ---- chat_sessions -------------------------------------------------------
+
+drop policy if exists "chat_sessions_select_owner_or_shared" on public.chat_sessions;
+
+create policy "chat_sessions_select_owner_or_shared"
+  on public.chat_sessions for select
+  using (
+    public.is_workspace_member(workspace_id)
+    and (user_id = auth.uid() or visibility = 'shared')
+  );
+
+-- The USING here has been the weaker half of an asymmetric pair since 0028,
+-- which added membership to the WITH CHECK and left USING as bare ownership.
+-- An ex-member's UPDATE was already refused — the check fails — but a policy
+-- whose two halves disagree about what it is for is one edit away from being
+-- read wrong. The agent-in-this-workspace guard from 0028 is unchanged.
+drop policy if exists "chat_sessions_update_owner" on public.chat_sessions;
+
+create policy "chat_sessions_update_owner"
+  on public.chat_sessions for update
+  using (user_id = auth.uid() and public.is_workspace_member(workspace_id))
+  with check (
+    user_id = auth.uid()
+    and public.is_workspace_member(workspace_id)
+    and exists (
+      select 1 from public.agents a
+      where a.id = chat_sessions.agent_id
+        and a.workspace_id = chat_sessions.workspace_id
+    )
+  );
+
+-- Deleting your own leftovers is not obviously harmful, and it is still the one
+-- of the three that could be argued either way. It goes with the others because
+-- a session marked shared is a thread the team is still reading, and somebody
+-- who has left the workspace should not be able to take it down from outside.
+drop policy if exists "chat_sessions_delete_owner" on public.chat_sessions;
+
+create policy "chat_sessions_delete_owner"
+  on public.chat_sessions for delete
+  using (user_id = auth.uid() and public.is_workspace_member(workspace_id));
+
+-- ---- messages ------------------------------------------------------------
+
+drop policy if exists "messages_select_session_visible" on public.messages;
+
+create policy "messages_select_session_visible"
+  on public.messages for select
+  using (public.session_is_visible(session_id));
+
+-- 0018's own-voice guard is unchanged: sender_id and role are what stop a
+-- client putting words in the agent's mouth, and they are independent of this.
+drop policy if exists "messages_insert_user_self" on public.messages;
+
+create policy "messages_insert_user_self"
+  on public.messages for insert
+  with check (
+    sender_id = auth.uid()
+    and role = 'user'
+    and public.session_is_visible(session_id)
+  );
+
+drop policy if exists "messages_update_owner" on public.messages;
+
+create policy "messages_update_owner"
+  on public.messages for update
+  using (
+    sender_id = auth.uid()
+    and role = 'user'
+    and public.session_is_visible(session_id)
+  )
+  with check (
+    sender_id = auth.uid()
+    and role = 'user'
+    and public.session_is_visible(session_id)
+  );
+
+-- The one that must NOT take the helper. Deleting a message has been the
+-- parent session's owner alone since 0001, while session_is_visible is true for
+-- every member of a shared session — swapping it in here would hand anyone
+-- reading a shared thread the power to delete lines out of it. Ownership stays
+-- inline; only the membership condition is added.
+drop policy if exists "messages_delete_owner" on public.messages;
+
+create policy "messages_delete_owner"
+  on public.messages for delete
+  using (
+    exists (
+      select 1
+      from public.chat_sessions cs
+      where cs.id = messages.session_id
+        and cs.user_id = auth.uid()
+        and public.is_workspace_member(cs.workspace_id)
+    )
+  );
+
+-- ---- ideas ---------------------------------------------------------------
+-- A brainstorm board hangs off a session exactly as messages do, so the same
+-- open branch reached the cards. The role and authorship guards from 0021 and
+-- 0028 — can_write_in_workspace, created_by, the pinned workspace_id, and the
+-- two immutability triggers from 0028 and 0030 — are unchanged.
+
+drop policy if exists "ideas_select_session_visible" on public.ideas;
+
+create policy "ideas_select_session_visible"
+  on public.ideas for select
+  using (public.session_is_visible(session_id));
+
+drop policy if exists "ideas_insert_session_visible" on public.ideas;
+
+create policy "ideas_insert_session_visible"
+  on public.ideas for insert
+  with check (
+    created_by = auth.uid()
+    and public.session_is_visible(session_id)
+  );
+
+drop policy if exists "ideas_update_session_visible" on public.ideas;
+
+create policy "ideas_update_session_visible"
+  on public.ideas for update
+  using (
+    (
+      created_by = auth.uid()
+      or public.can_write_in_workspace(
+        (select cs.workspace_id from public.chat_sessions cs where cs.id = ideas.session_id)
+      )
+    )
+    and public.session_is_visible(session_id)
+  )
+  with check (
+    workspace_id = (select cs.workspace_id from public.chat_sessions cs where cs.id = ideas.session_id)
+  );
+
+drop policy if exists "ideas_delete_session_visible" on public.ideas;
+
+create policy "ideas_delete_session_visible"
+  on public.ideas for delete
+  using (
+    (
+      created_by = auth.uid()
+      or public.can_write_in_workspace(
+        (select cs.workspace_id from public.chat_sessions cs where cs.id = ideas.session_id)
+      )
+    )
+    and public.session_is_visible(session_id)
+  );

--- a/tests/rls/membership.test.ts
+++ b/tests/rls/membership.test.ts
@@ -211,6 +211,153 @@ describe("leaving a workspace", () => {
   });
 });
 
+describe("a removed member's own conversation", () => {
+  /**
+   * The half `after being removed` below never built. It removes Carol, who
+   * owns nothing in Alice's workspace, so it proves she loses sight of other
+   * people's rows and says nothing about her own.
+   *
+   * The rows here are the ones that matter: a private session the guest opened
+   * against the HOST's agent. They wrote the questions, so keeping those is
+   * arguable — but every assistant reply in the thread was grounded in the
+   * workspace's knowledge bundles, so a readable transcript is a readable copy
+   * of what those documents said. Removing somebody has to take it back.
+   *
+   * Fresh users throughout: this takes a membership away, and the assertions
+   * elsewhere in the file depend on Carol keeping hers.
+   */
+  let host: TestUser;
+  let guest: TestUser;
+  let seeded: Seeded;
+  let ownSessionId: string;
+  let ownMessageId: string;
+  let cardInSharedSessionId: string;
+
+  async function setMembership(present: boolean) {
+    const members = serviceClient().from("workspace_members");
+    const { error } = present
+      ? await members.insert({
+          workspace_id: host.workspaceId,
+          user_id: guest.id,
+          role: "member",
+        })
+      : await members.delete().eq("workspace_id", host.workspaceId).eq("user_id", guest.id);
+    if (error) throw new Error(`could not set membership: ${error.message}`);
+  }
+
+  /** Reads as the service role, so "gone" is distinguishable from "invisible". */
+  async function stillExists(table: string, id: string): Promise<boolean> {
+    const { data } = await serviceClient().from(table).select("id").eq("id", id);
+    return (data ?? []).length > 0;
+  }
+
+  beforeAll(async () => {
+    host = await createTestUser("keeps-host");
+    guest = await createTestUser("keeps-guest");
+    seeded = await seedWorkspace(host, "shared");
+    await setMembership(true);
+
+    const { data: session, error: sessionError } = await guest.db
+      .from("chat_sessions")
+      .insert({
+        agent_id: seeded.agentId,
+        user_id: guest.id,
+        workspace_id: host.workspaceId,
+        visibility: "private",
+        title: "What the guest asked the workspace's agent",
+      })
+      .select("id")
+      .single();
+    if (sessionError) throw new Error(`guest could not open a session: ${sessionError.message}`);
+    ownSessionId = session.id as string;
+
+    const { data: message, error: messageError } = await guest.db
+      .from("messages")
+      .insert({
+        session_id: ownSessionId,
+        sender_id: guest.id,
+        role: "user",
+        content: "what does the pricing document say?",
+      })
+      .select("id")
+      .single();
+    if (messageError) throw new Error(`guest could not write a message: ${messageError.message}`);
+    ownMessageId = message.id as string;
+
+    // A card of their own on somebody else's shared board — same shape, one
+    // table further out, and the policy there carries the same open branch.
+    const { data: card, error: cardError } = await guest.db
+      .from("ideas")
+      .insert({
+        session_id: seeded.sessionId,
+        workspace_id: host.workspaceId,
+        title: "The guest's card",
+        created_by: guest.id,
+      })
+      .select("id")
+      .single();
+    if (cardError) throw new Error(`guest could not add a card: ${cardError.message}`);
+    cardInSharedSessionId = card.id as string;
+
+    await setMembership(false);
+  });
+
+  it("stops being readable, along with what the agent answered in it", async () => {
+    expect(await visible(guest, "chat_sessions", ownSessionId)).toBe(false);
+    expect(await visible(guest, "messages", ownMessageId)).toBe(false);
+    expect(await visible(guest, "ideas", cardInSharedSessionId)).toBe(false);
+  });
+
+  it("cannot be appended to", async () => {
+    // Harmless on its own — the agent is unreachable, so nothing answers — but
+    // it is a write into a workspace they are no longer in.
+    const { error } = await guest.db.from("messages").insert({
+      session_id: ownSessionId,
+      sender_id: guest.id,
+      role: "user",
+      content: "are you still there?",
+    });
+    expect(error, "an ex-member appended to a workspace thread").not.toBeNull();
+  });
+
+  it("cannot be edited or deleted either", async () => {
+    const { data: edited } = await guest.db
+      .from("messages")
+      .update({ content: "rewritten from outside the workspace" })
+      .eq("id", ownMessageId)
+      .select("id");
+    expect(edited ?? []).toEqual([]);
+
+    const { data: deleted } = await guest.db
+      .from("chat_sessions")
+      .delete()
+      .eq("id", ownSessionId)
+      .select("id");
+    expect(deleted ?? []).toEqual([]);
+    // Deleting is not obviously harmful, but a shared thread the team relies on
+    // is not an ex-member's to destroy, and the rows have to survive for the
+    // re-invitation below to mean anything.
+    expect(await stillExists("chat_sessions", ownSessionId)).toBe(true);
+  });
+
+  it("comes back if they are invited back", async () => {
+    // Nothing is deleted by removal — the rows are simply out of reach, which
+    // is what makes this reversible and what the removal dialog promises.
+    await setMembership(true);
+    expect(await visible(guest, "chat_sessions", ownSessionId)).toBe(true);
+    expect(await visible(guest, "messages", ownMessageId)).toBe(true);
+    expect(await visible(guest, "ideas", cardInSharedSessionId)).toBe(true);
+    await setMembership(false);
+  });
+
+  it("does not take the workspace's own copy with it", async () => {
+    // The other half of the invariant: the guest's card sits on the host's
+    // shared board, and the host keeps reading it after the guest is gone.
+    expect(await visible(host, "ideas", cardInSharedSessionId)).toBe(true);
+    expect(await visible(host, "chat_sessions", seeded.sessionId)).toBe(true);
+  });
+});
+
 describe("after being removed from the workspace", () => {
   // Runs last on purpose: it takes Carol's membership away, and the assertions
   // above depend on her having it.

--- a/worker/src/routes/sessions.ts
+++ b/worker/src/routes/sessions.ts
@@ -126,6 +126,15 @@ sessions.delete("/sessions/:id", async (c) => {
 });
 
 // GET /sessions/:id/messages
+//
+// Filtered on the session id alone, and that is the whole of it: what a caller
+// may read is `messages_select_session_visible`, which since 0031 defers to
+// `session_is_visible` — membership of the session's workspace first, then owner
+// or shared. Adding a workspace scope here would be a second query guarding
+// something the database already refuses, and it is the policy people would go
+// on trusting anyway. It was not always so: the same route with the same
+// filter handed an ex-member their old transcripts until 0031 closed the owner
+// branch above it.
 sessions.get("/sessions/:id/messages", async (c) => {
   const db = c.get("db");
   const id = c.req.param("id");


### PR DESCRIPTION
## What was open

Eleven policies across `chat_sessions`, `messages` and `ideas` gated on the same
copied predicate:

```
cs.user_id = auth.uid()
or (cs.visibility = 'shared' and is_workspace_member(cs.workspace_id))
```

The second branch checks membership. The first never did. Remove somebody from a
workspace and the list stopped showing their conversations; the rows went on
answering — a bookmarked session id or an open tab was enough.

What that leaves behind is not their own questions, which are arguably theirs to
keep. It is the other half of the transcript: **every assistant reply was
grounded in the workspace's knowledge bundles**, so removing somebody ended
their access to the documents and left them a readable copy of what those
documents said. The agent itself was already unreachable — the reply path loads
it through the caller's own client and 404s — which is what made this easy to
miss.

## The change

`0031_access_follows_membership.sql` rewrites the predicate so membership is
unconditional and ownership only decides *which* member:

```
is_workspace_member(cs.workspace_id)
and (cs.user_id = auth.uid() or cs.visibility = 'shared')
```

Seven of the eleven gate on a parent session rather than on their own columns,
and each carried its own copy of the expression — which is how one open branch
came to exist in five places at once. They now name a single
`session_is_visible(uuid)` helper and nothing else, the way 0021 collapsed every
write policy on a shared table onto `can_write_in_workspace`. `SECURITY DEFINER`
and `STABLE`, matching that family; no `REVOKE`, for the reason 0021 spells out —
a helper evaluated inside a policy needs EXECUTE or every read it guards fails.

**Two policies keep an inline predicate on purpose.** `messages_delete_owner` has
been the parent session's owner alone since 0001, while `session_is_visible` is
true for every reader of a *shared* session — the helper there would hand anyone
reading a shared thread the power to delete lines out of it. And
`chat_sessions_update_owner`'s USING has been the weaker half of an asymmetric
pair since 0028; the write was already refused by the WITH CHECK, but a policy
whose halves disagree is one edit from being read wrong.

## Not changed, deliberately

`routines_select_visible` carries the same open branch and keeps it. The harm is
already closed further up: the executor re-checks membership before every run
and pauses the routine with a recorded reason, and `routine_runs` records counts
and status, never content. Leaving the row readable **is** the point — it is the
only place that pause reason is ever shown.

## Tests

`tests/rls/membership.test.ts` never built the case that matters: its
"after being removed" block removes somebody who owns nothing in the workspace,
so it proved they lose sight of *other people's* rows and said nothing about
their own. The new block gives a guest a private session against the host's
agent, a message in it and a card on the host's shared board, then removes them —
and asserts the reads fail, the append fails, the edit and delete fail, the rows
still exist, and **all of it returns when they are invited back**.

## Fallout

- Both dialogs on the team page said less than the truth; the leave dialog's
  "What you made stays here" implied your own conversations were never at stake.
- `docs/team.md` documented the old behaviour in detail and `docs/concepts.md`
  printed the old policy body.
- `GET /sessions/:id/messages` still filters on the session id alone. That is the
  arrangement the whole suite is built on, so it gains a comment naming the
  policy it leans on rather than a second query guarding what the database
  already refuses.

## If you self-host

CI does not apply migrations to anything but a throwaway Postgres. `0031` is
written to be re-runnable (`drop policy if exists` throughout) and has to be
applied to your database like any other — until it is, the behaviour above is
what your deployment does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)