### PR TITLE
An invitation you sent is not one you received

### DIFF
--- a/docs/team.md
+++ b/docs/team.md
@@ -72,6 +72,21 @@ new account meets the same invitation as a step in the welcome flow instead —
 somebody who was invited already has a workspace waiting, so walking them through
 furnishing another one they are about to abandon would be the wrong order.
 
+**Only the invitee.** `invitations_select_admin_or_invitee` admits a row when the
+caller is an admin of the workspace *or* the row is addressed to them, which is
+right — the pending list on this page needs the first half. It is the wrong
+scope for the incoming banner, and that route used to lean on the policy for its
+scoping instead of saying which rows it meant. So an admin met their own
+outgoing invitations in it: *"You've been invited to \<your own workspace\> as
+\<the role you just granted somebody else\>"*, with an Accept button
+`accept_invitation()` was always going to refuse, because it compares the
+address against the caller's own. The query now filters on the caller's address;
+the policy is untouched.
+
+That is the same mistake as the usage figures below, one table over. A policy
+answers "may this person see this row", which stops being the same question as
+"is this row theirs" the moment anybody else is added to the `or`.
+
 Accepting runs `accept_invitation()`, a `SECURITY DEFINER` function, because the
 person accepting is by definition not yet a member and no policy would let them
 insert their own membership row. It compares the invitation's address with the

--- a/worker/src/routes/invitations.test.ts
+++ b/worker/src/routes/invitations.test.ts
@@ -26,15 +26,18 @@ const USER = { id: "user-1", email: "admin@example.com" };
 const WORKSPACE = "ws-1";
 const CREATED_AT = "2026-08-01T09:00:00.000Z";
 
-function appWith(spec: FakeDbSpec) {
+/** `user` overrides the caller — only the incoming-invitations case needs it,
+    to check an address whose capitals survived signup. */
+function appWith(spec: FakeDbSpec & { user?: { id: string; email: string } }) {
+  const { user = USER, ...dbSpec } = spec;
   const fake = fakeDb({
-    ...spec,
-    tables: { ...activeWorkspaceTables(USER.id, WORKSPACE), ...spec.tables },
+    ...dbSpec,
+    tables: { ...activeWorkspaceTables(user.id, WORKSPACE), ...dbSpec.tables },
   });
 
   const app = new Hono<AppEnv>();
   app.use("/*", async (c, next) => {
-    c.set("user", USER as never);
+    c.set("user", user as never);
     c.set("db", fake.db as never);
     await next();
   });
@@ -476,6 +479,60 @@ describe("GET /invitations/incoming", () => {
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual([expect.objectContaining({ workspaceName: "" })]);
+  });
+
+  /**
+   * The route used to lean entirely on `invitations_select_admin_or_invitee`,
+   * which admits a row when the caller is an admin of the workspace OR the row
+   * is addressed to them. So it answered "invitations you can see" to a
+   * question that asked "invitations addressed to you", and an admin met their
+   * own outgoing invitations in the incoming banner — "You've been invited to
+   * <your own workspace> as <the role you just granted somebody else>", with an
+   * Accept button `accept_invitation()` was always going to refuse.
+   *
+   * Asserted on the filter rather than on the rows, because the fake client
+   * cannot enforce a policy: a test that only checked the response would pass
+   * with the filter deleted.
+   */
+  it("asks only for invitations addressed to the caller, not every one they may read", async () => {
+    let filters: { column: string; value: unknown }[] = [];
+    const { app } = appWith({
+      tables: {
+        invitations: {
+          select: (ctx) => {
+            filters = ctx.filters as typeof filters;
+            return { data: [], error: null };
+          },
+        },
+      },
+    });
+
+    await json(app, "GET", "/invitations/incoming");
+
+    expect(filters).toContainEqual(expect.objectContaining({ column: "email", value: USER.email }));
+  });
+
+  it("lowercases the caller's own address, since the stored one always is", async () => {
+    let filters: { column: string; value: unknown }[] = [];
+    const { app } = appWith({
+      user: { id: USER.id, email: "Admin@Example.com" },
+      tables: {
+        invitations: {
+          select: (ctx) => {
+            filters = ctx.filters as typeof filters;
+            return { data: [], error: null };
+          },
+        },
+      },
+    });
+
+    await json(app, "GET", "/invitations/incoming");
+
+    // POST /invitations lowercases on the way in, so a caller whose auth record
+    // kept its capitals would otherwise match none of their own invitations.
+    expect(filters).toContainEqual(
+      expect.objectContaining({ column: "email", value: "admin@example.com" }),
+    );
   });
 });
 

