### PR TITLE
Stop offering an API nobody can hold a key to

### DIFF
--- a/src/routes/_authed.integrations.tsx
+++ b/src/routes/_authed.integrations.tsx
@@ -15,7 +15,12 @@ export const Route = createFileRoute("/_authed/integrations")({
   }),
 });
 
-type Status = "available" | "beta" | "soon";
+// No "beta" rung. The REST API was the only row that ever carried it, and it
+// has moved to the roadmap; a chip nothing renders is a chip nobody notices has
+// gone wrong. It belongs back the day there is a key you can hold. (No issue
+// number here on purpose: this file is byte-identical in covan-ai/covan, where
+// the same number is a different thing entirely.)
+type Status = "available" | "soon";
 
 type Integration = {
   name: string;
@@ -26,10 +31,17 @@ type Integration = {
 
 const items: Integration[] = [
   {
+    // On the roadmap even though the API exists and every screen in Covan runs
+    // on it, because what a caller needs is a credential they can hold, and
+    // there isn't one. `worker/src/middleware/auth.ts` accepts a Supabase JWT
+    // and nothing else; no migration defines an api_keys table, no route issues
+    // or revokes anything. So the only way in is to lift your own session token
+    // out of a browser, and it expires in an hour. That is not something a
+    // cron job can do, and listing it as available asked people to try.
     name: "REST API",
-    desc: "Call any shared agent programmatically, with the same knowledge it uses in chat.",
+    desc: "Call any shared agent programmatically, once there is a key you can hold.",
     icon: Code2,
-    status: "beta",
+    status: "soon",
   },
   {
     // Shipped, but narrower than "Slack" sounds: an incoming-webhook URL you
@@ -74,7 +86,7 @@ function StatusChip({ status }: { status: Status }) {
   // "Available", not "Connected": this list says what Covan can do, not what
   // this workspace has set up. Whether a webhook URL actually exists is a
   // question for Settings, and answering it here would be a guess.
-  const label = status === "beta" ? "Beta" : status === "available" ? "Available" : "Coming soon";
+  const label = status === "available" ? "Available" : "Coming soon";
   return <Chip tone={status === "soon" ? "neutral" : "on"}>{label}</Chip>;
 }
 
@@ -85,11 +97,7 @@ function IntegrationsPage() {
   return (
     <AppShell>
       <PageContainer width="list">
-        <PageHeader
-          badge="Integrations"
-          title="The API is here."
-          turn="The connectors are coming."
-        />
+        <PageHeader badge="Integrations" title="One thing is wired." turn="The rest is coming." />
 
         <section className="mt-14">
           <SectionHeading title="Available now" />


### PR DESCRIPTION
Ported from `covan-cloud`, where it closes the issue that raised it.

## What was wrong

Integrations listed **REST API** under "Available now" with a **Beta** chip and "Call any shared agent programmatically, with the same knowledge it uses in chat."

The API is real — every screen in Covan runs on it. The sentence is still a promise a reader cannot act on:

- `worker/src/middleware/auth.ts` takes `Authorization: Bearer <token>` and passes it to `auth.getUser`. A Supabase JWT, and nothing else.
- No migration defines an `api_keys` table. No route issues or revokes anything. `src/` never mentions a key.
- So the only credential in existence is your own session token, lifted out of a browser, expiring in an hour (`JWT_EXPIRY=3600`).
- There is no API reference in `docs/` either, so the endpoint list is not readable.

A cron job cannot do any of that, and the page was asking people to try. This matters more for a self-hosted Covan than a hosted one: the person reading this page owns the server and is the most likely of anyone to go and try to script against it.

## What changed

`src/routes/_authed.integrations.tsx`, one file:

- **The row moves to the roadmap** and names what is missing rather than what is promised — "Call any shared agent programmatically, once there is a key you can hold." The reason sits in a comment beside it, in the idiom the Slack webhook row already uses.
- **The page header goes with it.** "The API is here." was the same claim in larger type. It now reads "One thing is wired." / "The rest is coming." — exactly true: the Slack webhook is alone in "Available now".
- **`"beta"` leaves the `Status` union and `StatusChip`.** The API row was the only thing that carried it, and a chip nothing renders is a chip nobody notices has gone wrong. It also makes `StatusChip`'s docstring true, which already claimed there is no third state.

The comment deliberately names no issue number: this file is byte-identical in both trees, and the same number means something different in each.

## Testing

None, deliberately. The page is a static array, and the route tests here cover pages with behaviour; a test would assert the copy against itself. Locally: typecheck clean, lint clean (3 pre-existing warnings, 0 errors), 261 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)