### PR TITLE
Give the empty composer somewhere to go

### DIFF
--- a/src/routes/_authed.app.test.tsx
+++ b/src/routes/_authed.app.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+
+const navigate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (options: { component: () => React.ReactElement }) => ({
+    ...options,
+    useSearch: () => ({}),
+  }),
+  useNavigate: () => navigate,
+}));
+
+vi.mock("@tanstack/react-query", () => ({ useQuery: () => ({ data: undefined }) }));
+vi.mock("@/lib/api-client", () => ({ api: { me: vi.fn() } }));
+vi.mock("@/lib/quota", () => ({ useQuota: () => null, quotaSentence: () => "" }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/components/app-shell", () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Stands in for the real dialog so the test can tell "it opened" from "it
+// didn't" without rendering a form the assertion isn't about.
+vi.mock("@/components/create-agent-dialog", () => ({
+  CreateAgentDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="create-dialog" /> : null,
+}));
+
+const store = {
+  agents: [] as unknown[],
+  favorites: [] as string[],
+  sessions: [] as unknown[],
+  canWrite: true,
+  startSession: vi.fn(),
+};
+
+vi.mock("@/lib/agents-store", () => ({ useAgentsStore: () => store }));
+
+async function renderHome(canWrite: boolean) {
+  store.canWrite = canWrite;
+  const { Route } = await import("./_authed.app");
+  const Component = (Route as unknown as { component: () => React.ReactElement }).component;
+  render(<Component />);
+}
+
+beforeEach(() => {
+  navigate.mockClear();
+});
+
+// The composer owns the fold. With no agents in the workspace it was a closed
+// door: a disabled textarea, a disabled send button, and the inert words "No
+// agents yet" where the agent picker goes. The only real Create agent button
+// was in the gallery, far below. So the first screen a new workspace sees
+// described the problem and offered nothing to do about it.
+describe("the home composer, with no agents in the workspace", () => {
+  // Scoped to the composer's own footer rather than the page, because the
+  // gallery below renders two Create agent buttons of its own when the
+  // workspace is empty — a page-wide query passes with the bug still in place.
+  // Send is the anchor: the assertion is that the row holding it also holds a
+  // way out.
+  const composerRow = () => within(screen.getByLabelText("Send").closest("div")!);
+
+  it("gives a member a way to create one without scrolling", async () => {
+    await renderHome(true);
+
+    const create = composerRow().getByRole("button", { name: /create agent/i });
+
+    expect(screen.queryByTestId("create-dialog")).not.toBeInTheDocument();
+    await userEvent.click(create);
+    expect(screen.getByTestId("create-dialog")).toBeInTheDocument();
+  });
+
+  it("tells a viewer who to ask instead of offering a button the policies would refuse", async () => {
+    await renderHome(false);
+
+    const row = composerRow();
+    expect(row.queryByRole("button", { name: /create agent/i })).not.toBeInTheDocument();
+    expect(row.getByText(/ask an admin or a member to create one/i)).toBeInTheDocument();
+  });
+});

--- a/src/routes/_authed.app.tsx
+++ b/src/routes/_authed.app.tsx
@@ -84,7 +84,13 @@ function Home() {
             </p>
           ) : null}
         </div>
-        <HomeComposer agents={agents} favorites={favorites} className="mt-10" />
+        <HomeComposer
+          agents={agents}
+          favorites={favorites}
+          canCreate={canWrite}
+          onCreate={() => setCreateOpen(true)}
+          className="mt-10"
+        />
         {/* Directly under the composer, because this is the moment before
             spending — not buried in settings, where nobody looks until the
             replies have already stopped. Renders nothing when self-hosted. */}
@@ -119,10 +125,16 @@ function Home() {
 function HomeComposer({
   agents,
   favorites,
+  canCreate,
+  onCreate,
   className,
 }: {
   agents: Agent[];
   favorites: string[];
+  /** False for a viewer — same meaning as in the gallery below: the policies
+      refuse them either way, this is so the button is not there to press. */
+  canCreate: boolean;
+  onCreate: () => void;
   className?: string;
 }) {
   const { startSession } = useAgentsStore();
@@ -146,7 +158,11 @@ function HomeComposer({
     const body = text.trim();
     if (sending) return;
     if (!selected) {
-      navigate({ to: "/app", search: { new: true } });
+      // Reachable only if the disabled states below ever come off — the button
+      // in the empty row is the real path now. Straight to the dialog rather
+      // than a ?new=true round trip through the URL, since the handler that
+      // opens it is in scope here.
+      if (canCreate) onCreate();
       return;
     }
     setSending(true);
@@ -187,7 +203,11 @@ function HomeComposer({
             }
           }}
           placeholder={
-            empty ? "Create an agent to get started…" : `Message ${selected?.name ?? "your agent"}…`
+            empty
+              ? canCreate
+                ? "Create an agent to get started…"
+                : "No agents yet — a member has to make the first one…"
+              : `Message ${selected?.name ?? "your agent"}…`
           }
           disabled={empty}
           rows={3}
@@ -195,7 +215,25 @@ function HomeComposer({
         />
         <div className="flex items-center justify-between gap-2 px-4 pb-4">
           {empty ? (
-            <span className="px-1 text-sm text-muted-foreground">No agents yet</span>
+            // This slot used to hold the words "No agents yet" and nothing to
+            // press, on the one card that owns the fold — so the first screen
+            // of an empty workspace told you what was wrong and left the only
+            // way to fix it below the fold, in the gallery. Same control as the
+            // agent picker it replaces, deliberately: the row is the row, only
+            // its contents change. Not a `Button`, because a default-size one
+            // carries the amber chip and send is the single amber fill here.
+            canCreate ? (
+              <button
+                onClick={onCreate}
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors duration-200 hover:bg-surface"
+              >
+                <Plus className="h-4 w-4" /> Create agent
+              </button>
+            ) : (
+              <span className="px-1 text-sm text-muted-foreground">
+                Ask an admin or a member to create one.
+              </span>
+            )
           ) : (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>


### PR DESCRIPTION
The composer owns the fold on `/app`. With no agents in the workspace, every control in it was off:

- the textarea `disabled`, reading "Create an agent to get started…"
- the send button `disabled`
- and in the slot where the agent picker goes, the words **No agents yet** — a `<span>`, not a control

The only working **Create agent** button was in the gallery, several hundred pixels down. So the first screen a new workspace sees stated the problem and gave you nothing to press. This matters most in a fresh `docker compose up`, which is exactly where it lands.

That slot now holds a real **Create agent** button, opening the same dialog the gallery button and `⌘K → New agent` already open. It is a plain `<button>` in the agent picker's own shape rather than a `Button`, on purpose: a default-size `Button` renders the roller with the amber chip, and the comment two lines below says send is the one amber fill on this screen.

A viewer — `canWrite: false` — gets a sentence rather than a button the policies would refuse anyway, matching what the gallery's empty state already tells them. Their placeholder changes too, since "Create an agent to get started…" is an instruction they cannot follow.

`launch()` already handled the no-agent case by navigating to `?new=true` and letting the effect in `Home` open the dialog. With the handler now passed in as a prop it calls it directly, and the round trip through the URL goes away.

New `src/routes/_authed.app.test.tsx` covers both roles. Both cases were checked against the pre-fix file and both fail there. The queries are scoped to the composer's own footer, anchored on `aria-label="Send"` — a page-wide query for a "Create agent" button **passes with the bug still present**, because the empty gallery renders two of its own.

`bun run test` — 263 passed. `lint` and `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)