--- a/worker/src/routes/invitations.ts
+++ b/worker/src/routes/invitations.ts
@@ -255,13 +255,39 @@ invitations.delete("/invitations/:id", async (c) => {
 // GET /invitations/incoming — pending invites addressed to the caller's email.
 invitations.get("/invitations/incoming", async (c) => {
   const db = c.get("db");
+  const user = c.get("user");
 
-  // RLS select policy already limits rows to invites whose email == caller's JWT
-  // email (or workspaces they admin); filter to pending and join the name.
+  // The address filter is this query's job, not the policy's.
+  //
+  // `invitations_select_admin_or_invitee` (0003) admits a row when the caller
+  // is an admin of the workspace OR the row is addressed to them. That is the
+  // right policy — an admin has to be able to read the pending invitations the
+  // Team page lists. It is the wrong scope for this route, which used to lean
+  // on it entirely and so answered "invitations you can see" when it was asked
+  // "invitations addressed to you". An admin therefore met their own outgoing
+  // invitations in the incoming banner: "You've been invited to <your own
+  // workspace> as <the role you just granted somebody else>". Accepting one
+  // could never work either, because `accept_invitation()` compares the
+  // address against the caller's own — so the banner offered an action that
+  // was guaranteed to be refused.
+  //
+  // Exactly the mistake 0022 spent a header on: a policy answers "may this
+  // person see this row", which stopped being the same question as "is this
+  // row theirs" the moment admins were added to the `or`. The policy is left
+  // alone; the query says which rows it means.
+  //
+  // `.eq` rather than the `ilike` the create path needs: `invitations.email`
+  // is lowercased on insert, while `profiles.email` is copied verbatim from
+  // auth and is not. Lowercasing the caller's own address matches what the
+  // policy already does with `lower(auth.jwt() ->> 'email')`, and an absent
+  // one narrows to nothing rather than widening to everything.
+  const callerEmail = (user.email ?? "").toLowerCase();
+
   const { data, error } = await db
     .from("invitations")
     .select("id, workspace_id, role, created_at, workspaces(name)")
     .eq("status", "pending")
+    .eq("email", callerEmail)
     .gt("expires_at", new Date().toISOString())
     .order("created_at", { ascending: false });
 


### PR DESCRIPTION
Found while testing the invite flow: sending an invitation made the **inviter's own** banner say

> You've been invited to **\<your own workspace\>** as admin.

— their own workspace, and the role they had just granted somebody else.

## Why

`GET /invitations/incoming` filtered on `status` and `expires_at` and left the rest to RLS. `invitations_select_admin_or_invitee` (`0003`) is:

```sql
using (
  public.is_workspace_admin(workspace_id)
  or lower(email) = lower(coalesce(auth.jwt() ->> 'email', ''))
)
```

That policy is **correct** — the pending list on the Team page needs the admin half. It is the wrong *scope* for this route, which was asking "invitations addressed to me" and getting "invitations I may read".

Accepting one could never have worked, either: `accept_invitation()` compares the invitation's address against the caller's own and refuses if they differ. So the banner offered an Accept button that was guaranteed to be turned down — a dead end, not a privilege escalation. No row was ever exposed that the policy did not already permit; it was shown in the one place where it meant something else.

**This is the same mistake `0022` spent a header on, one table over.** A policy answers "may this person see this row", which stopped being the same question as "is this row theirs" the moment admins were added to the `or`. The route's own comment half-admitted it in a parenthesis: `(or workspaces they admin)`.

## The fix

One filter. The policy is untouched.

`.eq` rather than the `ilike` the create path needs: `invitations.email` is lowercased on insert, while `profiles.email` is copied verbatim from auth and is not. The caller's own address is lowercased to match what the policy already does, and an absent one narrows to nothing rather than widening to everything.

## Not a second bug

The role reads correctly end to end — `parsed.data.role` goes into the row, `/incoming` selects that column back, and `0021` widened the CHECK constraint to accept `viewer`. "as admin" was simply the role on the invitation the admin had just written; there was nothing else for the banner to show once it was showing the wrong row.

## Tests

Two, both asserting on the **filter** rather than on the returned rows: the fake client cannot enforce a policy, so a test that only checked the response body would pass with the filter deleted. Verified both fail against the pre-fix route.

- asks only for invitations addressed to the caller
- lowercases the caller's address, for a signup whose capitals survived

`appWith` gains an optional `user` override for the second one.

`lint`, `typecheck` and both test suites clean.

`docs/team.md` records it under "What the invitee sees", next to the usage-figures paragraph that describes the identical failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)