### PR TITLE
Show an admin what the workspace costs

### DIFF
--- a/docs/team.md
+++ b/docs/team.md
@@ -85,7 +85,7 @@ it; `create_workspace()` does the same for any workspace somebody makes later.
 | `member` | no                 | yes                   | yes             |
 | `viewer` | no                 | no                    | yes             |
 
-**Admin** governs two things and no more:
+**Admin** controls two things and no more:
 
 - **The workspace row.** Its name, its slug and its default model. One policy,
   `workspaces_update_admin`, covers all three, which is why the same people who
@@ -93,6 +93,10 @@ it; `create_workspace()` does the same for any workspace somebody makes later.
 - **The people in it.** Creating and revoking invitations, changing a role, and
   removing a member — the invitation policies plus
   `workspace_members_update_admin` and `workspace_members_delete_admin`.
+
+It also *sees* one thing nobody else does — what the workspace as a whole has
+spent, by agent and by month — which is a read and not a control, and is
+described under [Usage figures](#usage-figures-are-yours-alone) below.
 
 **Everything a workspace shares** — `agents`, `knowledge_bundles`, `documents`,
 `agent_bundles` and `document_chunks` — asks `can_write_in_workspace()`, which
@@ -198,7 +202,32 @@ two columns, and Postgres will not let `create or replace` change a return type
 rather than by inheritance. The two new sums are inside that same scoped join,
 and the grants the drop removed are restored in the same file.
 
-There is still no workspace-wide view: nobody sees what a colleague spends.
+**An admin can see what the workspace spends, and still not what a colleague
+spends.** `0032` adds two functions next to it — `workspace_usage_all`, the
+same per-agent shape across everybody's conversations, and
+`workspace_usage_monthly`, six buckets of tokens so "are we spending more than
+we were" has an answer. Both are `security definer`, because reading past RLS
+is the entire point: an admin's own view of `chat_sessions` excludes exactly
+the private sessions being asked about. So each checks
+`is_workspace_admin()` for itself before reading anything, and raises `42501`
+rather than returning no rows — a silent empty result is indistinguishable from
+a workspace that has never sent a message.
+
+Aggregated **by agent and by month, never by person**. That is a property of
+their shape rather than a rule the screens are asked to follow: `user_id` is
+not selected, not grouped by, and not returned, so there is no per-person
+breakdown for a later screen to render. Token counts are not conversation
+content, but a table of who spent what is still the wrong thing to hand an
+admin in a product that promises private rooms.
+
+The monthly buckets carry tokens and no money. `messages` records no model, so
+pricing a month would mean assuming every reply in it came from whatever the
+agent is set to today. The per-agent rows do carry a cost, with the same
+caveat named on the screen: changing an agent's model re-prices its history.
+
+This is the third thing admin governs, and the list above says two. Read it as
+"the workspace row, the people in it, and what the workspace costs" — the first
+two are what admin *controls*, and this one is only something it can *see*.
 
 The figures also now account for prompt caching. Most of what Covan sends the
 model on any given turn is the same bytes as last turn — the persona, the

--- a/src/components/workspace-usage-section.test.tsx
+++ b/src/components/workspace-usage-section.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WorkspaceUsageSection } from "./workspace-usage-section";
+import type { WorkspaceUsageResponse } from "@/lib/api-client";
+
+const { useQuery } = vi.hoisted(() => ({ useQuery: vi.fn() }));
+
+vi.mock("@tanstack/react-query", () => ({ useQuery }));
+vi.mock("@/lib/api-client", () => ({ api: { workspaceUsage: vi.fn() } }));
+
+const TOTALS = {
+  messageCount: 12,
+  promptTokens: 90_000,
+  completionTokens: 30_000,
+  cachedTokens: 0,
+  measuredPromptTokens: 0,
+  totalTokens: 120_000,
+  estCostUsd: 1.4,
+};
+
+const AGENT = {
+  agentId: "agent-1",
+  name: "GTM Agent",
+  emoji: "📈",
+  model: "gpt-4o",
+  messageCount: 12,
+  promptTokens: 90_000,
+  completionTokens: 30_000,
+  cachedTokens: 0,
+  measuredPromptTokens: 0,
+  totalTokens: 120_000,
+  estCostUsd: 1.4,
+};
+
+const response = (patch: Partial<WorkspaceUsageResponse> = {}): WorkspaceUsageResponse =>
+  ({
+    available: true,
+    agents: [AGENT],
+    totals: TOTALS,
+    months: [
+      { month: "2026-07-01", messageCount: 0, totalTokens: 0, cachedTokens: 0 },
+      { month: "2026-08-01", messageCount: 12, totalTokens: 120_000, cachedTokens: 0 },
+    ],
+    ...patch,
+  }) as WorkspaceUsageResponse;
+
+function renderWith(data: WorkspaceUsageResponse | undefined, isLoading = false) {
+  useQuery.mockReturnValue({ data, isLoading, isPending: isLoading });
+  render(<WorkspaceUsageSection />);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("WorkspaceUsageSection", () => {
+  it("shows what the workspace spent, by agent", () => {
+    renderWith(response());
+
+    expect(screen.getByText("GTM Agent")).toBeInTheDocument();
+    expect(screen.getByText("$1.40")).toBeInTheDocument();
+    expect(screen.getByText(/12 replies · gpt-4o/)).toBeInTheDocument();
+  });
+
+  // CI does not apply migrations, so there is a real window in which the API is
+  // deployed and 0032 is not. An admin should see nothing at all there — an
+  // error about a feature they never asked for is worse than the feature's
+  // absence.
+  it("renders nothing at all until the migration behind it exists", () => {
+    renderWith(response({ available: false }));
+
+    expect(screen.queryByText("The workspace")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing while it is still loading, rather than an empty shell", () => {
+    renderWith(undefined, true);
+
+    expect(screen.queryByText("The workspace")).not.toBeInTheDocument();
+  });
+
+  // Token counts are not conversation content, but a table of who spent what is
+  // the wrong thing to put in a product that promises private rooms. The
+  // functions in 0032 do not return a user_id, so there is nothing to render —
+  // this asserts the promise the heading makes out loud.
+  it("says out loud that nothing here is per-person", () => {
+    renderWith(response());
+
+    expect(screen.getByText(/never by person/i)).toBeInTheDocument();
+    expect(screen.getByText(/no view that does/i)).toBeInTheDocument();
+  });
+
+  it("keeps a month nobody used as a month, not a gap", () => {
+    renderWith(response());
+
+    // Both buckets are labelled and read out, including the empty one. A chart
+    // that closes up a quiet month makes a fall in spend look like a flat line.
+    expect(screen.getByText("Jul")).toBeInTheDocument();
+    expect(screen.getByText("Aug")).toBeInTheDocument();
+    expect(screen.getByText(/Jul: 0 tokens across 0 replies/)).toBeInTheDocument();
+  });
+
+  it("leaves the trend out when there is no history to draw", () => {
+    renderWith(response({ months: [] }));
+
+    expect(screen.queryByText(/last .* months/i)).not.toBeInTheDocument();
+    expect(screen.getByText("The workspace")).toBeInTheDocument();
+  });
+});

--- a/src/components/workspace-usage-section.tsx
+++ b/src/components/workspace-usage-section.tsx
@@ -1,0 +1,149 @@
+import { useQuery } from "@tanstack/react-query";
+import { api, type UsageMonth } from "@/lib/api-client";
+import { SectionHeading } from "@/components/page-container";
+import { SectionCard, DataRow, EmptyState } from "@/components/section-card";
+import { AgentAvatar } from "@/components/avatars";
+
+const compact = (n: number) =>
+  n >= 1_000_000
+    ? `${(n / 1_000_000).toFixed(1)}M`
+    : n >= 1_000
+      ? `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}k`
+      : String(n);
+
+const usd = (n: number) => (n < 0.01 ? "<$0.01" : `$${n.toFixed(2)}`);
+
+const monthLabel = (iso: string) =>
+  new Date(`${iso.slice(0, 10)}T00:00:00Z`).toLocaleDateString("en", {
+    month: "short",
+    timeZone: "UTC",
+  });
+
+/**
+ * What the whole workspace costs, for the person holding the invoice.
+ *
+ * The section above it is the caller's own and says so. This one is everyone's,
+ * and says that too — two figures on one screen that mean different things have
+ * to be labelled apart, which is the same reason the allowance and the lifetime
+ * totals above are under separate headings.
+ *
+ * **By agent and by month, never by person.** That is not a rule this component
+ * follows; it is the only thing it can do. `workspace_usage_all` does not
+ * select, group by or return a `user_id`, so there is no per-person breakdown
+ * to render even if a later screen wanted one. See `0032`.
+ *
+ * Rendered only for an admin, and only once the migration behind it exists —
+ * `available: false` is the window between deploying the API and hand-applying
+ * `0032`, and an admin should see nothing rather than an error about a feature
+ * they never asked for.
+ */
+export function WorkspaceUsageSection() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["usage", "workspace"],
+    queryFn: api.workspaceUsage,
+  });
+
+  if (isLoading || !data?.available) return null;
+
+  const used = data.agents.filter((a) => a.messageCount > 0);
+  const months = data.months;
+
+  return (
+    <section className="mt-16">
+      <SectionHeading
+        title="The workspace"
+        description="Everyone's conversations together, by agent — never by person."
+      />
+
+      {months.length > 0 && <MonthlyTrend months={months} />}
+
+      <SectionCard padded={false} className="mt-3 overflow-hidden">
+        {used.length === 0 ? (
+          <EmptyState
+            title="Nothing yet"
+            description="Once anybody talks to an agent, what the workspace spends shows up here."
+          />
+        ) : (
+          <ul className="divide-y divide-hairline">
+            {used.map((a) => (
+              <li key={a.agentId}>
+                <DataRow
+                  icon={<AgentAvatar emoji={a.emoji ?? "🤖"} className="h-8 w-8 text-sm" />}
+                  title={a.name}
+                  meta={`${a.messageCount} ${a.messageCount === 1 ? "reply" : "replies"} · ${a.model}`}
+                  trailing={
+                    <span className="text-right text-xs text-muted-foreground">
+                      <span className="block font-medium text-foreground">
+                        {compact(a.totalTokens)}
+                      </span>
+                      {usd(a.estCostUsd)}
+                    </span>
+                  }
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </SectionCard>
+
+      <p className="mt-3 text-xs text-muted-foreground">
+        Everything anybody in this workspace has ever asked, at list prices. The model shown is the
+        agent's current one, and it prices every reply that agent has ever sent — changing an
+        agent's model re-prices its history, because a reply does not record which model wrote it.
+        Nothing here is broken down by person, and there is no view that does.
+      </p>
+    </section>
+  );
+}
+
+/**
+ * Six months of tokens, in the system's own vocabulary: squares, one amber
+ * fill, no chart library. Everything the product shows is otherwise either a
+ * lifetime total or the current month, so this is the only place that answers
+ * "are we spending more than we were".
+ *
+ * A month nobody used is a zero rather than a gap — `workspace_usage_monthly`
+ * generates the span so a quiet month cannot silently close up and make a fall
+ * look like a flat line.
+ */
+function MonthlyTrend({ months }: { months: UsageMonth[] }) {
+  const peak = Math.max(...months.map((m) => m.totalTokens), 1);
+
+  return (
+    <SectionCard className="mt-6">
+      <div className="flex items-baseline justify-between gap-4">
+        <span className="text-sm text-muted-foreground">Last {months.length} months</span>
+        <span className="text-sm font-medium">
+          {compact(months.reduce((n, m) => n + m.totalTokens, 0))} tokens
+        </span>
+      </div>
+
+      <div className="mt-4 flex items-end gap-2">
+        {months.map((m) => (
+          <div key={m.month} className="flex flex-1 flex-col items-center gap-2">
+            {/* 64px of headroom, and a 2px floor so an empty month still reads
+                as a month rather than as missing. */}
+            <div className="flex h-16 w-full items-end" title={`${compact(m.totalTokens)} tokens`}>
+              <div
+                className="w-full bg-accent-orange"
+                style={{ height: `${Math.max(2, Math.round((m.totalTokens / peak) * 100))}%` }}
+                aria-hidden
+              />
+            </div>
+            <span className="text-[11px] text-muted-foreground">{monthLabel(m.month)}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* The bars are decoration; this is the same data in a form a screen
+          reader can read out. */}
+      <ul className="sr-only">
+        {months.map((m) => (
+          <li key={m.month}>
+            {monthLabel(m.month)}: {m.totalTokens} tokens across {m.messageCount} replies
+          </li>
+        ))}
+      </ul>
+    </SectionCard>
+  );
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -368,6 +368,7 @@ export const api = {
     remove: (id: string): Promise<void> => request("DELETE", `/delivery-channels/${id}`),
   },
   usage: (): Promise<UsageResponse> => request("GET", "/usage"),
+  workspaceUsage: (): Promise<WorkspaceUsageResponse> => request("GET", "/usage/workspace"),
   notifications: {
     get: (): Promise<NotificationPreferences> => request("GET", "/notification-preferences"),
     update: (patch: Partial<NotificationPreferences>): Promise<NotificationPreferences> =>
@@ -426,16 +427,47 @@ export type QuotaSnapshot = {
   resetsAt: string | null;
 };
 
+export type UsageTotals = {
+  messageCount: number;
+  promptTokens: number;
+  cachedTokens: number;
+  measuredPromptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  estCostUsd: number;
+};
+
 export type UsageResponse = {
   agents: AgentUsage[];
   quota: QuotaSnapshot;
-  totals: {
-    messageCount: number;
-    promptTokens: number;
-    cachedTokens: number;
-    measuredPromptTokens: number;
-    completionTokens: number;
-    totalTokens: number;
-    estCostUsd: number;
-  };
+  totals: UsageTotals;
+};
+
+/**
+ * One month of the workspace's traffic. No cost: `messages` records no model,
+ * so pricing a month would mean assuming every reply in it came from whatever
+ * the agent is set to today. The per-agent rows carry the money.
+ */
+export type UsageMonth = {
+  /** First day of the month, ISO. Oldest first, so it draws left to right. */
+  month: string;
+  messageCount: number;
+  totalTokens: number;
+  cachedTokens: number;
+};
+
+/**
+ * The workspace's own figures, for an admin. Aggregated by agent and by month
+ * and never by person — that is a property of the functions in `0032`, which
+ * do not select, group by or return a `user_id` at all.
+ *
+ * `available` is false in exactly one situation: the API is deployed and
+ * `0032` has not been applied yet. CI does not run migrations, so that window
+ * is real, and it renders as the section being absent rather than as an error.
+ */
+export type WorkspaceUsageResponse = {
+  available: boolean;
+  agents: AgentUsage[];
+  totals: UsageTotals;
+  months: UsageMonth[];
 };

--- a/src/routes/_authed.settings.tsx
+++ b/src/routes/_authed.settings.tsx
@@ -7,6 +7,7 @@ import { SectionCard } from "@/components/section-card";
 import { UserAvatar } from "@/components/avatars";
 import { DeliveryChannelsCard } from "@/components/routines/delivery-channels-card";
 import { UsageSection } from "@/components/usage-section";
+import { WorkspaceUsageSection } from "@/components/workspace-usage-section";
 import { PreferencesSection } from "@/components/preferences-section";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -207,6 +208,13 @@ function SettingsPage() {
         <PreferencesSection me={me} />
 
         <UsageSection />
+
+        {/* Directly under the caller's own figures, because the two answer the
+            same question at different scopes and reading one without the other
+            is how "Yours alone" got mistaken for the whole bill. Admin only:
+            the functions behind it refuse anybody else anyway, so this is so
+            the section is not there to be confused by. */}
+        {isAdmin && <WorkspaceUsageSection />}
 
         <DeliveryChannelsCard />
 

--- a/supabase/migrations/0032_what_the_workspace_costs.sql
+++ b/supabase/migrations/0032_what_the_workspace_costs.sql
@@ -1,0 +1,160 @@
+-- 0032_what_the_workspace_costs.sql
+--
+-- `workspace_usage` scopes every figure to the caller, and 0022 went to some
+-- trouble to make sure it keeps doing that even as sharing changed underneath
+-- it. The Usage section says so in its own heading: "Yours alone".
+--
+-- That is right for a product whose conversations are private, and it leaves
+-- the person paying the OpenAI bill unable to see what the workspace spends,
+-- which agent is expensive, or whether one is quietly costing more than the
+-- rest put together. It hurts a self-hoster most: they are the one holding the
+-- invoice, and they have no billing console to go and look at instead.
+--
+-- **By agent and by month. Never by person.** These functions cannot report
+-- who spent what, and that is a property of their shape rather than a rule the
+-- interface is asked to follow: `user_id` is not selected, not grouped by, and
+-- not returned. Token counts are not conversation content, but a table of who
+-- spent what is still the wrong thing to hand an admin in a product that
+-- promises private rooms — the signal is the problem, not the data.
+--
+-- SECURITY DEFINER, because that is the whole point: an admin's own RLS view
+-- of `chat_sessions` deliberately excludes their colleagues' private sessions,
+-- which is exactly the traffic being asked about. So each function checks for
+-- itself that the caller is an admin of the workspace it was handed, before
+-- reading anything. `is_workspace_admin` is the same helper the invitation and
+-- membership policies use, so there is one answer to "is this person an admin"
+-- and not two.
+--
+-- The guard raises rather than returning no rows. A silent empty result is
+-- indistinguishable from a workspace that has never sent a message, and the
+-- route needs to tell 403 from "nothing yet".
+--
+-- Idempotent, because CI does not apply migrations — this is hand-applied and
+-- may well be pasted twice. Both functions are dropped by exact signature and
+-- recreated, the same shape 0025 used when it replaced `workspace_usage`.
+
+drop function if exists public.workspace_usage_all(uuid);
+drop function if exists public.workspace_usage_monthly(uuid, int);
+
+-- ---- workspace_usage_all --------------------------------------------------
+-- The same columns as `workspace_usage`, so one renderer can read either, and
+-- the same LEFT JOIN discipline: an agent nobody has chatted with keeps
+-- appearing at zero rather than dropping out of the list. The only difference
+-- that matters is the missing `s.user_id = auth.uid()` in the session join.
+create function public.workspace_usage_all(p_workspace_id uuid)
+returns table (
+  agent_id uuid,
+  agent_name text,
+  agent_emoji text,
+  agent_model text,
+  message_count bigint,
+  prompt_tokens bigint,
+  completion_tokens bigint,
+  cached_tokens bigint,
+  measured_prompt_tokens bigint
+)
+language plpgsql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+begin
+  if not public.is_workspace_admin(p_workspace_id) then
+    raise exception 'not an admin of this workspace' using errcode = '42501';
+  end if;
+
+  return query
+  select a.id,
+         a.name,
+         a.emoji,
+         a.model,
+         count(m.id) as message_count,
+         coalesce(sum(m.prompt_tokens), 0) as prompt_tokens,
+         coalesce(sum(m.completion_tokens), 0) as completion_tokens,
+         coalesce(sum(m.cached_tokens), 0) as cached_tokens,
+         -- The denominator a cache hit rate has to be divided by; 0025
+         -- explains why it is not `prompt_tokens`.
+         coalesce(sum(m.prompt_tokens) filter (where m.cached_tokens is not null), 0)
+           as measured_prompt_tokens
+  from public.agents a
+  left join public.chat_sessions s on s.agent_id = a.id
+  left join public.messages m on m.session_id = s.id and m.role = 'assistant'
+  where a.workspace_id = p_workspace_id
+  group by a.id, a.name, a.emoji, a.model
+  order by (coalesce(sum(m.prompt_tokens), 0) + coalesce(sum(m.completion_tokens), 0)) desc;
+end;
+$$;
+
+-- ---- workspace_usage_monthly ----------------------------------------------
+-- Everything the product shows today is either a lifetime total or the current
+-- month, with nothing in between — so "are we spending more than we were" has
+-- never had an answer. Buckets by the month a reply was stored, newest last,
+-- so a renderer can draw them left to right without reversing anything.
+--
+-- `generate_series` rather than a plain group-by: a month in which nobody sent
+-- anything has to appear as a zero, not as a gap. A chart that silently closes
+-- up a quiet month makes a fall in spend look like a flat line.
+create function public.workspace_usage_monthly(p_workspace_id uuid, p_months int default 6)
+returns table (
+  month date,
+  message_count bigint,
+  prompt_tokens bigint,
+  completion_tokens bigint,
+  cached_tokens bigint
+)
+language plpgsql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_months int := greatest(1, least(coalesce(p_months, 6), 24));
+begin
+  if not public.is_workspace_admin(p_workspace_id) then
+    raise exception 'not an admin of this workspace' using errcode = '42501';
+  end if;
+
+  return query
+  with span as (
+    select generate_series(
+             date_trunc('month', now()) - make_interval(months => v_months - 1),
+             date_trunc('month', now()),
+             interval '1 month'
+           ) as bucket
+  )
+  select span.bucket::date,
+         count(m.id) as message_count,
+         coalesce(sum(m.prompt_tokens), 0) as prompt_tokens,
+         coalesce(sum(m.completion_tokens), 0) as completion_tokens,
+         coalesce(sum(m.cached_tokens), 0) as cached_tokens
+  from span
+  left join public.messages m
+    on m.role = 'assistant'
+   and date_trunc('month', m.created_at) = span.bucket
+   and exists (
+         select 1
+         from public.chat_sessions s
+         join public.agents a on a.id = s.agent_id
+         where s.id = m.session_id
+           and a.workspace_id = p_workspace_id
+       )
+  group by span.bucket
+  order by span.bucket;
+end;
+$$;
+
+-- ---- who may execute ------------------------------------------------------
+-- A newly created function grants EXECUTE to `public` by default, which on a
+-- SECURITY DEFINER function reading other people's sessions is not something
+-- to leave to the default. The guard inside would refuse an anonymous caller
+-- anyway — `auth.uid()` is null, so `is_workspace_admin` is false — but a
+-- definer function should not be reachable by a role that can never pass its
+-- own check.
+--
+-- Deliberately narrower than `workspace_usage`, which carries `anon` from
+-- 0025; that grant exists to preserve a state the database was already in, and
+-- is not a precedent for a new function.
+revoke execute on function public.workspace_usage_all(uuid) from public;
+revoke execute on function public.workspace_usage_monthly(uuid, int) from public;
+grant execute on function public.workspace_usage_all(uuid) to authenticated, service_role;
+grant execute on function public.workspace_usage_monthly(uuid, int) to authenticated, service_role;

--- a/tests/rls/workspace-usage.test.ts
+++ b/tests/rls/workspace-usage.test.ts
@@ -123,3 +123,71 @@ describe("the usage figures", () => {
     expect(Number(row.prompt_tokens)).toBe(0);
   });
 });
+
+/**
+ * The other direction, added with `0032`: an admin asking what the whole
+ * workspace costs.
+ *
+ * `workspace_usage_all` is SECURITY DEFINER because it has to be — an admin's
+ * own view of `chat_sessions` deliberately excludes their colleagues' private
+ * sessions, which is exactly the traffic being asked about. A definer function
+ * that reads past RLS is only as safe as the check it makes for itself, and
+ * that check is the thing worth a live database rather than a fake one.
+ */
+describe("the workspace-wide figures", () => {
+  const bothPeople = OWNERS_TOKENS + COLLEAGUES_TOKENS;
+
+  async function allFor(user: TestUser) {
+    return user.db.rpc("workspace_usage_all", { p_workspace_id: owner.workspaceId });
+  }
+
+  it("count everybody's conversations for an admin, private ones included", async () => {
+    const { data, error } = await allFor(owner);
+    expect(error, error?.message).toBeNull();
+
+    const row = (data ?? []).find((r: { agent_id: string }) => r.agent_id === seeded.agentId);
+    // The colleague's session is shared and the owner's is private. The point
+    // of the definer function is that neither of those facts changes the total.
+    expect(Number(row.prompt_tokens)).toBe(bothPeople);
+  });
+
+  it("refuse a member outright rather than quietly returning their own", async () => {
+    const { error } = await allFor(colleague);
+
+    // A silent empty result is indistinguishable from a workspace that has
+    // never sent a message, and the route has to tell 403 from "nothing yet".
+    expect(error).not.toBeNull();
+    expect(error?.code).toBe("42501");
+  });
+
+  it("say nothing about who spent it", async () => {
+    const { data } = await allFor(owner);
+
+    // Not a rule the interface is asked to follow: there is no user_id in the
+    // function's return type, so no screen can break this by choosing to.
+    expect(Object.keys((data ?? [])[0] ?? {})).not.toContain("user_id");
+  });
+
+  it("bucket the same total by month for an admin, and refuse a member the same way", async () => {
+    const { data, error } = await owner.db.rpc("workspace_usage_monthly", {
+      p_workspace_id: owner.workspaceId,
+      p_months: 6,
+    });
+    expect(error, error?.message).toBeNull();
+
+    // Six buckets whether or not anybody used them — a month that closes up
+    // silently makes a fall in spend look like a flat line.
+    expect(data).toHaveLength(6);
+    const total = (data ?? []).reduce(
+      (n: number, m: { prompt_tokens: number }) => n + Number(m.prompt_tokens),
+      0,
+    );
+    expect(total).toBe(bothPeople);
+
+    const refused = await colleague.db.rpc("workspace_usage_monthly", {
+      p_workspace_id: owner.workspaceId,
+      p_months: 6,
+    });
+    expect(refused.error?.code).toBe("42501");
+  });
+});

--- a/worker/src/routes/usage.test.ts
+++ b/worker/src/routes/usage.test.ts
@@ -1,0 +1,164 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import type { AppEnv } from "../types";
+import { usage } from "./usage";
+
+const USER_ID = "user-1";
+const WORKSPACE_ID = "workspace-1";
+
+type RpcResult = { data: unknown[] | null; error: { code?: string; message?: string } | null };
+
+/**
+ * Enough of the request-scoped client for `getActiveWorkspaceId` to resolve and
+ * for the two RPCs to answer. Every table read here is one that helper makes.
+ */
+function fakeDb(rpcs: Record<string, RpcResult>) {
+  const calls: string[] = [];
+  const db = {
+    from(table: string) {
+      const single = async () =>
+        table === "profiles"
+          ? { data: { active_workspace_id: WORKSPACE_ID }, error: null }
+          : { data: { workspace_id: WORKSPACE_ID }, error: null };
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        maybeSingle: single,
+        single,
+      };
+      return chain;
+    },
+    async rpc(name: string) {
+      calls.push(name);
+      return rpcs[name] ?? { data: [], error: null };
+    },
+  };
+  return { db, calls };
+}
+
+function appWithDb(db: unknown) {
+  const app = new Hono<AppEnv>();
+  app.use("/*", async (c, next) => {
+    c.set("user", { id: USER_ID, email: "a@example.com" } as never);
+    c.set("db", db as never);
+    await next();
+  });
+  app.route("/", usage);
+  return app;
+}
+
+const AGENT_ROW = {
+  agent_id: "agent-1",
+  agent_name: "GTM",
+  agent_emoji: "📈",
+  agent_model: "gpt-4o",
+  message_count: 4,
+  prompt_tokens: 1000,
+  completion_tokens: 500,
+  cached_tokens: 0,
+  measured_prompt_tokens: 0,
+};
+
+describe("GET /usage/workspace", () => {
+  it("returns the workspace's own figures, and nothing keyed to a person", async () => {
+    const { db, calls } = fakeDb({
+      workspace_usage_all: { data: [AGENT_ROW], error: null },
+      workspace_usage_monthly: {
+        data: [
+          {
+            month: "2026-08-01",
+            message_count: 4,
+            prompt_tokens: 1000,
+            completion_tokens: 500,
+            cached_tokens: 0,
+          },
+        ],
+        error: null,
+      },
+    });
+
+    const res = await appWithDb(db).request("/usage/workspace");
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.available).toBe(true);
+    expect(calls).toContain("workspace_usage_all");
+    // The per-caller function is the one that scopes to auth.uid(); reaching
+    // for it here would answer a different question than the heading asks.
+    expect(calls).not.toContain("workspace_usage");
+    expect(JSON.stringify(body)).not.toContain("user_id");
+  });
+
+  // 0032 raises 42501 rather than returning no rows, precisely so this can be
+  // told apart from a workspace that has never sent a message.
+  it("turns the function's own refusal into a 403, not an empty result", async () => {
+    const { db } = fakeDb({
+      workspace_usage_all: { data: null, error: { code: "42501", message: "not an admin" } },
+      workspace_usage_monthly: { data: [], error: null },
+    });
+
+    const res = await appWithDb(db).request("/usage/workspace");
+
+    expect(res.status).toBe(403);
+  });
+
+  // CI does not apply migrations. Between deploying this and somebody pasting
+  // 0032 into the SQL editor, the function genuinely is not there, and that is
+  // a deployment state rather than a fault.
+  it("reports a missing migration as unavailable rather than as a failure", async () => {
+    for (const code of ["PGRST202", "42883"]) {
+      const { db } = fakeDb({
+        workspace_usage_all: { data: null, error: { code, message: "could not find function" } },
+        workspace_usage_monthly: { data: [], error: null },
+      });
+
+      const res = await appWithDb(db).request("/usage/workspace");
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.available).toBe(false);
+      expect(body.agents).toEqual([]);
+    }
+  });
+
+  it("still fails loudly on an error that is neither of those", async () => {
+    const { db } = fakeDb({
+      workspace_usage_all: { data: null, error: { code: "57014", message: "canceling statement" } },
+      workspace_usage_monthly: { data: [], error: null },
+    });
+
+    const res = await appWithDb(db).request("/usage/workspace");
+
+    expect(res.status).toBe(500);
+  });
+
+  it("prices agents but not months, because a reply does not record its model", async () => {
+    const { db } = fakeDb({
+      workspace_usage_all: { data: [AGENT_ROW], error: null },
+      workspace_usage_monthly: {
+        data: [
+          {
+            month: "2026-08-01",
+            message_count: 4,
+            prompt_tokens: 1000,
+            completion_tokens: 500,
+            cached_tokens: 0,
+          },
+        ],
+        error: null,
+      },
+    });
+
+    const res = await appWithDb(db).request("/usage/workspace");
+    const body = (await res.json()) as {
+      agents: { estCostUsd: number }[];
+      months: Record<string, unknown>[];
+      totals: { totalTokens: number };
+    };
+
+    expect(body.agents[0].estCostUsd).toBeGreaterThan(0);
+    expect(body.totals.totalTokens).toBe(1500);
+    expect(body.months[0]).not.toHaveProperty("estCostUsd");
+    expect(body.months[0].totalTokens).toBe(1500);
+  });
+});

--- a/worker/src/routes/usage.ts
+++ b/worker/src/routes/usage.ts
@@ -18,6 +18,14 @@ type UsageRow = {
   measured_prompt_tokens: number;
 };
 
+type MonthRow = {
+  month: string;
+  message_count: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  cached_tokens: number;
+};
+
 const emptyTotals = {
   messageCount: 0,
   promptTokens: 0,
@@ -27,6 +35,51 @@ const emptyTotals = {
   totalTokens: 0,
   estCostUsd: 0,
 };
+
+/** One agent's row, priced. Shared by the per-caller and workspace-wide reads,
+    which return identical columns on purpose so one renderer can read either. */
+function mapAgent(r: UsageRow) {
+  const model = resolveModel(r.agent_model);
+  const promptTokens = Number(r.prompt_tokens) || 0;
+  const completionTokens = Number(r.completion_tokens) || 0;
+  // A subset of promptTokens, so it is priced into estCostUsd rather than
+  // added to totalTokens — the total is how many tokens moved, the cost is
+  // what they were billed at, and only the second one knows about caching.
+  // Replies from before 0025 report null here and sum as 0, which reads as
+  // "no discount recorded" and leaves their historical figure unchanged.
+  const cachedTokens = Number(r.cached_tokens) || 0;
+  // Only the prompt tokens on replies that carry a cache measurement — the
+  // honest denominator for a hit rate. See 0025.
+  const measuredPromptTokens = Number(r.measured_prompt_tokens) || 0;
+  return {
+    agentId: r.agent_id,
+    name: r.agent_name,
+    emoji: r.agent_emoji,
+    model,
+    messageCount: Number(r.message_count) || 0,
+    promptTokens,
+    completionTokens,
+    cachedTokens,
+    measuredPromptTokens,
+    totalTokens: promptTokens + completionTokens,
+    estCostUsd: estimateCostUsd(model, promptTokens, completionTokens, cachedTokens),
+  };
+}
+
+function sumTotals(agents: ReturnType<typeof mapAgent>[]) {
+  return agents.reduce(
+    (acc, a) => ({
+      messageCount: acc.messageCount + a.messageCount,
+      promptTokens: acc.promptTokens + a.promptTokens,
+      completionTokens: acc.completionTokens + a.completionTokens,
+      cachedTokens: acc.cachedTokens + a.cachedTokens,
+      measuredPromptTokens: acc.measuredPromptTokens + a.measuredPromptTokens,
+      totalTokens: acc.totalTokens + a.totalTokens,
+      estCostUsd: acc.estCostUsd + a.estCostUsd,
+    }),
+    { ...emptyTotals },
+  );
+}
 
 // GET /usage — per-agent message + token totals and an estimated cost, scoped
 // to the active workspace. Sessions are private per user (RLS), so figures
@@ -54,48 +107,80 @@ usage.get("/usage", async (c) => {
     return c.json({ error: "failed to load usage" }, 500);
   }
 
-  const agents = ((data ?? []) as UsageRow[]).map((r) => {
-    const model = resolveModel(r.agent_model);
-    const promptTokens = Number(r.prompt_tokens) || 0;
-    const completionTokens = Number(r.completion_tokens) || 0;
-    // A subset of promptTokens, so it is priced into estCostUsd rather than
-    // added to totalTokens — the total is how many tokens moved, the cost is
-    // what they were billed at, and only the second one knows about caching.
-    // Replies from before 0025 report null here and sum as 0, which reads as
-    // "no discount recorded" and leaves their historical figure unchanged.
-    const cachedTokens = Number(r.cached_tokens) || 0;
-    // Only the prompt tokens on replies that carry a cache measurement — the
-    // honest denominator for a hit rate. See 0025.
-    const measuredPromptTokens = Number(r.measured_prompt_tokens) || 0;
+  const agents = ((data ?? []) as UsageRow[]).map(mapAgent);
+  return c.json({ agents, totals: sumTotals(agents), quota });
+});
+
+/**
+ * A function that is not there yet.
+ *
+ * CI does not apply migrations, so between merging `0032` and somebody pasting
+ * it into the SQL editor the API is deployed against a database that has never
+ * heard of these functions. PostgREST answers that with `PGRST202` (nothing by
+ * that name in the schema cache) or, once found but mismatched, `42883`.
+ *
+ * That window is reported as `available: false` and a 200 rather than a 500,
+ * so the interface can leave the section out instead of showing an admin an
+ * error about a feature they never asked for. It is the difference between "we
+ * have not finished deploying" and "something is broken".
+ */
+function isMissingFunction(error: { code?: string; message?: string }): boolean {
+  return error.code === "PGRST202" || error.code === "42883";
+}
+
+/** The workspace's own refusal, raised inside the function. See 0032. */
+function isNotAdmin(error: { code?: string }): boolean {
+  return error.code === "42501";
+}
+
+// GET /usage/workspace — the same per-agent shape as above, but across
+// everybody's conversations, plus a month-by-month trend. Admin only, and the
+// check that enforces it lives in the function rather than here: an admin's own
+// RLS view excludes exactly the sessions being asked about, so this has to be
+// SECURITY DEFINER, and a definer function that trusts its caller to have
+// checked is one refactor away from being wrong.
+//
+// There is nothing per-person in the response, by construction — see 0032.
+usage.get("/usage/workspace", async (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+
+  const workspaceId = await getActiveWorkspaceId(db, user.id);
+  if (!workspaceId) return c.json({ available: true, agents: [], totals: emptyTotals, months: [] });
+
+  const [wide, monthly] = await Promise.all([
+    db.rpc("workspace_usage_all", { p_workspace_id: workspaceId }),
+    db.rpc("workspace_usage_monthly", { p_workspace_id: workspaceId, p_months: 6 }),
+  ]);
+
+  const error = wide.error ?? monthly.error;
+  if (error) {
+    if (isNotAdmin(error)) return c.json({ error: "admins only" }, 403);
+    if (isMissingFunction(error)) {
+      console.warn("workspace usage functions are not applied yet", error.message);
+      return c.json({ available: false, agents: [], totals: emptyTotals, months: [] });
+    }
+    console.error("workspace usage failed", error);
+    return c.json({ error: "failed to load usage" }, 500);
+  }
+
+  const agents = ((wide.data ?? []) as UsageRow[]).map(mapAgent);
+  const months = ((monthly.data ?? []) as MonthRow[]).map((m) => {
+    const promptTokens = Number(m.prompt_tokens) || 0;
+    const completionTokens = Number(m.completion_tokens) || 0;
     return {
-      agentId: r.agent_id,
-      name: r.agent_name,
-      emoji: r.agent_emoji,
-      model,
-      messageCount: Number(r.message_count) || 0,
-      promptTokens,
-      completionTokens,
-      cachedTokens,
-      measuredPromptTokens,
+      month: m.month,
+      messageCount: Number(m.message_count) || 0,
+      // No cost here, and not an oversight: `messages` records no model, so a
+      // month's tokens cannot be priced without assuming every reply in it
+      // came from whatever the agent is set to today. Tokens are the honest
+      // figure at this grain; the per-agent rows above carry the money.
       totalTokens: promptTokens + completionTokens,
-      estCostUsd: estimateCostUsd(model, promptTokens, completionTokens, cachedTokens),
+      cachedTokens: Number(m.cached_tokens) || 0,
     };
   });
 
-  const totals = agents.reduce(
-    (acc, a) => ({
-      messageCount: acc.messageCount + a.messageCount,
-      promptTokens: acc.promptTokens + a.promptTokens,
-      completionTokens: acc.completionTokens + a.completionTokens,
-      cachedTokens: acc.cachedTokens + a.cachedTokens,
-      measuredPromptTokens: acc.measuredPromptTokens + a.measuredPromptTokens,
-      totalTokens: acc.totalTokens + a.totalTokens,
-      estCostUsd: acc.estCostUsd + a.estCostUsd,
-    }),
-    { ...emptyTotals },
-  );
-
-  return c.json({ agents, totals, quota });
+  return c.json({ available: true, agents, totals: sumTotals(agents), months });
 });
 
 export { usage };


### PR DESCRIPTION
Every usage figure is the caller's own, and `0022` went to some trouble to keep it that way after `0008` quietly broke it. That is right for a product whose conversations are private, and it leaves the person paying the OpenAI bill unable to see what the workspace spends, which agent is expensive, or whether one is quietly costing more than the rest put together.

**That hurts a self-hoster most.** A hosted user has an allowance and a bill somebody else reconciles. A self-hoster holds the OpenAI invoice and has no billing console to go and look at instead.

## Needs the migration applied

`0032` is hand-applied, as all of them are. **Merging this does not break anything on its own**: the route reports a missing function (`PGRST202` / `42883`) as `available: false` with a 200, and the section is simply absent until the SQL is run. That is a deployment state, not a fault, and it is tested in both halves.

## `0032`

Two functions beside `workspace_usage`:

- `workspace_usage_all(uuid)` — the same columns, so one renderer reads either, and the same LEFT JOIN discipline so an unused agent still appears at zero. The only difference that matters is the missing `s.user_id = auth.uid()`.
- `workspace_usage_monthly(uuid, int default 6)` — buckets by month, oldest first. `generate_series` rather than a plain group-by, because a month nobody used has to be a zero and not a gap; a chart that closes up a quiet month makes a fall in spend look like a flat line.

Both are `SECURITY DEFINER`, because that is the entire point — an admin's own RLS view of `chat_sessions` excludes exactly the private sessions being asked about. So each checks `is_workspace_admin()` for itself, using the same helper the invitation and membership policies use, and **raises `42501` rather than returning no rows**: a silent empty result is indistinguishable from a workspace that has never sent a message, and the route has to tell 403 from "nothing yet".

Both are revoked from `public` and granted to `authenticated, service_role` only. The guard would refuse `anon` anyway, but a definer function should not be reachable by a role that can never pass its own check.

Idempotent — dropped by exact signature and recreated, the shape `0025` used.

## By agent and by month, never by person

Not a rule the screens are asked to follow: `user_id` is not selected, not grouped by, and not returned, so there is no per-person breakdown for a later screen to render even if someone wanted one. Token counts are not conversation content, but a table of who spent what is still the wrong thing to hand an admin in a product that promises private rooms — the signal is the problem, not the data.

## Two things that are not in it

- **No chart library.** Six squares and one amber fill say the same thing in the system's own vocabulary and cost nothing, which matters more in a project whose pitch is one `docker compose up`.
- **No cost on the monthly buckets.** `messages` records no model, so pricing a month would mean assuming every reply in it came from whatever the agent is set to *today*. The per-agent rows do carry cost, with that caveat printed on the screen.

## Tests

- **`tests/rls/workspace-usage.test.ts`** (live database) — four new cases: an admin's total includes a colleague's *private* session; a member is refused with `42501` rather than quietly getting their own figures; the returned columns carry no `user_id`; the monthly buckets sum to the same total and refuse a member the same way. A definer function that reads past RLS is only as safe as the check it makes for itself, and a fake client cannot prove that check works.
- **`worker/src/routes/usage.test.ts`** (new) — the error mapping, and that the route never reaches for the per-caller `workspace_usage`.
- **`src/components/workspace-usage-section.test.tsx`** (new) — renders nothing while loading or unavailable, keeps an empty month as a month, and asserts the "never by person" promise is actually on screen.

`bun run test` 267, `worker` 488, `check:rls` clean, `lint` and `typecheck` clean.

`docs/team.md` gains the section and corrects "admin governs two things" — it is now two things it *controls* and one it can *see*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)