### PR TITLE
Give the inviter something to send

### DIFF
--- a/docs/team.md
+++ b/docs/team.md
@@ -41,6 +41,29 @@ this page learned to read `emailed`; the three rows in the first run did not,
 and went on reporting "3 invitations sent" to people running an install with no
 mail at all. The sentence is now decided in one place for both of them.
 
+**"Tell them" comes with the words.** When nothing was emailed, the notice
+carries a *Copy invite text* action, and every waiting invitation on this page
+has a *Copy invite* button of its own — the durable version, for whenever the
+notice is long gone. What you get is a short message naming your Covan's address
+and the one address that will work:
+
+> You've been invited to Covan — a shared AI agent our team trains together.
+> Sign up at `https://covan.app/sign-up` with `ali@example.com` and the
+> invitation will be waiting.
+
+The URL is the front door, not a key. It carries no token and does not pre-fill
+the address, for the reason above and one more: a link that fills the field in
+gets forwarded in place of the address, and then somebody signs up as themselves
+and cannot see why nothing is waiting. Naming the address in prose keeps it
+visibly the thing that matters. Self-hosted installs get their own origin in
+that sentence, so it reads `http://localhost:3000/sign-up` where that is true.
+
+The button is offered whether or not the email went out, because this list
+cannot tell: `emailed` is only ever known about the invitation you have just
+created, nothing stores it, and a second nudge is a normal thing to send anyway.
+For the same reason a waiting invitation says when it was sent rather than
+claiming an email reached anyone.
+
 ### What the invitee sees
 
 When that person signs in with the address the invitation names, two places offer

