### PR TITLE
Say what the first week still needs

### DIFF
--- a/src/components/first-week-checklist.tsx
+++ b/src/components/first-week-checklist.tsx
@@ -1,0 +1,112 @@
+import { Link } from "@tanstack/react-router";
+import { Check, X } from "lucide-react";
+import { SectionCard } from "@/components/section-card";
+import { firstWeekRemaining, type FirstWeekStep } from "@/lib/first-week";
+
+/**
+ * The first-week checklist: quiet, finite, and gone when it is finished.
+ *
+ * It sits under the composer rather than over it, because the composer is the
+ * product and this is scaffolding. It is not shown at all to a viewer (three of
+ * the four steps are things the policies refuse them), to a workspace with no
+ * agents (that screen has one job, and the composer above already says it), or
+ * once every step is done.
+ */
+export function FirstWeekChecklist({
+  steps,
+  agentId,
+  onDismiss,
+}: {
+  steps: FirstWeekStep[];
+  /** Whichever agent the two agent-scoped links should point at. */
+  agentId: string;
+  onDismiss: () => void;
+}) {
+  const remaining = firstWeekRemaining(steps);
+  const done = steps.length - remaining;
+
+  return (
+    <SectionCard className="mt-8">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="font-dm text-[17px] font-medium leading-tight">Getting set up</h2>
+          <p className="mt-1 text-sm leading-[1.45] text-muted-foreground">
+            {done} of {steps.length} done. This disappears when it is finished.
+          </p>
+        </div>
+        {/* A checklist you cannot put down is a nag. Somebody who is never
+            going to schedule a routine should be able to say so once. */}
+        <button
+          onClick={onDismiss}
+          aria-label="Hide the setup checklist"
+          className="-mr-1 -mt-1 grid h-8 w-8 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors duration-200 hover:bg-surface hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <ul className="mt-5 flex flex-col gap-3.5">
+        {steps.map((step) => (
+          <li key={step.key} className="flex items-start gap-3">
+            {/* No circles — §3.5 allows exactly two, and neither is this. A
+                done step gets the amber tick; an open one gets the dashed
+                tile the Team page already uses for something still waiting. */}
+            {step.done ? (
+              <span className="mt-px grid h-5 w-5 shrink-0 place-items-center rounded-sm bg-accent-orange text-[#251f19]">
+                <Check className="h-3.5 w-3.5" />
+              </span>
+            ) : (
+              <span className="mt-px h-5 w-5 shrink-0 rounded-sm border border-dashed border-border" />
+            )}
+            <div className="min-w-0">
+              <div
+                className={
+                  step.done ? "text-sm text-muted-foreground line-through" : "text-sm font-medium"
+                }
+              >
+                {step.label}
+              </div>
+              {!step.done && (
+                <p className="mt-0.5 text-[13px] leading-[1.45] text-muted-foreground">
+                  {step.hint} <StepLink step={step} agentId={agentId} />
+                </p>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </SectionCard>
+  );
+}
+
+/**
+ * Where to go to do it. "Ask it something" has no link on purpose: the place
+ * to do that is the composer directly above, and a link that scrolls you three
+ * inches up is worse than no link.
+ */
+function StepLink({ step, agentId }: { step: FirstWeekStep; agentId: string }) {
+  const className = "text-foreground underline underline-offset-4";
+
+  switch (step.key) {
+    case "knowledge":
+      return (
+        <Link to="/agents/$agentId/knowledge" params={{ agentId }} className={className}>
+          Upload one
+        </Link>
+      );
+    case "team":
+      return (
+        <Link to="/team" className={className}>
+          Invite someone
+        </Link>
+      );
+    case "routine":
+      return (
+        <Link to="/agents/$agentId/routines" params={{ agentId }} className={className}>
+          Set one up
+        </Link>
+      );
+    case "ask":
+      return null;
+  }
+}

--- a/src/lib/first-week.test.ts
+++ b/src/lib/first-week.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { firstWeekSteps, firstWeekRemaining, type FirstWeekInput } from "./first-week";
+import type { Agent, ChatSession } from "./agents-store";
+
+const agent = (documents: number): Agent =>
+  ({
+    id: "agent-1",
+    documents: Array.from({ length: documents }, (_, i) => ({ id: `doc-${i}` })),
+  }) as unknown as Agent;
+
+const session = (messageCount: number): ChatSession =>
+  ({ id: "session-1", messageCount }) as unknown as ChatSession;
+
+const input = (patch: Partial<FirstWeekInput> = {}): FirstWeekInput => ({
+  agents: [agent(0)],
+  sessions: [],
+  memberCount: 1,
+  routineCount: 0,
+  ...patch,
+});
+
+const step = (i: FirstWeekInput, key: string) => firstWeekSteps(i).find((s) => s.key === key)!;
+
+describe("firstWeekSteps", () => {
+  it("has nothing ticked for a workspace that has only made an agent", () => {
+    expect(firstWeekRemaining(firstWeekSteps(input()))).toBe(4);
+  });
+
+  it("counts a document on any agent, not only the first", () => {
+    expect(step(input({ agents: [agent(0), agent(3)] }), "knowledge").done).toBe(true);
+  });
+
+  // Opening the composer starts a session before anybody has said anything, so
+  // counting sessions would tick this for a workspace that has never asked a
+  // question — which is the one thing the step is asking about.
+  it("does not count an empty session as having asked something", () => {
+    expect(step(input({ sessions: [session(0)] }), "ask").done).toBe(false);
+    expect(step(input({ sessions: [session(0), session(2)] }), "ask").done).toBe(true);
+  });
+
+  // A pending invitation is not a teammate. With no RESEND_API_KEY it is a row
+  // nobody has been told about, and this step's whole question is whether
+  // anyone actually arrived.
+  it("ticks the team step on membership, and the workspace's founder is not company", () => {
+    expect(step(input({ memberCount: 1 }), "team").done).toBe(false);
+    expect(step(input({ memberCount: 2 }), "team").done).toBe(true);
+  });
+
+  it("ticks the routine step as soon as one exists", () => {
+    expect(step(input({ routineCount: 1 }), "routine").done).toBe(true);
+  });
+
+  it("has nothing left once all four are true", () => {
+    const steps = firstWeekSteps(
+      input({ agents: [agent(1)], sessions: [session(4)], memberCount: 3, routineCount: 1 }),
+    );
+    expect(firstWeekRemaining(steps)).toBe(0);
+  });
+});

--- a/src/lib/first-week.ts
+++ b/src/lib/first-week.ts
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import type { Agent, ChatSession } from "./agents-store";
+
+/**
+ * What a new workspace still has left to do.
+ *
+ * The first run ends with an agent that has read something, and then nothing
+ * says what this becomes once it is set up. The four steps below are the ones
+ * that decide whether a workspace stays: knowledge in it, an answer out of it,
+ * somebody else in the room, and something that runs while nobody is watching.
+ *
+ * Every fact is read off state the home screen already holds. That is a
+ * constraint, not a coincidence — a checklist worth one round trip is worth
+ * none, and the alternative is a counters table that has to be kept true.
+ */
+export type FirstWeekStep = {
+  key: "knowledge" | "ask" | "team" | "routine";
+  label: string;
+  hint: string;
+  done: boolean;
+};
+
+export type FirstWeekInput = {
+  agents: Agent[];
+  sessions: ChatSession[];
+  /** Everyone in the workspace, including the person reading this. */
+  memberCount: number;
+  routineCount: number;
+};
+
+export function firstWeekSteps({
+  agents,
+  sessions,
+  memberCount,
+  routineCount,
+}: FirstWeekInput): FirstWeekStep[] {
+  return [
+    {
+      key: "knowledge",
+      label: "Upload what the team knows",
+      hint: "A process doc, a contract, a research note. This is what the agent answers from.",
+      done: agents.some((a) => a.documents.length > 0),
+    },
+    {
+      key: "ask",
+      label: "Ask it something the document answers",
+      hint: "The reply names the file it came from — that is the difference between this and a chat window.",
+      // `messageCount`, not `sessions.length`: opening the composer starts a
+      // session before anybody has said anything, so counting sessions would
+      // tick this box for a workspace that has never asked a question.
+      done: sessions.some((s) => s.messageCount > 0),
+    },
+    {
+      key: "team",
+      label: "Bring in a teammate",
+      hint: "They get the same agent, and their own conversations with it stay private.",
+      // Membership, not a pending invitation. "Invited somebody" is a fact the
+      // Team page already reports; this asks whether anyone actually arrived,
+      // which is the thing an invitation that never reached anybody looks
+      // exactly like.
+      done: memberCount > 1,
+    },
+    {
+      key: "routine",
+      label: "Schedule something that runs without you",
+      hint: "Point one at a feed or a page, say what to do with it, and the result arrives by email or Slack.",
+      done: routineCount > 0,
+    },
+  ];
+}
+
+/** Nothing to nag about once they are all done. */
+export function firstWeekRemaining(steps: FirstWeekStep[]): number {
+  return steps.filter((s) => !s.done).length;
+}
+
+/**
+ * Dismissal, remembered per workspace — a second workspace is a second setup,
+ * and being told once about this one should not silence the next.
+ *
+ * The read is in an effect rather than a lazy initialiser because the workspace
+ * id arrives from `api.me()` a beat after the first render: an initialiser
+ * would run against `undefined` and never look again, so a dismissed checklist
+ * would come back on every load. It also keeps the server render out of
+ * `localStorage`, which does not exist there.
+ *
+ * Storage can throw — private mode, quota — and the answer is a checklist that
+ * shows up again, which is the harmless direction.
+ */
+export function useChecklistDismissed(workspaceId: string | undefined) {
+  const key = workspaceId ? `covan:first-week-dismissed:${workspaceId}` : null;
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (!key) return;
+    try {
+      setDismissed(window.localStorage.getItem(key) === "1");
+    } catch {
+      setDismissed(false);
+    }
+  }, [key]);
+
+  const dismiss = () => {
+    setDismissed(true);
+    if (!key) return;
+    try {
+      window.localStorage.setItem(key, "1");
+    } catch {
+      /* back next reload; see above */
+    }
+  };
+
+  return { dismissed, dismiss };
+}

--- a/src/routes/_authed.app.test.tsx
+++ b/src/routes/_authed.app.test.tsx
@@ -11,10 +11,22 @@ vi.mock("@tanstack/react-router", () => ({
     useSearch: () => ({}),
   }),
   useNavigate: () => navigate,
+  Link: ({ children, ...props }: { children: React.ReactNode; to: string }) => (
+    <a href={props.to}>{children}</a>
+  ),
 }));
 
-vi.mock("@tanstack/react-query", () => ({ useQuery: () => ({ data: undefined }) }));
-vi.mock("@/lib/api-client", () => ({ api: { me: vi.fn() } }));
+// Keyed rather than blanket-undefined, because the checklist's visibility is
+// decided by three separate queries and a test that cannot tell them apart
+// cannot test it. `enabled: false` returns nothing, the same as the real thing.
+const queries: Record<string, unknown> = {};
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryKey, enabled }: { queryKey: string[]; enabled?: boolean }) => ({
+    data: enabled === false ? undefined : queries[queryKey[0]],
+  }),
+}));
+vi.mock("@/lib/api-client", () => ({ api: { me: vi.fn(), routines: { list: vi.fn() } } }));
 vi.mock("@/lib/quota", () => ({ useQuota: () => null, quotaSentence: () => "" }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock("@/components/app-shell", () => ({
@@ -47,6 +59,15 @@ async function renderHome(canWrite: boolean) {
 
 beforeEach(() => {
   navigate.mockClear();
+  localStorage.clear();
+  store.agents = [];
+  store.sessions = [];
+  queries.me = {
+    user: { id: "u1", name: "Ada" },
+    workspace: { id: "w1", name: "Acme" },
+    members: [{ id: "u1" }],
+  };
+  queries.routines = [];
 });
 
 // The composer owns the fold. With no agents in the workspace it was a closed
@@ -78,5 +99,66 @@ describe("the home composer, with no agents in the workspace", () => {
     const row = composerRow();
     expect(row.queryByRole("button", { name: /create agent/i })).not.toBeInTheDocument();
     expect(row.getByText(/ask an admin or a member to create one/i)).toBeInTheDocument();
+  });
+});
+
+// The other half of the same complaint: the first run ends and nothing says
+// what this becomes once it is set up. Four steps, and it is gone when they
+// are done.
+describe("the first-week checklist", () => {
+  const withAgent = (documents = 0) => {
+    store.agents = [
+      { id: "agent-1", name: "GTM", documents: Array.from({ length: documents }, () => ({})) },
+    ];
+  };
+
+  it("appears once there is an agent, and counts what is left", async () => {
+    withAgent(1);
+    await renderHome(true);
+
+    expect(screen.getByText("Getting set up")).toBeInTheDocument();
+    expect(screen.getByText(/1 of 4 done/)).toBeInTheDocument();
+  });
+
+  it("stays away while the workspace has no agents at all", async () => {
+    await renderHome(true);
+
+    // That screen has one job, and the composer above is already saying it.
+    expect(screen.queryByText("Getting set up")).not.toBeInTheDocument();
+  });
+
+  it("is not shown to a viewer, who is refused three of the four steps", async () => {
+    withAgent(1);
+    await renderHome(false);
+
+    expect(screen.queryByText("Getting set up")).not.toBeInTheDocument();
+  });
+
+  it("disappears when all four are done rather than sitting there congratulating anybody", async () => {
+    withAgent(2);
+    store.sessions = [{ id: "s1", messageCount: 6 }];
+    queries.me = {
+      user: { id: "u1", name: "Ada" },
+      workspace: { id: "w1", name: "Acme" },
+      members: [{ id: "u1" }, { id: "u2" }],
+    };
+    queries.routines = [{ id: "r1" }];
+
+    await renderHome(true);
+
+    expect(screen.queryByText("Getting set up")).not.toBeInTheDocument();
+  });
+
+  it("can be put down, and stays down for that workspace", async () => {
+    withAgent(1);
+    await renderHome(true);
+
+    await userEvent.click(screen.getByLabelText(/hide the setup checklist/i));
+    expect(screen.queryByText("Getting set up")).not.toBeInTheDocument();
+
+    // A second workspace is a second setup: silencing this one must not
+    // silence the next.
+    expect(localStorage.getItem("covan:first-week-dismissed:w1")).toBe("1");
+    expect(localStorage.getItem("covan:first-week-dismissed:w2")).toBeNull();
   });
 });

--- a/src/routes/_authed.app.test.tsx
+++ b/src/routes/_authed.app.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+
+const navigate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (options: { component: () => React.ReactElement }) => ({
+    ...options,
+    useSearch: () => ({}),
+  }),
+  useNavigate: () => navigate,
+}));
+
+vi.mock("@tanstack/react-query", () => ({ useQuery: () => ({ data: undefined }) }));
+vi.mock("@/lib/api-client", () => ({ api: { me: vi.fn() } }));
+vi.mock("@/lib/quota", () => ({ useQuota: () => null, quotaSentence: () => "" }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/components/app-shell", () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Stands in for the real dialog so the test can tell "it opened" from "it
+// didn't" without rendering a form the assertion isn't about.
+vi.mock("@/components/create-agent-dialog", () => ({
+  CreateAgentDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="create-dialog" /> : null,
+}));
+
+const store = {
+  agents: [] as unknown[],
+  favorites: [] as string[],
+  sessions: [] as unknown[],
+  canWrite: true,
+  startSession: vi.fn(),
+};
+
+vi.mock("@/lib/agents-store", () => ({ useAgentsStore: () => store }));
+
+async function renderHome(canWrite: boolean) {
+  store.canWrite = canWrite;
+  const { Route } = await import("./_authed.app");
+  const Component = (Route as unknown as { component: () => React.ReactElement }).component;
+  render(<Component />);
+}
+
+beforeEach(() => {
+  navigate.mockClear();
+});
+
+// The composer owns the fold. With no agents in the workspace it was a closed
+// door: a disabled textarea, a disabled send button, and the inert words "No
+// agents yet" where the agent picker goes. The only real Create agent button
+// was in the gallery, far below. So the first screen a new workspace sees
+// described the problem and offered nothing to do about it.
+describe("the home composer, with no agents in the workspace", () => {
+  // Scoped to the composer's own footer rather than the page, because the
+  // gallery below renders two Create agent buttons of its own when the
+  // workspace is empty — a page-wide query passes with the bug still in place.
+  // Send is the anchor: the assertion is that the row holding it also holds a
+  // way out.
+  const composerRow = () => within(screen.getByLabelText("Send").closest("div")!);
+
+  it("gives a member a way to create one without scrolling", async () => {
+    await renderHome(true);
+
+    const create = composerRow().getByRole("button", { name: /create agent/i });
+
+    expect(screen.queryByTestId("create-dialog")).not.toBeInTheDocument();
+    await userEvent.click(create);
+    expect(screen.getByTestId("create-dialog")).toBeInTheDocument();
+  });
+
+  it("tells a viewer who to ask instead of offering a button the policies would refuse", async () => {
+    await renderHome(false);
+
+    const row = composerRow();
+    expect(row.queryByRole("button", { name: /create agent/i })).not.toBeInTheDocument();
+    expect(row.getByText(/ask an admin or a member to create one/i)).toBeInTheDocument();
+  });
+});

--- a/src/routes/_authed.app.tsx
+++ b/src/routes/_authed.app.tsx
@@ -12,6 +12,8 @@ import { Badge, Headline, SectionHeading } from "@/components/page-container";
 import { Chip, DataRow, EmptyState } from "@/components/section-card";
 import { AgentAvatar, UserAvatar } from "@/components/avatars";
 import { useQuota, quotaSentence } from "@/lib/quota";
+import { FirstWeekChecklist } from "@/components/first-week-checklist";
+import { firstWeekSteps, firstWeekRemaining, useChecklistDismissed } from "@/lib/first-week";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -56,6 +58,24 @@ function Home() {
   const members = me?.members ?? [];
   const quota = useQuota();
 
+  // The one fact the checklist needs that the home screen does not already
+  // hold. Asked for only while it could still change the answer, so a
+  // settled workspace stops paying for it on every visit.
+  const { dismissed, dismiss } = useChecklistDismissed(me?.workspace.id);
+  const showChecklist = canWrite && !dismissed && agents.length > 0;
+  const { data: routines = [] } = useQuery({
+    queryKey: ["routines"],
+    queryFn: () => api.routines.list(),
+    enabled: showChecklist,
+  });
+
+  const steps = firstWeekSteps({
+    agents,
+    sessions,
+    memberCount: members.length,
+    routineCount: routines.length,
+  });
+
   // The ⌘K "New agent" action deep-links here with ?new=true.
   useEffect(() => {
     if (openNew) {
@@ -99,6 +119,14 @@ function Home() {
             {quota.level !== "fine" && <span className="h-2 w-2 shrink-0 bg-accent-orange" />}
             {quotaSentence(quota)}
           </p>
+        )}
+        {/* Under the composer, never over it: the composer is the product and
+            this is scaffolding. Hidden from a viewer, since the policies refuse
+            them three of the four steps, and hidden while the workspace has no
+            agents at all — that screen has one job and the composer above is
+            already saying it. */}
+        {showChecklist && firstWeekRemaining(steps) > 0 && (
+          <FirstWeekChecklist steps={steps} agentId={agents[0].id} onDismiss={dismiss} />
         )}
       </div>
 

--- a/src/routes/_authed.app.tsx
+++ b/src/routes/_authed.app.tsx
@@ -84,7 +84,13 @@ function Home() {
             </p>
           ) : null}
         </div>
-        <HomeComposer agents={agents} favorites={favorites} className="mt-10" />
+        <HomeComposer
+          agents={agents}
+          favorites={favorites}
+          canCreate={canWrite}
+          onCreate={() => setCreateOpen(true)}
+          className="mt-10"
+        />
         {/* Directly under the composer, because this is the moment before
             spending — not buried in settings, where nobody looks until the
             replies have already stopped. Renders nothing when self-hosted. */}
@@ -119,10 +125,16 @@ function Home() {
 function HomeComposer({
   agents,
   favorites,
+  canCreate,
+  onCreate,
   className,
 }: {
   agents: Agent[];
   favorites: string[];
+  /** False for a viewer — same meaning as in the gallery below: the policies
+      refuse them either way, this is so the button is not there to press. */
+  canCreate: boolean;
+  onCreate: () => void;
   className?: string;
 }) {
   const { startSession } = useAgentsStore();
@@ -146,7 +158,11 @@ function HomeComposer({
     const body = text.trim();
     if (sending) return;
     if (!selected) {
-      navigate({ to: "/app", search: { new: true } });
+      // Reachable only if the disabled states below ever come off — the button
+      // in the empty row is the real path now. Straight to the dialog rather
+      // than a ?new=true round trip through the URL, since the handler that
+      // opens it is in scope here.
+      if (canCreate) onCreate();
       return;
     }
     setSending(true);
@@ -187,7 +203,11 @@ function HomeComposer({
             }
           }}
           placeholder={
-            empty ? "Create an agent to get started…" : `Message ${selected?.name ?? "your agent"}…`
+            empty
+              ? canCreate
+                ? "Create an agent to get started…"
+                : "No agents yet — a member has to make the first one…"
+              : `Message ${selected?.name ?? "your agent"}…`
           }
           disabled={empty}
           rows={3}
@@ -195,7 +215,25 @@ function HomeComposer({
         />
         <div className="flex items-center justify-between gap-2 px-4 pb-4">
           {empty ? (
-            <span className="px-1 text-sm text-muted-foreground">No agents yet</span>
+            // This slot used to hold the words "No agents yet" and nothing to
+            // press, on the one card that owns the fold — so the first screen
+            // of an empty workspace told you what was wrong and left the only
+            // way to fix it below the fold, in the gallery. Same control as the
+            // agent picker it replaces, deliberately: the row is the row, only
+            // its contents change. Not a `Button`, because a default-size one
+            // carries the amber chip and send is the single amber fill here.
+            canCreate ? (
+              <button
+                onClick={onCreate}
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-colors duration-200 hover:bg-surface"
+              >
+                <Plus className="h-4 w-4" /> Create agent
+              </button>
+            ) : (
+              <span className="px-1 text-sm text-muted-foreground">
+                Ask an admin or a member to create one.
+              </span>
+            )
           ) : (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>


### PR DESCRIPTION
**Stacked on #33** — merge that one first and GitHub will retarget this to `main`.

The first run ends with an agent that has read something, and then the app stops guiding anybody. The home screen has per-section empty states, but nothing says "here is what this becomes once you finish setting it up", and nothing tracks the four things that decide whether a workspace stays.

## The four steps

A checklist under the composer — under, never over: the composer is the product and this is scaffolding.

| Step | The fact behind it |
| --- | --- |
| Upload what the team knows | any agent has a document |
| Ask it something the document answers | any session has `messageCount > 0` |
| Bring in a teammate | `members.length > 1` |
| Schedule something that runs without you | `routines.length > 0` |

Everything except routines is already in `useAgentsStore()` and the `me` query this page makes anyway. The routines query is `enabled` only while the checklist could still be shown, so a settled workspace stops paying for it on every visit. A checklist worth a round trip is worth none, and the alternative is a counters table somebody has to keep true.

Two of the four are narrower than they look, on purpose, and both have a test:

- **`messageCount`, not `sessions.length`.** Opening the composer starts a session before anybody has said anything, so counting sessions would tick "asked it something" for a workspace that never has.
- **Membership, not a pending invitation.** This step asks whether anyone actually *arrived*, which is exactly the thing an invitation nobody was told about looks like — and with no `RESEND_API_KEY`, that is every invitation a self-hosted Covan sends.

## One thing I did not build

A truly *grounded* answer is not visible from the client. `Message.sources` carries the citations, but the session list does not carry messages. Getting it truthfully means an aggregate the API does not expose.

So the tick is on "has asked a question", and the step's hint carries the intent instead: *"The reply names the file it came from — that is the difference between this and a chat window."* Worth knowing this is an approximation.

## When it is not there

Hidden from a **viewer** — the policies refuse them three of the four steps. Hidden while the workspace has **no agents** — that screen has one job and the composer above is already saying it. Gone once all four are done. And dismissible, per workspace: a checklist you cannot put down is a nag, and somebody who is never going to schedule a routine should be able to say so once.

The dismissal is read in an effect rather than a lazy initialiser, because the workspace id arrives from `api.me()` a beat after the first render — an initialiser would run against `undefined` and never look again, so a dismissed checklist would come back on every load.

## Design

`SectionCard` on the canvas, no shadow. A done step gets the amber tick in a 20px `rounded-sm` tile; an open one gets the dashed tile the Team page already uses for something still waiting. No circles — §3.5 allows exactly two places and neither is this.

## Tests

`src/lib/first-week.test.ts` covers the six facts. `_authed.app.test.tsx` gains five cases for visibility and dismissal — its react-query mock is now keyed rather than blanket-`undefined`, because the checklist's visibility is decided by three separate queries and a mock that cannot tell them apart cannot test it.

`bun run test` — 274 passed. `lint` and `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)