--- a/src/components/invite-member-dialog.tsx
+++ b/src/components/invite-member-dialog.tsx
@@ -14,6 +14,7 @@ import {
 import { api, ApiError } from "@/lib/api-client";
 import { ROLE_SUMMARY, WORKSPACE_ROLES, type WorkspaceRole } from "@/lib/roles";
 import { invitationNotice } from "@/lib/invitation-notice";
+import { copyInviteText } from "@/lib/invite-text";
 import { toast } from "sonner";
 
 export function InviteMemberDialog({
@@ -49,7 +50,22 @@ export function InviteMemberDialog({
         emailed: invite.emailed ? 1 : 0,
         failed: [],
       });
-      toast[notice.tone](notice.message);
+      // Nothing went out, so "let them know" is now a job with a tool attached.
+      // Twelve seconds rather than the default four: an action nobody has time
+      // to read is the same as no action. The durable copy is on the Team page,
+      // one button per waiting invitation, for whenever this toast is gone.
+      toast[notice.tone](
+        notice.message,
+        invite.emailed
+          ? undefined
+          : {
+              duration: 12000,
+              action: {
+                label: "Copy invite text",
+                onClick: () => copyInviteText([invite.email]),
+              },
+            },
+      );
       reset();
       onOpenChange(false);
     } catch (e) {

--- a/src/components/welcome/invite-step.test.tsx
+++ b/src/components/welcome/invite-step.test.tsx
@@ -3,10 +3,11 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { InviteStep } from "./invite-step";
 
-const { create, invalidateQueries, toast } = vi.hoisted(() => ({
+const { create, invalidateQueries, toast, copyInviteText } = vi.hoisted(() => ({
   create: vi.fn(),
   invalidateQueries: vi.fn(),
   toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+  copyInviteText: vi.fn(),
 }));
 
 vi.mock("@/lib/api-client", () => ({
@@ -16,6 +17,7 @@ vi.mock("@/lib/api-client", () => ({
 
 vi.mock("@tanstack/react-query", () => ({ useQueryClient: () => ({ invalidateQueries }) }));
 vi.mock("sonner", () => ({ toast }));
+vi.mock("@/lib/invite-text", () => ({ copyInviteText }));
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -40,17 +42,38 @@ describe("InviteStep", () => {
 
     await invite(["a@x.com", "b@x.com"]);
 
-    expect(toast.success).toHaveBeenCalledWith(expect.stringContaining("no email went out"));
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.stringContaining("no email went out"),
+      expect.anything(),
+    );
     expect(onDone).toHaveBeenCalled();
   });
 
-  it("says plainly that they were emailed when they were", async () => {
+  // Telling someone to "let them know" and then moving to the next step forever
+  // is a job with no tool. This is the surface where that hurts most: the first
+  // run, on an install with no mail, where the Team page has not been seen yet.
+  it("hands over the text for exactly the people no email reached", async () => {
+    create.mockImplementation(async ({ email }: { email: string }) => ({
+      email,
+      emailed: email === "a@x.com",
+    }));
+    render(<InviteStep onDone={vi.fn()} />);
+
+    await invite(["a@x.com", "b@x.com"]);
+
+    const [, options] = toast.warning.mock.calls[0] ?? toast.success.mock.calls[0];
+    expect(options.action.label).toBe("Copy invite text");
+    options.action.onClick();
+    expect(copyInviteText).toHaveBeenCalledWith(["b@x.com"]);
+  });
+
+  it("says plainly that they were emailed when they were, and offers nothing to copy", async () => {
     create.mockImplementation(async ({ email }: { email: string }) => ({ email, emailed: true }));
     render(<InviteStep onDone={vi.fn()} />);
 
     await invite(["a@x.com", "b@x.com"]);
 
-    expect(toast.success).toHaveBeenCalledWith("2 invitations emailed.");
+    expect(toast.success).toHaveBeenCalledWith("2 invitations emailed.", undefined);
   });
 
   it("stays put when every address was refused", async () => {

--- a/src/components/welcome/invite-step.tsx
+++ b/src/components/welcome/invite-step.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "@/lib/api-client";
 import { invitationNotice } from "@/lib/invitation-notice";
+import { copyInviteText } from "@/lib/invite-text";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -31,7 +32,9 @@ export function InviteStep({ onDone }: { onDone: () => void }) {
     // One at a time, and a failure on one address does not discard the others.
     const invited: string[] = [];
     const failed: string[] = [];
-    let emailed = 0;
+    // Which ones, not just how many: these are the addresses the copy action
+    // below has to name, and each person needs their own.
+    const unmailed: string[] = [];
     for (const email of wanted) {
       try {
         const invite = await api.invitations.create({ email, role: "member" });
@@ -39,7 +42,7 @@ export function InviteStep({ onDone }: { onDone: () => void }) {
         // Undefined means "this response does not know", which is not the same
         // as false — but no create response omits it, and counting an unknown
         // as unsent is the error that costs nothing.
-        if (invite.emailed) emailed += 1;
+        if (!invite.emailed) unmailed.push(invite.email);
       } catch (err) {
         failed.push(err instanceof ApiError ? `${email} (${err.message})` : email);
       }
@@ -49,8 +52,23 @@ export function InviteStep({ onDone }: { onDone: () => void }) {
     // This step used to report "N invitations sent" whichever way it went. On
     // an install with no mail configured — a supported one — that was three
     // people invited, nobody told, and the inviter assured otherwise.
-    const notice = invitationNotice({ invited, emailed, failed });
-    toast[notice.tone](notice.message);
+    const notice = invitationNotice({ invited, emailed: invited.length - unmailed.length, failed });
+    // This is the surface where the gap hurts most: the first run, on an
+    // install with no mail configured, invites three people and then moves on
+    // to the next step forever. The Team page keeps a copy button per waiting
+    // invitation, but nobody has seen the Team page yet.
+    toast[notice.tone](
+      notice.message,
+      unmailed.length === 0
+        ? undefined
+        : {
+            duration: 12000,
+            action: {
+              label: unmailed.length === 1 ? "Copy invite text" : "Copy invite texts",
+              onClick: () => copyInviteText(unmailed),
+            },
+          },
+    );
 
     if (invited.length === 0) {
       // Nothing landed. Stay put so the addresses can be corrected rather than

--- a/src/lib/invite-text.test.ts
+++ b/src/lib/invite-text.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { inviteText } from "./invite-text";
+
+describe("inviteText", () => {
+  it("names the address the invitation is actually keyed to", () => {
+    const text = inviteText(["ali@example.com"], "https://covan.app");
+
+    // `accept_invitation` matches this against the caller's verified JWT email.
+    // If the message does not say which address to use, the recipient signs up
+    // with whichever one they prefer and the invitation stays invisible.
+    expect(text).toContain("ali@example.com");
+    expect(text).toContain("https://covan.app/sign-up");
+  });
+
+  it("carries no link a recipient could mistake for the credential", () => {
+    const text = inviteText(["ali@example.com"], "https://covan.app");
+
+    // The URL is the front door, not a key: it must be the bare sign-up page,
+    // with no token and no pre-filled address. `docs/team.md` argues a token in
+    // a URL would be "a second and weaker key to the same door", and a URL that
+    // carries the address invites people to forward it in place of the address.
+    expect(text).not.toMatch(/sign-up\?/);
+    expect(text).not.toMatch(/token|invite=|[?&]email=/i);
+  });
+
+  it("takes the origin it is given, so a self-hosted install says its own", () => {
+    expect(inviteText(["ali@example.com"], "http://localhost:3000")).toContain(
+      "http://localhost:3000/sign-up",
+    );
+  });
+
+  it("gives each person their own block rather than one message listing everybody", () => {
+    const text = inviteText(["ali@example.com", "veli@example.com"], "https://covan.app");
+    const blocks = text.split("\n\n");
+
+    expect(blocks).toHaveLength(2);
+    // The first-run step invites up to three at once, and the address is
+    // per-person: a block naming two addresses is a block you cannot send to
+    // either of them.
+    expect(blocks[0]).toContain("ali@example.com");
+    expect(blocks[0]).not.toContain("veli@example.com");
+    expect(blocks[1]).toContain("veli@example.com");
+  });
+
+  it("is empty when there is nobody to write to", () => {
+    expect(inviteText([], "https://covan.app")).toBe("");
+  });
+});

--- a/src/lib/invite-text.ts
+++ b/src/lib/invite-text.ts
@@ -1,0 +1,48 @@
+import { toast } from "sonner";
+
+/**
+ * The message you send somebody after inviting them.
+ *
+ * `invitation-notice.ts` next door made both invite surfaces stop claiming an
+ * email had gone out when none had. It left the user holding a job with no
+ * tool: "let them know" is a real instruction, but the address they need and
+ * the URL they need are things you then have to work out yourself. On an
+ * install with no `RESEND_API_KEY` — the default after `docker compose up` —
+ * that is every invitation ever sent.
+ *
+ * It is a sentence, not a link, and that is the whole design. `accept_invitation`
+ * matches the invitation's email against the caller's verified JWT email, and
+ * `docs/team.md` says why: a token in a URL "would be a second and weaker key to
+ * the same door". A pre-filled link would add no credential either, but it would
+ * *read* like one — someone forwards it, the recipient signs up with a different
+ * address, and a wrong-address problem arrives looking like a broken link. Naming
+ * the address in prose keeps the address visibly load-bearing.
+ *
+ * The origin is passed in rather than read here, so the text is testable and so
+ * self-hosted installs say `http://localhost:3000` without being told to.
+ */
+export function inviteText(emails: string[], origin: string): string {
+  // One block per person, because the address is per-person: a single message
+  // listing everybody's address is not a message you can send to any of them.
+  return emails.map((email) => oneInvitation(email, origin)).join("\n\n");
+}
+
+function oneInvitation(email: string, origin: string): string {
+  return [
+    `You've been invited to Covan — a shared AI agent our team trains together.`,
+    `Sign up at ${origin}/sign-up with ${email} and the invitation will be waiting.`,
+  ].join(" ");
+}
+
+/**
+ * Copy it, and say so. Both invite surfaces call this rather than each wiring
+ * up a clipboard, for the same reason they share `invitationNotice`: two copies
+ * of a sentence are two sentences waiting to disagree.
+ */
+export function copyInviteText(emails: string[]): void {
+  const text = inviteText(emails, window.location.origin);
+  navigator.clipboard?.writeText(text).then(
+    () => toast.success("Invite text copied"),
+    () => toast.error("Couldn't copy — your browser blocked it."),
+  );
+}

--- a/src/routes/_authed.team.tsx
+++ b/src/routes/_authed.team.tsx
@@ -29,6 +29,8 @@ import { LogOut, MailPlus, Trash2, UserPlus } from "lucide-react";
 import { api, ApiError } from "@/lib/api-client";
 import { invalidateWorkspaceScoped } from "@/lib/workspace-queries";
 import { canWriteAsRole, WORKSPACE_ROLES, type WorkspaceRole } from "@/lib/roles";
+import { copyInviteText } from "@/lib/invite-text";
+import { formatRelative } from "@/lib/relative-time";
 import { InviteMemberDialog } from "@/components/invite-member-dialog";
 import { toast } from "sonner";
 
@@ -342,10 +344,26 @@ function TeamPage() {
                         </span>
                       }
                       title={inv.email}
-                      meta="Invitation sent"
+                      // Not "Invitation sent". `PendingInvitation.emailed` is
+                      // only on the invitation you just created — nothing
+                      // stores it, so this list cannot answer whether mail
+                      // went anywhere, and with no RESEND_API_KEY the answer
+                      // is no. What the row does know is that it is waiting.
+                      meta={`Invited ${formatRelative(inv.createdAt)}`}
                       trailing={
                         <span className="flex shrink-0 items-center gap-2">
                           <RoleChip role={inv.role} />
+                          {/* The durable half of "let them know" — unconditional,
+                              because a nudge is a normal thing to send even when
+                              the email did go out, and this list could not tell
+                              the difference anyway. */}
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => copyInviteText([inv.email])}
+                          >
+                            Copy invite
+                          </Button>
                           <Button variant="ghost" size="sm" onClick={() => revokeInvite(inv.id)}>
                             Revoke
                           </Button>


### PR DESCRIPTION
Both invite surfaces stopped claiming an email was sent when none was. That was honest, and it left the user holding a job with no tool: "let them know" is a real instruction, but the URL and the exact address the invitation is keyed to were things you then had to work out yourself.

With no `RESEND_API_KEY` — a supported configuration, and the default after `docker compose up` — that is **every invitation a self-hosted Covan ever sends**. The invitation is a row that exists and nobody is told about.

## The sentence, not a link

> You've been invited to Covan — a shared AI agent our team trains together. Sign up at `http://localhost:3000/sign-up` with `ali@example.com` and the invitation will be waiting.

`accept_invitation` matches the invitation's email against the caller's verified JWT email, and `docs/team.md` argues that a token in a URL "would be a second and weaker key to the same door". A link that merely pre-fills the sign-up address adds no credential either — but it *reads* like one. It gets forwarded in place of the address, the recipient signs up as themselves, and a wrong-address problem arrives looking like a broken link. Naming the address in prose keeps the address visibly the thing that matters.

The origin is passed in rather than read inside the builder, so the text is testable without jsdom globals and a self-hosted install says its own address without being configured to.

## Where it appears

**New `src/lib/invite-text.ts`** — the sentence and the clipboard call. Both surfaces import it for the same reason they already share `invitationNotice`: two copies of a sentence are two sentences waiting to disagree.

**The dialog and the first-run step** — when nothing was emailed, the notice carries a **Copy invite text** action at `duration: 12000`. An action nobody has time to read is the same as no action. The first-run step now tracks *which* addresses went unmailed rather than just how many, because each person needs their own block — a single message listing everybody's address is not a message you can send to any of them.

**The Team page** — every waiting invitation gets a **Copy invite** button. This is the durable half: the first-run step moves on to the next screen forever, and a toast is gone in seconds.

## The pending rows also stop saying "Invitation sent"

`PendingInvitation.emailed` is only ever populated on the invitation you have just created — nothing stores it, and the type says so — so that list was making a claim it had no way to check, and on an install with no mail the claim was false. It now says when the invitation went out.

The copy button is unconditional for the same reason: this list cannot tell whether mail was sent, and a second nudge is a normal thing to send regardless.

## Tests

- New `src/lib/invite-text.test.ts` — five cases. Two are about what the text must **not** contain: no `?` on the sign-up URL, no `token`/`email=` parameter. Those are the ones that catch somebody later turning this into a pre-filled link without reopening the argument.
- `invite-step.test.tsx` gains a case asserting the action names exactly the addresses no email reached, and that a fully-emailed batch offers nothing to copy.

`bun run test` — 267 passed. `lint` and `typecheck` clean.

`docs/team.md` documents the sentence and why it is not a link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)