### PR TITLE
Give the API a credential that outlives a session

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -328,6 +328,12 @@ services:
       RATE_LIMIT_EXPENSIVE_PER_MINUTE: ${RATE_LIMIT_EXPENSIVE_PER_MINUTE:-}
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       RESEND_FROM: ${RESEND_FROM:-}
+      # The same secret GoTrue signs sessions with, passed through so the API can
+      # exchange an API key for a short-lived token belonging to the key's owner.
+      # It is already in .env for the auth service, so a self-hosted stack gets
+      # API keys with no extra configuration; leaving it out turns them off
+      # rather than breaking anything.
+      SUPABASE_JWT_SECRET: ${JWT_SECRET}
       PORT: 8787
       ROUTINE_TICK_MS: ${ROUTINE_TICK_MS:-60000}
     volumes:

--- a/supabase/migrations/0033_a_key_that_is_a_person.sql
+++ b/supabase/migrations/0033_a_key_that_is_a_person.sql
@@ -1,0 +1,200 @@
+-- 0033_a_key_that_is_a_person.sql
+--
+-- A long-lived credential for the REST API. Until now there was none: the only
+-- way to reach the API was a browser session's bearer token, which expires in an
+-- hour and cannot be handed to a cron job. The docs say the API exists; nothing
+-- said how to hold a key to it, and that gap is what this closes.
+--
+-- ---- what a key is -------------------------------------------------------
+--
+-- A key belongs to a PERSON and acts as that person. That is not a shortcut, it
+-- is the only shape that keeps the authorization model intact: everything in
+-- this database gates on `auth.uid()`, so a credential that resolves to nobody
+-- would have to be scoped by application code instead — which is precisely what
+-- worker/src/service-client.static.test.ts exists to prevent. The API Worker
+-- looks a key up, mints a sixty-second JWT for its owner, and makes the request
+-- as them. Postgres cannot tell the difference, and that is the point.
+--
+-- The consequence is deliberate and should be said out loud: when somebody
+-- leaves a workspace their keys stop working, because their own access stopped
+-- working. A script that ran on a departed colleague's key goes quiet. The
+-- alternative — a key owned by the workspace rather than by a person — needs a
+-- service-account user to be, which is a second kind of member for the Team
+-- page, the removal flow and every "who did this" question to learn about. That
+-- is a larger decision than this migration, so the removal dialog is being
+-- taught to count somebody's live keys instead (see the function at the bottom).
+--
+-- ---- what is stored ------------------------------------------------------
+--
+-- The hash, never the key. `token_hash` is SHA-256 hex of the plaintext, and
+-- SHA-256 rather than bcrypt or argon deliberately: the token is 32 bytes from a
+-- CSPRNG, so there is no dictionary to slow an attacker down through. A slow
+-- hash here would buy nothing and spend Worker CPU on every single request.
+--
+-- `prefix` is the first characters of the key, kept in the clear so a row can be
+-- recognised in a list. It is not a secret and not enough to reconstruct one.
+
+create table if not exists public.api_keys (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references public.workspaces(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  -- What it is for, in the owner's words. Bounded so the list stays readable.
+  name text not null check (length(btrim(name)) between 1 and 60),
+  token_hash text not null unique,
+  prefix text not null,
+  created_at timestamptz not null default now(),
+  -- Written past the end of the response and only when the stored value is
+  -- already stale — see `touchApiKey` in worker/src/lib/api-keys.ts. A forgotten
+  -- key is recognised at five-minute resolution, which is all the interface
+  -- asks for and much less than a write on every request costs.
+  last_used_at timestamptz,
+  revoked_at timestamptz
+);
+
+-- The lookup the API Worker makes on every key-authenticated request is by
+-- `token_hash`, which the unique constraint already indexes. This one serves the
+-- list in Settings and the count function below.
+create index if not exists api_keys_user_live_idx
+  on public.api_keys (user_id)
+  where revoked_at is null;
+
+alter table public.api_keys enable row level security;
+
+-- ---- policies ------------------------------------------------------------
+--
+-- Own keys only, on all four verbs. No admin branch, and its absence is a
+-- decision: an `or is_workspace_admin(...)` here would be read by the next
+-- person as "admins may list a colleague's keys", and the route that wanted to
+-- answer "my keys" would quietly start answering "keys I am allowed to see".
+-- That is the mistake 0022 documented and that GET /invitations/incoming made
+-- for real. The one thing an admin genuinely needs — how many live keys somebody
+-- has, before removing them — is a function, at the bottom, that checks for
+-- itself.
+
+drop policy if exists "api_keys_select_own" on public.api_keys;
+
+create policy "api_keys_select_own"
+  on public.api_keys for select
+  using (user_id = auth.uid());
+
+-- Membership is required as well as ownership, so a key cannot be minted into a
+-- workspace the caller has left. `is_workspace_member` rather than
+-- `can_write_in_workspace`: a viewer may hold a key, because the key can do no
+-- more than the viewer can, and every policy it meets will say so.
+drop policy if exists "api_keys_insert_own" on public.api_keys;
+
+create policy "api_keys_insert_own"
+  on public.api_keys for insert
+  with check (
+    user_id = auth.uid()
+    and public.is_workspace_member(workspace_id)
+  );
+
+-- UPDATE exists for revocation, and the trigger below is what keeps it to that.
+-- Membership is deliberately NOT required: somebody who has been removed from a
+-- workspace should still be able to revoke the key they left behind.
+drop policy if exists "api_keys_update_own" on public.api_keys;
+
+create policy "api_keys_update_own"
+  on public.api_keys for update
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+drop policy if exists "api_keys_delete_own" on public.api_keys;
+
+create policy "api_keys_delete_own"
+  on public.api_keys for delete
+  using (user_id = auth.uid());
+
+-- ---- what an update may change -------------------------------------------
+--
+-- The policy above says who may update. This says what an update is for, the
+-- way 0028 and 0030 pinned the columns a client could choose on ideas.
+--
+-- Two things it stops. Re-pointing a row — a new `token_hash`, a different
+-- `user_id`, another workspace — would turn "revoke a key" into "swap the secret
+-- behind a row somebody else's audit trail is looking at". And un-revoking:
+-- without the second check, revocation is reversible, so a key revoked because
+-- it leaked comes back the moment the same request is replayed with a null.
+create or replace function public.api_keys_only_revocation()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.id is distinct from old.id
+    or new.workspace_id is distinct from old.workspace_id
+    or new.user_id is distinct from old.user_id
+    or new.token_hash is distinct from old.token_hash
+    or new.prefix is distinct from old.prefix
+    or new.created_at is distinct from old.created_at
+  then
+    raise exception 'an api key can only be renamed or revoked'
+      using errcode = '42501';
+  end if;
+
+  if old.revoked_at is not null and new.revoked_at is distinct from old.revoked_at then
+    raise exception 'a revoked api key cannot be restored'
+      using errcode = '42501';
+  end if;
+
+  -- last_used_at is written by the service role, which does not reach this
+  -- trigger's `authenticated` path in practice — but it is left out of the list
+  -- above rather than defended here, because a rule that fires on the row's own
+  -- bookkeeping would make every request's touch fail.
+  return new;
+end;
+$$;
+
+drop trigger if exists api_keys_only_revocation on public.api_keys;
+
+create trigger api_keys_only_revocation
+  before update on public.api_keys
+  for each row
+  execute function public.api_keys_only_revocation();
+
+-- ---- what an admin may know ----------------------------------------------
+--
+-- One number, for the dialog that removes somebody from a workspace. Their keys
+-- die with their membership, and an admin who is not told that finds out when a
+-- script stops at three in the morning.
+--
+-- SECURITY DEFINER because the policies above are own-keys-only by design, and
+-- it checks `is_workspace_admin` for itself rather than trusting a caller who
+-- has already checked — the arrangement 0032 settled on. It raises instead of
+-- returning zero, because "you are not an admin" and "they have no keys" are
+-- different answers and a bare 0 cannot tell them apart.
+--
+-- Nothing here identifies a key. A name or a prefix would put one person's
+-- credentials on another person's screen for a reason that only needs a count.
+create or replace function public.workspace_api_key_count(
+  p_workspace_id uuid,
+  p_user_id uuid
+)
+returns integer
+language plpgsql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  n integer;
+begin
+  if not public.is_workspace_admin(p_workspace_id) then
+    raise exception 'not an admin of this workspace' using errcode = '42501';
+  end if;
+
+  select count(*)
+    into n
+    from public.api_keys k
+   where k.workspace_id = p_workspace_id
+     and k.user_id = p_user_id
+     and k.revoked_at is null;
+
+  return n;
+end;
+$$;
+
+-- Reached through PostgREST, so it follows 0032's rule rather than 0021's:
+-- revoked from PUBLIC and granted back to the roles that actually call it.
+revoke execute on function public.workspace_api_key_count(uuid, uuid) from public;
+grant execute on function public.workspace_api_key_count(uuid, uuid) to authenticated, service_role;

--- a/tests/rls/api-keys.test.ts
+++ b/tests/rls/api-keys.test.ts
@@ -1,0 +1,218 @@
+/**
+ * What the database says about API keys.
+ *
+ * A key is a credential that becomes a person: the Worker looks it up, mints a
+ * short-lived token for its owner, and the request arrives as them. Everything
+ * downstream of that is already covered by the rest of this suite, because the
+ * request is indistinguishable from a browser's. What is NOT covered anywhere
+ * else is the `api_keys` table itself, and it holds the one thing in this
+ * database that is worth stealing on its own.
+ *
+ * So: a key is visible only to the person it belongs to, an update may revoke
+ * and rename and nothing else, revocation is one-way, and the count an admin can
+ * ask for is refused to everybody else.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeSql,
+  createTestUser,
+  destroyTestUsers,
+  serviceClient,
+  type TestUser,
+} from "./harness";
+
+let owner: TestUser;
+let colleague: TestUser;
+let outsider: TestUser;
+
+/** A key row, inserted as the person it belongs to, the way the route does. */
+async function createKey(user: TestUser, name: string, workspaceId = user.workspaceId) {
+  return user.db
+    .from("api_keys")
+    .insert({
+      workspace_id: workspaceId,
+      user_id: user.id,
+      name,
+      // Any distinct string: nothing in the database interprets it, and the
+      // hashing happens in the Worker.
+      token_hash: `hash-${name}-${user.id}`,
+      prefix: "covan_sk_aaaaaa",
+    })
+    .select("id")
+    .single();
+}
+
+beforeAll(async () => {
+  owner = await createTestUser("keys-owner");
+  colleague = await createTestUser("keys-colleague");
+  outsider = await createTestUser("keys-outsider");
+
+  const { error } = await serviceClient()
+    .from("workspace_members")
+    .insert({ workspace_id: owner.workspaceId, user_id: colleague.id, role: "member" });
+  if (error) throw new Error(`could not add the colleague: ${error.message}`);
+}, 60_000);
+
+afterAll(async () => {
+  await destroyTestUsers();
+  await closeSql();
+});
+
+describe("who can see a key", () => {
+  it("shows a key to nobody but its owner", async () => {
+    const { data: created, error } = await createKey(owner, "owner-visible");
+    expect(error).toBeNull();
+
+    const mine = await owner.db.from("api_keys").select("id").eq("id", created!.id);
+    expect(mine.data).toHaveLength(1);
+
+    // A colleague in the same workspace, and an admin of it, still sees nothing:
+    // the select policy has no admin branch, deliberately. A key acts as its
+    // owner, so listing somebody else's is listing their credentials.
+    const theirs = await colleague.db.from("api_keys").select("id").eq("id", created!.id);
+    expect(theirs.data).toEqual([]);
+
+    const strangers = await outsider.db.from("api_keys").select("id").eq("id", created!.id);
+    expect(strangers.data).toEqual([]);
+  });
+
+  it("refuses a key minted in somebody else's name", async () => {
+    const { error } = await colleague.db.from("api_keys").insert({
+      workspace_id: owner.workspaceId,
+      user_id: owner.id,
+      name: "not mine to make",
+      token_hash: "hash-impersonation",
+      prefix: "covan_sk_aaaaaa",
+    });
+
+    expect(error).not.toBeNull();
+  });
+
+  it("refuses a key in a workspace the caller is not in", async () => {
+    const { error } = await createKey(outsider, "wrong-workspace", owner.workspaceId);
+
+    expect(error).not.toBeNull();
+  });
+});
+
+describe("what an update may do", () => {
+  it("lets the owner revoke", async () => {
+    const { data: created } = await createKey(owner, "to-revoke");
+
+    const { data, error } = await owner.db
+      .from("api_keys")
+      .update({ revoked_at: new Date().toISOString() })
+      .eq("id", created!.id)
+      .select("id");
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+  });
+
+  it("refuses to un-revoke", async () => {
+    // Without this, revocation is reversible and a key revoked because it leaked
+    // comes back the moment the same request is replayed with a null.
+    const { data: created } = await createKey(owner, "stays-revoked");
+    await owner.db
+      .from("api_keys")
+      .update({ revoked_at: new Date().toISOString() })
+      .eq("id", created!.id);
+
+    const { error } = await owner.db
+      .from("api_keys")
+      .update({ revoked_at: null })
+      .eq("id", created!.id);
+
+    expect(error).not.toBeNull();
+  });
+
+  it("refuses to move the secret behind a row", async () => {
+    // Renaming is allowed; re-pointing is not. Otherwise "revoke a key" becomes
+    // "swap the credential a row's history is describing".
+    const { data: created } = await createKey(owner, "fixed-hash");
+
+    const renamed = await owner.db
+      .from("api_keys")
+      .update({ name: "a better name" })
+      .eq("id", created!.id)
+      .select("id");
+    expect(renamed.error).toBeNull();
+    expect(renamed.data).toHaveLength(1);
+
+    const rehashed = await owner.db
+      .from("api_keys")
+      .update({ token_hash: "hash-of-a-key-i-just-made-up" })
+      .eq("id", created!.id);
+    expect(rehashed.error).not.toBeNull();
+
+    const reowned = await owner.db
+      .from("api_keys")
+      .update({ user_id: colleague.id })
+      .eq("id", created!.id);
+    expect(reowned.error).not.toBeNull();
+  });
+
+  it("refuses an update to somebody else's key", async () => {
+    const { data: created } = await createKey(owner, "not-yours-to-revoke");
+
+    const { data } = await colleague.db
+      .from("api_keys")
+      .update({ revoked_at: new Date().toISOString() })
+      .eq("id", created!.id)
+      .select("id");
+
+    // No error, no rows: the policy hides it rather than refusing it, which is
+    // what RLS does on an UPDATE that matches nothing.
+    expect(data).toEqual([]);
+  });
+});
+
+describe("workspace_api_key_count", () => {
+  it("tells an admin how many live keys somebody has", async () => {
+    // The number the removal dialog needs: their keys die with their membership,
+    // and an admin who is not told finds out when a script stops overnight.
+    const { data: created } = await createKey(colleague, "colleagues-live-key", owner.workspaceId);
+
+    const { data, error } = await owner.db.rpc("workspace_api_key_count", {
+      p_workspace_id: owner.workspaceId,
+      p_user_id: colleague.id,
+    });
+
+    expect(error).toBeNull();
+    expect(data).toBeGreaterThanOrEqual(1);
+
+    // And a revoked key is not a live one.
+    const before = data as number;
+    await colleague.db
+      .from("api_keys")
+      .update({ revoked_at: new Date().toISOString() })
+      .eq("id", created!.id);
+
+    const after = await owner.db.rpc("workspace_api_key_count", {
+      p_workspace_id: owner.workspaceId,
+      p_user_id: colleague.id,
+    });
+    expect(after.data).toBe(before - 1);
+  });
+
+  it("raises for a member who is not an admin, rather than answering zero", async () => {
+    // 0032's rule: a definer function that returns an empty answer to somebody
+    // it should have refused is indistinguishable from an empty workspace.
+    const { error } = await colleague.db.rpc("workspace_api_key_count", {
+      p_workspace_id: owner.workspaceId,
+      p_user_id: owner.id,
+    });
+
+    expect(error).not.toBeNull();
+  });
+
+  it("raises for somebody outside the workspace entirely", async () => {
+    const { error } = await outsider.db.rpc("workspace_api_key_count", {
+      p_workspace_id: owner.workspaceId,
+      p_user_id: owner.id,
+    });
+
+    expect(error).not.toBeNull();
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -23,6 +23,7 @@ import { usage } from "./routes/usage";
 import { routines } from "./routes/routines";
 import { notifications } from "./routes/notifications";
 import { onboarding } from "./routes/onboarding";
+import { apiKeys } from "./routes/api-keys";
 
 const app = new Hono<AppEnv>();
 
@@ -124,6 +125,7 @@ api.route("/", usage);
 api.route("/", routines);
 api.route("/", notifications);
 api.route("/", onboarding);
+api.route("/", apiKeys);
 
 app.route("/", api);
 

--- a/worker/src/lib/api-keys.test.ts
+++ b/worker/src/lib/api-keys.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { Bindings } from "../types";
+import {
+  API_KEY_PREFIX,
+  generateApiKey,
+  hashApiKey,
+  looksLikeApiKey,
+  mintUserToken,
+  resolveApiKey,
+  touchApiKey,
+} from "./api-keys";
+
+/**
+ * The two things this file has to get right are the two that cannot be seen
+ * from a route test.
+ *
+ * A key must never be reconstructible from what is stored, and the token minted
+ * for its owner must be a token the project would actually accept — a signature
+ * that is subtly wrong fails at the first query, in a place that looks like a
+ * database problem rather than a signing one.
+ */
+
+const SECRET = "a-jwt-secret-that-is-long-enough-to-be-plausible";
+
+describe("the key itself", () => {
+  it("is recognisable without being parsed", async () => {
+    const { token } = await generateApiKey();
+
+    expect(looksLikeApiKey(token)).toBe(true);
+    // A Supabase session JWT is what the other branch of authMiddleware takes,
+    // and the two must never be confusable.
+    expect(looksLikeApiKey("eyJhbGciOiJIUzI1NiJ9.e30.sig")).toBe(false);
+  });
+
+  it("stores a hash and a head, and neither is the key", async () => {
+    const { token, tokenHash, prefix } = await generateApiKey();
+
+    expect(tokenHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(tokenHash).not.toContain(token);
+    expect(token.startsWith(prefix)).toBe(true);
+    // Enough to tell two rows apart in a list, nowhere near enough to guess.
+    expect(prefix.length).toBeLessThan(token.length / 2);
+  });
+
+  it("does not repeat itself", async () => {
+    const keys = await Promise.all(Array.from({ length: 50 }, () => generateApiKey()));
+
+    expect(new Set(keys.map((k) => k.token)).size).toBe(50);
+    expect(new Set(keys.map((k) => k.tokenHash)).size).toBe(50);
+  });
+
+  it("hashes the same key to the same digest, and different keys apart", async () => {
+    const a = `${API_KEY_PREFIX}aaaa`;
+    const b = `${API_KEY_PREFIX}aaab`;
+
+    expect(await hashApiKey(a)).toBe(await hashApiKey(a));
+    expect(await hashApiKey(a)).not.toBe(await hashApiKey(b));
+  });
+});
+
+describe("the token minted for a key's owner", () => {
+  const user = { id: "user-1", email: "a@example.com" } as never;
+
+  /** Decode without verifying — the claims are what these assertions are about. */
+  function claims(jwt: string): Record<string, unknown> {
+    const [, payload] = jwt.split(".");
+    return JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
+  }
+
+  it("names the user Postgres will resolve as auth.uid()", async () => {
+    const token = await mintUserToken(SECRET, user);
+
+    expect(claims(token).sub).toBe("user-1");
+    // Without this PostgREST stays in the anon role and every policy that
+    // mentions auth.uid() refuses, which would look like a permissions bug.
+    expect(claims(token).role).toBe("authenticated");
+    expect(claims(token).aud).toBe("authenticated");
+    expect(claims(token).email).toBe("a@example.com");
+  });
+
+  it("expires in a minute, so a captured one is worth nothing by the time it is read", async () => {
+    const token = await mintUserToken(SECRET, user);
+    const { iat, exp } = claims(token) as { iat: number; exp: number };
+
+    expect(exp - iat).toBe(60);
+    expect(exp * 1000).toBeGreaterThan(Date.now());
+  });
+
+  it("carries a signature the secret verifies and a different secret does not", async () => {
+    const token = await mintUserToken(SECRET, user);
+    const [header, payload, signature] = token.split(".");
+
+    const verify = async (secret: string) => {
+      const key = await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(secret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["verify"],
+      );
+      const b64 = signature.replace(/-/g, "+").replace(/_/g, "/");
+      const bytes = Uint8Array.from(atob(b64), (ch) => ch.charCodeAt(0));
+      return crypto.subtle.verify(
+        "HMAC",
+        key,
+        bytes,
+        new TextEncoder().encode(`${header}.${payload}`),
+      );
+    };
+
+    expect(await verify(SECRET)).toBe(true);
+    expect(await verify("not-the-project-secret")).toBe(false);
+  });
+
+  it("says HS256 in the header, which is what the project signs sessions with", async () => {
+    const [header] = (await mintUserToken(SECRET, user)).split(".");
+
+    expect(JSON.parse(atob(header))).toEqual({ alg: "HS256", typ: "JWT" });
+  });
+});
+
+// ---- lookup ----------------------------------------------------------------
+
+const getUserById = vi.fn();
+const from = vi.fn();
+const serviceClient = vi.fn((_env: unknown) => ({ from, auth: { admin: { getUserById } } }));
+
+vi.mock("./supabase", () => ({
+  serviceClient: (env: unknown) => serviceClient(env),
+}));
+
+const ENV = { SUPABASE_URL: "https://example.supabase.co" } as Bindings;
+
+/** One `from("api_keys")` chain, ending in `maybeSingle()` or a bare await. */
+function chain(result: { data: unknown; error: unknown }) {
+  const link = {
+    select: () => link,
+    eq: () => link,
+    is: () => link,
+    update: () => link,
+    maybeSingle: async () => result,
+    then: (resolve: (value: unknown) => unknown) => Promise.resolve(result).then(resolve),
+  };
+  return link;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveApiKey", () => {
+  it("answers with the key's owner", async () => {
+    from.mockReturnValue(
+      chain({
+        data: { id: "key-1", workspace_id: "ws-1", user_id: "user-1", last_used_at: null },
+        error: null,
+      }),
+    );
+    getUserById.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+
+    const resolved = await resolveApiKey(ENV, `${API_KEY_PREFIX}abc`);
+
+    expect(resolved?.keyId).toBe("key-1");
+    expect(resolved?.workspaceId).toBe("ws-1");
+    expect(resolved?.user).toEqual({ id: "user-1" });
+  });
+
+  it.each([
+    ["an unknown key", { data: null, error: null }],
+    ["a lookup that failed", { data: null, error: { message: "boom" } }],
+  ])("answers null for %s", async (_label, result) => {
+    from.mockReturnValue(chain(result));
+
+    await expect(resolveApiKey(ENV, `${API_KEY_PREFIX}abc`)).resolves.toBeNull();
+    // Nothing to look a user up for, so no second round trip is spent.
+    expect(getUserById).not.toHaveBeenCalled();
+  });
+
+  it("answers null when the owner's account is gone", async () => {
+    // The row outlives the account only until the cascade runs, and a request in
+    // that window must not be honoured as a user who no longer exists.
+    from.mockReturnValue(
+      chain({
+        data: { id: "key-1", workspace_id: "ws-1", user_id: "user-1", last_used_at: null },
+        error: null,
+      }),
+    );
+    getUserById.mockResolvedValue({ data: { user: null }, error: null });
+
+    await expect(resolveApiKey(ENV, `${API_KEY_PREFIX}abc`)).resolves.toBeNull();
+  });
+
+  it("looks the key up by hash and excludes revoked rows", async () => {
+    const filters: { method: string; args: unknown[] }[] = [];
+    const link = {
+      select: () => link,
+      eq: (...args: unknown[]) => (filters.push({ method: "eq", args }), link),
+      is: (...args: unknown[]) => (filters.push({ method: "is", args }), link),
+      maybeSingle: async () => ({ data: null, error: null }),
+    };
+    from.mockReturnValue(link);
+
+    const token = `${API_KEY_PREFIX}abc`;
+    await resolveApiKey(ENV, token);
+
+    // The plaintext must never appear in a query — what is stored is the digest,
+    // and asking by anything else would mean the column held the key itself.
+    expect(filters).toContainEqual({ method: "eq", args: ["token_hash", await hashApiKey(token)] });
+    expect(JSON.stringify(filters)).not.toContain(token);
+    expect(filters).toContainEqual({ method: "is", args: ["revoked_at", null] });
+  });
+});
+
+describe("touchApiKey", () => {
+  const key = { keyId: "key-1", workspaceId: "ws-1", user: { id: "user-1" } as never };
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("writes when the stored value is stale", async () => {
+    const update = vi.fn(() => ({ eq: async () => ({ data: null, error: null }) }));
+    from.mockReturnValue({ update });
+
+    await touchApiKey(ENV, { ...key, lastUsedAt: new Date(Date.now() - 3_600_000).toISOString() });
+
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes when there is no stored value at all", async () => {
+    const update = vi.fn(() => ({ eq: async () => ({ data: null, error: null }) }));
+    from.mockReturnValue({ update });
+
+    await touchApiKey(ENV, { ...key, lastUsedAt: null });
+
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not put a write in front of every request", async () => {
+    // The point of the throttle: a key used in a loop should cost one UPDATE
+    // every five minutes, not one per request.
+    const update = vi.fn(() => ({ eq: async () => ({ data: null, error: null }) }));
+    from.mockReturnValue({ update });
+
+    await touchApiKey(ENV, { ...key, lastUsedAt: new Date(Date.now() - 1_000).toISOString() });
+
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/worker/src/lib/api-keys.ts
+++ b/worker/src/lib/api-keys.ts
@@ -1,0 +1,193 @@
+import type { User } from "@supabase/supabase-js";
+import type { Bindings } from "../types";
+import { serviceClient } from "./supabase";
+
+/**
+ * API keys: a credential that outlives a browser session.
+ *
+ * The whole authorization model rests on `auth.uid()` resolving inside RLS, and
+ * an opaque key resolves to nothing on its own. So a key is not a second way to
+ * be authorized — it is a way to become the person who owns it. Look the key up,
+ * mint a very short-lived JWT for that user, and make the request with it. From
+ * Postgres's side nothing has changed, which is the property worth protecting:
+ * the alternative is re-implementing tenancy in the API, which
+ * `service-client.static.test.ts` exists to stop.
+ *
+ * Every request that arrives with a key pays for two round trips before it does
+ * any work — the key lookup and the user lookup. That is the price of not having
+ * a session, and it is bounded by the standard rate limit like anything else.
+ */
+
+/**
+ * What a Covan key looks like. The prefix is load-bearing rather than
+ * decorative: `authMiddleware` uses it to tell a key from a JWT without trying
+ * to parse either, and a secret scanner can match on it.
+ */
+export const API_KEY_PREFIX = "covan_sk_";
+
+/** How much of a key is shown in the interface so a row can be recognised. */
+const DISPLAY_PREFIX_LENGTH = API_KEY_PREFIX.length + 6;
+
+/**
+ * How long the minted token lives. Long enough for one request and its retries,
+ * short enough that a token captured in a log is worthless by the time anyone
+ * reads it. It is never returned to the caller and never leaves the Worker.
+ */
+const MINTED_TOKEN_TTL_SECONDS = 60;
+
+/**
+ * How stale `last_used_at` may get before it is worth a write. A forgotten key
+ * is recognised at this resolution, which is all the interface asks for; writing
+ * on every request would put an UPDATE in front of every read.
+ */
+const TOUCH_AFTER_MS = 5 * 60 * 1000;
+
+export function looksLikeApiKey(token: string): boolean {
+  return token.startsWith(API_KEY_PREFIX);
+}
+
+/** A new key, and the two things that get stored instead of it. */
+export async function generateApiKey(): Promise<{
+  token: string;
+  tokenHash: string;
+  prefix: string;
+}> {
+  // 32 bytes of CSPRNG, base64url so the whole key is one selectable word.
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const token = API_KEY_PREFIX + base64url(bytes);
+  return {
+    token,
+    tokenHash: await hashApiKey(token),
+    prefix: token.slice(0, DISPLAY_PREFIX_LENGTH),
+  };
+}
+
+/**
+ * SHA-256 hex, and deliberately not a password hash. The token is 32 random
+ * bytes, so there is no dictionary for bcrypt's slowness to defend against —
+ * it would cost Worker CPU on every request and buy nothing. What matters is
+ * that the database never holds anything that can be replayed.
+ */
+export async function hashApiKey(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export type ResolvedApiKey = {
+  keyId: string;
+  workspaceId: string;
+  user: User;
+  /** The stored value, so the caller can decide whether a write is worth it. */
+  lastUsedAt: string | null;
+};
+
+/**
+ * Turn a key into the person who owns it, or null.
+ *
+ * Null for every failure — unknown, revoked, or owned by a user who no longer
+ * exists — because the caller turns all of them into the same 401. Telling a
+ * holder which of those it was tells them something about a key they do not have.
+ *
+ * This is the fifth place in the API that reaches past RLS, and the reason is
+ * the same one `authClient` has: authentication cannot be performed by the
+ * caller's own client, because there is no caller yet. It goes no further than
+ * the row it was given a hash for.
+ */
+export async function resolveApiKey(env: Bindings, token: string): Promise<ResolvedApiKey | null> {
+  const admin = serviceClient(env);
+
+  const { data: row, error } = await admin
+    .from("api_keys")
+    .select("id, workspace_id, user_id, last_used_at")
+    .eq("token_hash", await hashApiKey(token))
+    .is("revoked_at", null)
+    .maybeSingle();
+
+  if (error || !row) return null;
+
+  // The authoritative source for the email the minted token has to carry, and
+  // the check that the account still exists at all — a deleted user leaves the
+  // row behind only until the cascade runs.
+  const { data: found, error: userError } = await admin.auth.admin.getUserById(
+    row.user_id as string,
+  );
+  if (userError || !found?.user) return null;
+
+  return {
+    keyId: row.id as string,
+    workspaceId: row.workspace_id as string,
+    user: found.user,
+    lastUsedAt: (row.last_used_at as string | null) ?? null,
+  };
+}
+
+/**
+ * A JWT the project will accept, for a user we have already identified.
+ *
+ * HS256 against the project's JWT secret, which is the same secret GoTrue signs
+ * a browser's session with — so the token below is indistinguishable from one,
+ * except that it expires in a minute and names no session. `role` is what
+ * PostgREST switches into, and `sub` is what `auth.uid()` reads; the rest is
+ * what the client libraries expect to find.
+ */
+export async function mintUserToken(secret: string, user: User): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return signHs256(secret, {
+    sub: user.id,
+    email: user.email ?? "",
+    role: "authenticated",
+    aud: "authenticated",
+    iat: now,
+    exp: now + MINTED_TOKEN_TTL_SECONDS,
+  });
+}
+
+/**
+ * Record that a key was used, if it has been long enough to be worth a write.
+ *
+ * Called through `deferred`, so it runs past the end of the response and a
+ * failure costs nothing — a `last_used_at` that is five minutes behind is not
+ * worth failing a request over.
+ */
+export async function touchApiKey(env: Bindings, key: ResolvedApiKey): Promise<void> {
+  const last = key.lastUsedAt ? Date.parse(key.lastUsedAt) : 0;
+  if (Number.isFinite(last) && Date.now() - last < TOUCH_AFTER_MS) return;
+
+  await serviceClient(env)
+    .from("api_keys")
+    .update({ last_used_at: new Date().toISOString() })
+    .eq("id", key.keyId);
+}
+
+// ---- signing ---------------------------------------------------------------
+
+function base64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function encodeSegment(value: object): string {
+  return base64url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+/**
+ * WebCrypto rather than a JWT library: both runtimes this ships on have it, and
+ * the whole of HS256 is one `sign` call. A dependency here would be a supply
+ * chain for eleven lines.
+ */
+async function signHs256(secret: string, payload: object): Promise<string> {
+  const body = `${encodeSegment({ alg: "HS256", typ: "JWT" })}.${encodeSegment(payload)}`;
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+
+  return `${body}.${base64url(new Uint8Array(signature))}`;
+}

--- a/worker/src/lib/dto.ts
+++ b/worker/src/lib/dto.ts
@@ -63,6 +63,20 @@ export type PendingInvitationDTO = {
   emailed?: boolean;
 };
 
+export type ApiKeyDTO = {
+  id: string;
+  name: string;
+  /** The visible head of the key, so a row can be told from its neighbours. */
+  prefix: string;
+  createdAt: number;
+  lastUsedAt: number | null;
+  /**
+   * The key itself, present exactly once: on the row returned when it is
+   * created. Nothing stores it, so no later request can put it back.
+   */
+  token?: string;
+};
+
 export type IncomingInvitationDTO = {
   id: string;
   workspaceId: string;

--- a/worker/src/lib/env.ts
+++ b/worker/src/lib/env.ts
@@ -103,6 +103,13 @@ export function loadEnv(source: Record<string, string | undefined> = process.env
     ALLOWED_ORIGIN: source.ALLOWED_ORIGIN!,
     WORKER_HOST: source.WORKER_HOST,
     ADMIN_API_KEY: source.ADMIN_API_KEY,
+    // Optional, and either name works. `SUPABASE_JWT_SECRET` is what the
+    // Cloudflare deployment sets; `JWT_SECRET` is what a self-hosted stack
+    // already has, because GoTrue and PostgREST are configured with it in the
+    // same .env. Accepting both means docker-compose gets API keys without the
+    // operator having to copy a value they already set once. Absent means the
+    // feature is simply off — see routes/api-keys.ts.
+    SUPABASE_JWT_SECRET: source.SUPABASE_JWT_SECRET || source.JWT_SECRET,
     // Optional on purpose: absent means the defaults in lib/ratelimit, so a
     // stack that was never configured is still bounded. `0` turns a tier off.
     RATE_LIMIT_STANDARD_PER_MINUTE: source.RATE_LIMIT_STANDARD_PER_MINUTE,

--- a/worker/src/middleware/auth.test.ts
+++ b/worker/src/middleware/auth.test.ts
@@ -24,11 +24,30 @@ vi.mock("../lib/supabase", () => ({
   userClient: (env: unknown, token: string) => userClient(env, token),
 }));
 
+const resolveApiKey = vi.fn(async (..._args: unknown[]): Promise<unknown> => null);
+const mintUserToken = vi.fn(async (..._args: unknown[]) => "minted-jwt");
+const touchApiKey = vi.fn(async (..._args: unknown[]) => {});
+
+vi.mock("../lib/api-keys", async () => {
+  // `looksLikeApiKey` is the real one: the branch it decides is the subject of
+  // half these tests, and a mocked predicate would be asserting on the mock.
+  const actual = await vi.importActual<typeof import("../lib/api-keys")>("../lib/api-keys");
+  return {
+    ...actual,
+    resolveApiKey: (...args: unknown[]) => resolveApiKey(...args),
+    mintUserToken: (...args: unknown[]) => mintUserToken(...args),
+    touchApiKey: (...args: unknown[]) => touchApiKey(...args),
+  };
+});
+
 const { authMiddleware } = await import("./auth");
+const { API_KEY_PREFIX } = await import("../lib/api-keys");
 
 /** Records what the middleware put on the context, if it let the request past. */
 function app() {
-  const seen: { user?: unknown; db?: unknown; reached: boolean } = { reached: false };
+  const seen: { user?: unknown; db?: unknown; apiKeyId?: unknown; reached: boolean } = {
+    reached: false,
+  };
 
   const server = new Hono<AppEnv>();
   server.use("/*", authMiddleware);
@@ -36,6 +55,7 @@ function app() {
     seen.reached = true;
     seen.user = c.get("user");
     seen.db = c.get("db");
+    seen.apiKeyId = c.get("apiKeyId");
     return c.json({ ok: true });
   });
 
@@ -44,6 +64,9 @@ function app() {
 
 /** Stands in for the Worker bindings; only its identity is asserted on. */
 const ENV = { SUPABASE_URL: "https://example.supabase.co" };
+
+/** The same, for a deployment that can mint tokens for API keys. */
+const KEYED_ENV = { ...ENV, SUPABASE_JWT_SECRET: "a-signing-secret" };
 
 const get = (server: Hono<AppEnv>, headers: Record<string, string> = {}) =>
   server.request("/probe", { headers }, ENV);
@@ -139,5 +162,116 @@ describe("authMiddleware", () => {
 
     expect(authGetUser).toHaveBeenCalledWith("padded-token");
     expect(userClient).toHaveBeenCalledWith(ENV, "padded-token");
+  });
+});
+
+/**
+ * The API-key branch.
+ *
+ * A key is not a second authorization model — it is a way to become the person
+ * who owns it, so that everything downstream, and every policy in Postgres, goes
+ * on working exactly as it does for a browser. These tests are about the seam:
+ * that a key is told apart from a session token without either being parsed,
+ * that the client handed on is built from the *minted* token rather than from
+ * the key, and that nothing gets through when the key does not resolve.
+ */
+describe("authMiddleware, with an API key", () => {
+  const KEY = `${API_KEY_PREFIX}0123456789abcdef`;
+  const USER = { id: "user-1", email: "a@example.com" };
+  const RESOLVED = { keyId: "key-1", workspaceId: "ws-1", user: USER, lastUsedAt: null };
+
+  const withKey = (server: Hono<AppEnv>, env: Record<string, unknown> = KEYED_ENV) =>
+    server.request("/probe", { headers: { Authorization: `Bearer ${KEY}` } }, env);
+
+  it("does not send a key to Supabase as if it were a session token", async () => {
+    resolveApiKey.mockResolvedValue(RESOLVED);
+    const { server } = app();
+
+    await withKey(server);
+
+    // getUser would answer 401 for a `covan_sk_` string, which is the right
+    // answer to the wrong question and would make every key look invalid.
+    expect(authGetUser).not.toHaveBeenCalled();
+    expect(resolveApiKey).toHaveBeenCalledWith(KEYED_ENV, KEY);
+  });
+
+  it("builds the data client from the minted token, never from the key", async () => {
+    resolveApiKey.mockResolvedValue(RESOLVED);
+    const { server, seen } = app();
+
+    await withKey(server);
+
+    expect(mintUserToken).toHaveBeenCalledWith("a-signing-secret", USER);
+    expect(userClient).toHaveBeenCalledWith(KEYED_ENV, "minted-jwt");
+    expect(seen.db).toEqual({ marker: "user-client", token: "minted-jwt" });
+    // The key is a credential, not a token any database would accept.
+    expect(userClient).not.toHaveBeenCalledWith(expect.anything(), KEY);
+  });
+
+  it("carries the key's owner as the caller", async () => {
+    resolveApiKey.mockResolvedValue(RESOLVED);
+    const { server, seen } = app();
+
+    const res = await withKey(server);
+
+    expect(res.status).toBe(200);
+    expect(seen.user).toEqual(USER);
+  });
+
+  it("marks the request as key-authenticated, so a route can refuse", async () => {
+    // Nothing here uses it; routes/api-keys.ts does, and without this flag a
+    // leaked key could write itself successors that revocation would not reach.
+    resolveApiKey.mockResolvedValue(RESOLVED);
+    const { server, seen } = app();
+
+    await withKey(server);
+
+    expect(seen.apiKeyId).toBe("key-1");
+  });
+
+  it.each([
+    ["an unknown or revoked key", null],
+    ["a key whose owner is gone", null],
+  ])("refuses %s", async (_label, resolved) => {
+    resolveApiKey.mockResolvedValue(resolved);
+    const { server, seen } = app();
+
+    const res = await withKey(server);
+
+    expect(res.status).toBe(401);
+    expect(seen.reached).toBe(false);
+    expect(userClient).not.toHaveBeenCalled();
+  });
+
+  it("refuses a key on a deployment that cannot sign a token for it", async () => {
+    const { server, seen } = app();
+
+    const res = await withKey(server, ENV);
+
+    expect(res.status).toBe(401);
+    expect(seen.reached).toBe(false);
+    // Not even looked up: without a secret there is nothing to do with a hit.
+    expect(resolveApiKey).not.toHaveBeenCalled();
+    await expect(res.json()).resolves.toEqual({
+      error: "api keys are not enabled on this deployment",
+    });
+  });
+
+  it("records the use after the response rather than before it", async () => {
+    resolveApiKey.mockResolvedValue(RESOLVED);
+    const { server } = app();
+
+    await withKey(server);
+
+    expect(touchApiKey).toHaveBeenCalledWith(KEYED_ENV, RESOLVED);
+  });
+
+  it("does not record a use for a key it refused", async () => {
+    resolveApiKey.mockResolvedValue(null);
+    const { server } = app();
+
+    await withKey(server);
+
+    expect(touchApiKey).not.toHaveBeenCalled();
   });
 });

--- a/worker/src/middleware/auth.ts
+++ b/worker/src/middleware/auth.ts
@@ -1,6 +1,8 @@
-import type { MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler, Next } from "hono";
 import type { AppEnv } from "../types";
 import { authClient, userClient } from "../lib/supabase";
+import { looksLikeApiKey, mintUserToken, resolveApiKey, touchApiKey } from "../lib/api-keys";
+import { deferred } from "../lib/defer";
 
 /**
  * Validates the `Authorization: Bearer <token>` header against Supabase auth,
@@ -11,6 +13,12 @@ import { authClient, userClient } from "../lib/supabase";
  * The `db` client is what downstream routes must use for data access — it
  * ensures Postgres RLS (`auth.uid()`) resolves to the caller, so tenant
  * isolation is enforced by the database, not by application code.
+ *
+ * Two kinds of credential arrive here and both end in the same place. A browser
+ * sends the session JWT GoTrue gave it. A script sends a `covan_sk_` API key,
+ * which is exchanged below for a sixty-second JWT belonging to the key's owner.
+ * What `c.set("db")` receives is a token-scoped client either way — the branch
+ * is about how the caller proved who they are, never about what they may do.
  */
 export const authMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
   const header = c.req.header("Authorization");
@@ -18,6 +26,10 @@ export const authMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
 
   if (!token) {
     return c.json({ error: "unauthorized" }, 401);
+  }
+
+  if (looksLikeApiKey(token)) {
+    return authenticateWithApiKey(c, token, next);
   }
 
   const { data, error } = await authClient(c.env).auth.getUser(token);
@@ -31,3 +43,40 @@ export const authMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
 
   await next();
 };
+
+/**
+ * The API-key half.
+ *
+ * `apiKeyId` on the context is not bookkeeping — it is what lets a route refuse
+ * to do something a key must not do, and the one that matters is minting more
+ * keys. Without it a leaked key writes itself permanent successors and revoking
+ * the original achieves nothing. See routes/api-keys.ts.
+ */
+async function authenticateWithApiKey(c: Context<AppEnv>, token: string, next: Next) {
+  const secret = c.env.SUPABASE_JWT_SECRET;
+
+  // No secret, no minting, so a key cannot be honoured however valid it looks.
+  // A deployment that has not set one has not turned this on; saying so is
+  // better than a 401 that reads like a bad key.
+  if (!secret) {
+    return c.json({ error: "api keys are not enabled on this deployment" }, 401);
+  }
+
+  const resolved = await resolveApiKey(c.env, token);
+
+  // Unknown, revoked, or owned by an account that no longer exists — one answer
+  // for all three. Distinguishing them tells a holder about a key they do not have.
+  if (!resolved) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  c.set("user", resolved.user);
+  c.set("db", userClient(c.env, await mintUserToken(secret, resolved.user)));
+  c.set("apiKeyId", resolved.keyId);
+
+  await next();
+
+  // After the response, and only if the stored value is stale enough to be
+  // worth a write. Nothing downstream should wait on bookkeeping.
+  deferred(c, touchApiKey(c.env, resolved));
+}

--- a/worker/src/routes/api-keys.test.ts
+++ b/worker/src/routes/api-keys.test.ts
@@ -1,0 +1,254 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import type { AppEnv } from "../types";
+import { activeWorkspaceTables, fakeDb, type FakeDbSpec } from "../test-support/fake-db";
+import { apiKeys } from "./api-keys";
+
+const USER = { id: "user-1", email: "a@example.com" };
+const WORKSPACE_ID = "workspace-1";
+
+const KEY_ROW = {
+  id: "key-1",
+  name: "Nightly report",
+  prefix: "covan_sk_ab12cd",
+  created_at: "2026-08-01T00:00:00.000Z",
+  last_used_at: null,
+};
+
+/**
+ * @param apiKeyId set it to pretend the caller proved themselves with a key
+ * rather than with a session — which is the whole subject of half this file.
+ */
+function appWith(spec: FakeDbSpec & { apiKeyId?: string; noJwtSecret?: boolean }) {
+  const { apiKeyId, noJwtSecret, ...dbSpec } = spec;
+  // A flag rather than `jwtSecret: undefined`, which a default parameter would
+  // quietly fill back in — the absence is the thing being tested.
+  const jwtSecret = noJwtSecret ? undefined : "a-signing-secret";
+  const { db, calls, callsTo } = fakeDb({
+    ...dbSpec,
+    tables: { ...activeWorkspaceTables(USER.id, WORKSPACE_ID), ...(dbSpec.tables ?? {}) },
+  });
+
+  const app = new Hono<AppEnv>();
+  app.use("/*", async (c, next) => {
+    c.set("user", USER as never);
+    c.set("db", db as never);
+    if (apiKeyId) c.set("apiKeyId", apiKeyId);
+    await next();
+  });
+  app.route("/", apiKeys);
+
+  return { app, calls, callsTo, env: { SUPABASE_JWT_SECRET: jwtSecret } };
+}
+
+async function json(
+  fixture: ReturnType<typeof appWith>,
+  method: string,
+  path: string,
+  body?: unknown,
+) {
+  const res = await fixture.app.request(
+    path,
+    {
+      method,
+      headers: body ? { "Content-Type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    },
+    fixture.env,
+  );
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe("GET /api-keys", () => {
+  it("asks only for the caller's own live keys", async () => {
+    let filters: { column: string; value: unknown; kind: string }[] = [];
+    const fixture = appWith({
+      tables: {
+        api_keys: {
+          select: (ctx) => {
+            filters = ctx.filters as typeof filters;
+            return { data: [KEY_ROW], error: null };
+          },
+        },
+      },
+    });
+
+    const { status, body } = await json(fixture, "GET", "/api-keys");
+
+    expect(status).toBe(200);
+    expect(body.available).toBe(true);
+    // The policy in 0033 is own-keys-only, and this filter agrees with it rather
+    // than leaning on it — the arrangement GET /invitations/incoming did not
+    // have, which is how an admin met their own outgoing invitations.
+    expect(filters).toContainEqual(expect.objectContaining({ column: "user_id", value: USER.id }));
+    // `.is`, not `.eq`: eq(column, null) sends the string "null" and matches
+    // nothing, which would quietly list revoked keys as live.
+    expect(filters).toContainEqual({ column: "revoked_at", value: null, kind: "is" });
+  });
+
+  it("never returns the hash, and has no column to return the key from", async () => {
+    const fixture = appWith({
+      tables: { api_keys: { select: () => ({ data: [KEY_ROW], error: null }) } },
+    });
+
+    const { body } = await json(fixture, "GET", "/api-keys");
+
+    expect(JSON.stringify(body)).not.toContain("token_hash");
+    expect((body.keys as Record<string, unknown>[])[0]).not.toHaveProperty("token");
+  });
+
+  it("says the feature is unavailable rather than that you have no keys", async () => {
+    // Two different sentences. Without a signing secret nothing could honour a
+    // key, so offering an empty list with a create button would be a lie.
+    const fixture = appWith({ noJwtSecret: true, tables: {} });
+
+    const { status, body } = await json(fixture, "GET", "/api-keys");
+
+    expect(status).toBe(200);
+    expect(body.available).toBe(false);
+    expect(body.keys).toEqual([]);
+  });
+});
+
+describe("POST /api-keys", () => {
+  it("returns the key once, and stores only its hash", async () => {
+    let inserted: Record<string, unknown> = {};
+    const fixture = appWith({
+      tables: {
+        api_keys: {
+          insert: (ctx) => {
+            inserted = ctx.values ?? {};
+            return { data: [KEY_ROW], error: null };
+          },
+        },
+      },
+    });
+
+    const { status, body } = await json(fixture, "POST", "/api-keys", { name: "Nightly report" });
+
+    expect(status).toBe(201);
+    expect(String(body.token)).toMatch(/^covan_sk_/);
+    // The row must not carry it. This is the assertion that would fail if
+    // somebody ever "helpfully" added a plaintext column to make listing easier.
+    expect(inserted).not.toHaveProperty("token");
+    expect(Object.values(inserted)).not.toContain(body.token);
+    expect(String(inserted.token_hash)).toMatch(/^[0-9a-f]{64}$/);
+    expect(inserted.user_id).toBe(USER.id);
+    expect(inserted.workspace_id).toBe(WORKSPACE_ID);
+  });
+
+  it.each([
+    ["an empty name", { name: "   " }],
+    ["no name at all", {}],
+    ["a name longer than the column allows", { name: "x".repeat(61) }],
+  ])("refuses %s", async (_label, payload) => {
+    const fixture = appWith({
+      tables: { api_keys: { insert: () => ({ data: [], error: null }) } },
+    });
+
+    const { status } = await json(fixture, "POST", "/api-keys", payload);
+
+    expect(status).toBe(400);
+  });
+
+  it("treats a policy refusal as forbidden, not as a fault", async () => {
+    const fixture = appWith({
+      tables: { api_keys: { insert: () => ({ data: [], error: null }) } },
+    });
+
+    const { status } = await json(fixture, "POST", "/api-keys", { name: "Nightly report" });
+
+    expect(status).toBe(403);
+  });
+
+  // The rule this whole feature rests on. A key that can create keys cannot be
+  // revoked: it writes successors the moment it leaks, and taking down the
+  // original leaves every one of them working.
+  it("refuses to mint a key for a caller who is already using one", async () => {
+    const fixture = appWith({
+      apiKeyId: "key-1",
+      tables: {
+        api_keys: {
+          insert: () => {
+            throw new Error("the route reached the database, which it must not");
+          },
+        },
+      },
+    });
+
+    const { status, body } = await json(fixture, "POST", "/api-keys", { name: "Another" });
+
+    expect(status).toBe(403);
+    expect(String(body.error)).toContain("sign in");
+  });
+
+  it("refuses when the deployment cannot sign a token to honour the key with", async () => {
+    const fixture = appWith({ noJwtSecret: true, tables: {} });
+
+    const { status } = await json(fixture, "POST", "/api-keys", { name: "Nightly report" });
+
+    expect(status).toBe(501);
+  });
+});
+
+describe("DELETE /api-keys/:id", () => {
+  it("revokes by writing a timestamp rather than removing the row", async () => {
+    let values: Record<string, unknown> = {};
+    let filters: { column: string; value: unknown; kind: string }[] = [];
+    const fixture = appWith({
+      tables: {
+        api_keys: {
+          update: (ctx) => {
+            values = ctx.values ?? {};
+            filters = ctx.filters as typeof filters;
+            return { data: [{ id: "key-1" }], error: null };
+          },
+          delete: () => {
+            throw new Error("revocation must not delete the row");
+          },
+        },
+      },
+    });
+
+    const { status } = await json(fixture, "DELETE", "/api-keys/key-1");
+
+    expect(status).toBe(200);
+    expect(values).toHaveProperty("revoked_at");
+    expect(filters).toContainEqual(expect.objectContaining({ column: "id", value: "key-1" }));
+    // Already-revoked rows are excluded, so a second revocation is a 404 rather
+    // than a silent success that moves the timestamp — 0033's trigger would
+    // refuse it anyway, and a route that relied on that would surface a 500.
+    expect(filters).toContainEqual({ column: "revoked_at", value: null, kind: "is" });
+  });
+
+  it("reports a key that is not the caller's as missing", async () => {
+    // RLS returns no rows rather than an error, and the route must not read that
+    // as success.
+    const fixture = appWith({
+      tables: { api_keys: { update: () => ({ data: [], error: null }) } },
+    });
+
+    const { status } = await json(fixture, "DELETE", "/api-keys/somebody-elses");
+
+    expect(status).toBe(404);
+  });
+
+  it("refuses a caller who is using a key", async () => {
+    // The other half of the rule above: a leaked key must not be able to revoke
+    // the keys somebody is still relying on.
+    const fixture = appWith({
+      apiKeyId: "key-1",
+      tables: {
+        api_keys: {
+          update: () => {
+            throw new Error("the route reached the database, which it must not");
+          },
+        },
+      },
+    });
+
+    const { status } = await json(fixture, "DELETE", "/api-keys/key-2");
+
+    expect(status).toBe(403);
+  });
+});

--- a/worker/src/routes/api-keys.ts
+++ b/worker/src/routes/api-keys.ts
@@ -1,0 +1,150 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import type { AppEnv } from "../types";
+import { toEpochMs } from "../lib/dto";
+import type { ApiKeyDTO } from "../lib/dto";
+import { getActiveWorkspaceId } from "../lib/workspace";
+import { generateApiKey } from "../lib/api-keys";
+
+const apiKeys = new Hono<AppEnv>();
+
+const createKeySchema = z.object({
+  // Trimmed inside the schema, the way invitations.ts does it: validating first
+  // and trimming after rejects "  Nightly report  " as too long or too short
+  // before the trim that would have made it fine.
+  name: z.string().trim().min(1).max(60),
+});
+
+/**
+ * Whether this deployment can honour a key at all.
+ *
+ * A key is exchanged for a minted JWT, and minting needs the project's signing
+ * secret. Without it the honest answer to "show me my API keys" is not an empty
+ * list — an empty list means "you have none" — but "this deployment does not do
+ * that". The interface leaves the section out rather than offering a button that
+ * creates a credential nothing would accept.
+ */
+function keysAreAvailable(c: { env: { SUPABASE_JWT_SECRET?: string } }): boolean {
+  return !!c.env.SUPABASE_JWT_SECRET;
+}
+
+/**
+ * What a key may not do: make another one.
+ *
+ * Everything else a key can reach is reached as its owner, and RLS decides —
+ * that is the whole design. This is the one place where acting as the owner is
+ * not enough, because a key that can mint keys cannot be revoked: the moment one
+ * leaks it writes successors, and revoking the original leaves every one of them
+ * working. The same goes for revocation itself, which a leaked key would
+ * otherwise use to take down the keys somebody was still relying on.
+ *
+ * So both writes require a session. This is a deliberate second permission
+ * system, and it is exactly one rule wide.
+ */
+function refuseIfKeyAuthenticated(c: { get: (k: "apiKeyId") => string | undefined }) {
+  return c.get("apiKeyId")
+    ? ({ error: "api keys cannot manage api keys — sign in to do this" } as const)
+    : null;
+}
+
+function mapKey(row: Record<string, unknown>): ApiKeyDTO {
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    prefix: row.prefix as string,
+    createdAt: toEpochMs(row.created_at as string),
+    lastUsedAt: row.last_used_at ? toEpochMs(row.last_used_at as string) : null,
+  };
+}
+
+// GET /api-keys — the caller's own live keys.
+//
+// Own, not "keys I am allowed to see": the select policy in 0033 is
+// own-keys-only and this filter agrees with it rather than leaning on it, which
+// is the arrangement GET /invitations/incoming learned the hard way.
+apiKeys.get("/api-keys", async (c) => {
+  if (!keysAreAvailable(c)) return c.json({ available: false, keys: [] });
+
+  const db = c.get("db");
+  const user = c.get("user");
+
+  const { data, error } = await db
+    .from("api_keys")
+    .select("id, name, prefix, created_at, last_used_at")
+    .eq("user_id", user.id)
+    .is("revoked_at", null)
+    .order("created_at", { ascending: false });
+
+  if (error) return c.json({ error: "failed to load api keys" }, 500);
+
+  return c.json({ available: true, keys: (data ?? []).map(mapKey) });
+});
+
+// POST /api-keys — create one, and return the plaintext for the only time.
+apiKeys.post("/api-keys", async (c) => {
+  if (!keysAreAvailable(c)) {
+    return c.json({ error: "api keys are not enabled on this deployment" }, 501);
+  }
+
+  const refusal = refuseIfKeyAuthenticated(c);
+  if (refusal) return c.json(refusal, 403);
+
+  const parsed = createKeySchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
+
+  const db = c.get("db");
+  const user = c.get("user");
+
+  const workspaceId = await getActiveWorkspaceId(db, user.id);
+  if (!workspaceId) return c.json({ error: "no workspace found for user" }, 404);
+
+  const { token, tokenHash, prefix } = await generateApiKey();
+
+  const { data, error } = await db
+    .from("api_keys")
+    .insert({
+      workspace_id: workspaceId,
+      user_id: user.id,
+      name: parsed.data.name,
+      token_hash: tokenHash,
+      prefix,
+    })
+    .select("id, name, prefix, created_at, last_used_at");
+
+  // The insert policy wants ownership and membership; a failure here is one of
+  // those, not a fault worth a 500.
+  if (error || !data || data.length === 0) {
+    return c.json({ error: "could not create a key in this workspace" }, 403);
+  }
+
+  // The one response that carries it. Nothing stores the plaintext, so a client
+  // that loses this has lost the key rather than mislaid it.
+  return c.json({ ...mapKey(data[0]), token }, 201);
+});
+
+// DELETE /api-keys/:id — revoke.
+//
+// A write of `revoked_at`, not a delete: the row is what says a key existed and
+// when it stopped, and 0033's trigger makes the change one-way so a revocation
+// cannot be replayed back into a working key.
+apiKeys.delete("/api-keys/:id", async (c) => {
+  const refusal = refuseIfKeyAuthenticated(c);
+  if (refusal) return c.json(refusal, 403);
+
+  const db = c.get("db");
+
+  const { data, error } = await db
+    .from("api_keys")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", c.req.param("id"))
+    .is("revoked_at", null)
+    .select("id");
+
+  if (error) return c.json({ error: "failed to revoke api key" }, 500);
+  if (!data || data.length === 0) {
+    return c.json({ error: "key not found or already revoked" }, 404);
+  }
+  return c.json({ ok: true });
+});
+
+export { apiKeys };

--- a/worker/src/service-client.static.test.ts
+++ b/worker/src/service-client.static.test.ts
@@ -34,6 +34,10 @@ const SERVICE_CLIENT_ALLOWLIST = new Map([
     "lib/routines/dispatcher.ts",
     "the scheduled Worker runs on a cron with no caller, so there is no JWT for RLS to resolve",
   ],
+  [
+    "lib/api-keys.ts",
+    "authentication, the same exemption authClient has: an API key is looked up before there is a caller for RLS to resolve, so there is no user client to do it with — it reads one row by hash and writes that row's last_used_at, and nothing else",
+  ],
 ]);
 
 /**

--- a/worker/src/test-support/fake-db.ts
+++ b/worker/src/test-support/fake-db.ts
@@ -26,7 +26,7 @@ export type QueryResult = {
   error: { message: string; code?: string } | null;
 };
 
-export type Filter = { column: string; value: unknown; kind: "eq" | "in" | "gt" | "ilike" };
+export type Filter = { column: string; value: unknown; kind: "eq" | "in" | "gt" | "ilike" | "is" };
 
 export type QueryContext = {
   table: string;
@@ -106,6 +106,15 @@ class Chain implements PromiseLike<QueryResult> {
 
   ilike(column: string, value: unknown) {
     this.ctx.filters.push({ column, value, kind: "ilike" });
+    return this;
+  }
+
+  // `.is(column, null)` is how PostgREST asks for a NULL, and it is not the
+  // same query as `.eq(column, null)` — which sends the literal string "null".
+  // Recorded as its own kind so a test can tell the two apart, because a route
+  // that reached for `eq` here would silently stop excluding revoked rows.
+  is(column: string, value: unknown) {
+    this.ctx.filters.push({ column, value, kind: "is" });
     return this;
   }
 

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -63,6 +63,20 @@ export type RoutineEnv = {
  */
 export type Bindings = RoutineEnv & {
   SUPABASE_ANON_KEY: string;
+  /**
+   * The project's JWT signing secret, and the one thing that makes API keys
+   * possible: a key is exchanged for a short-lived JWT for its owner, so the
+   * request reaches Postgres as that person and RLS decides as it always does.
+   * See `lib/api-keys.ts`.
+   *
+   * Optional, and its absence is a supported configuration rather than a
+   * misconfiguration — a deployment that never sets it simply has no API keys,
+   * and says so instead of failing. On Cloudflare: `wrangler secret put
+   * SUPABASE_JWT_SECRET`. On a self-hosted stack it is the same `JWT_SECRET` the
+   * rest of the compose file already uses, which is why `lib/env.ts` accepts
+   * either name.
+   */
+  SUPABASE_JWT_SECRET?: string;
   /** The R2 bucket, on Cloudflare only. Absent on the Node/Docker runtime. */
   DOCS?: R2Bucket;
   /** Filesystem document root, on the Node runtime only. Absent on Cloudflare. */
@@ -96,6 +110,12 @@ export type Variables = {
   db: SupabaseClient;
   /** What this caller may spend. Unmetered unless a hosted build says otherwise. */
   entitlements: Entitlements;
+  /**
+   * Set only when the caller proved themselves with an API key rather than a
+   * browser session. Routes read it to refuse the things a key must not do —
+   * chiefly creating another key, which would make revocation meaningless.
+   */
+  apiKeyId?: string;
 };
 
 export type AppEnv = {


### PR DESCRIPTION
There has been no way to hold a key to the REST API: the only credential is a browser session's bearer token, which expires in an hour and cannot be handed to a cron job. This is the API half; the Settings section and `docs/api.md` follow.

## What a key is

A key belongs to a **person** and acts as that person — the only shape that leaves the authorization model intact. Everything in this database gates on `auth.uid()`, so a credential that resolves to nobody would have to be scoped by application code, which is precisely what `service-client.static.test.ts` exists to prevent.

`authMiddleware` grows a branch: a token starting `covan_sk_` is looked up by its SHA-256, and on a hit a **sixty-second** HS256 JWT is minted for the key's owner and used to build the request-scoped client. Everything downstream is unchanged; Postgres cannot tell the request from a browser's.

The consequence is deliberate and stated in the migration: **when somebody leaves a workspace their keys stop working**, because their own access stopped working. `0033` adds `workspace_api_key_count` so the removal dialog can say so in advance rather than a script finding out at three in the morning.

## Two rules worth calling out

**A key cannot manage keys.** Without this a leaked key writes itself permanent successors and revoking the original achieves nothing — and the same guard stops a leaked key revoking the keys somebody is still relying on. Both writes require a session. A second permission system, exactly one rule wide.

**The feature is optional.** Minting needs the project's JWT secret. A deployment without `SUPABASE_JWT_SECRET` answers `available: false` rather than failing, so an install that never wanted API keys is not broken by them. `docker-compose.yml` passes the `JWT_SECRET` the stack already has, so a self-hosted Covan gets keys with no extra configuration.

## What is stored

A SHA-256 hash and a visible head — never the key. SHA-256 rather than bcrypt on purpose: the token is 32 CSPRNG bytes, so there is no dictionary for a slow hash to defend against, and it would spend Worker CPU on every request for nothing.

`last_used_at` is written through `deferred()` past the end of the response, and only when the stored value is already five minutes stale.

## Policies

Own-keys-only on all four verbs, with **no admin branch** — its absence is the point. An `or is_workspace_admin(...)` would be read next year as "admins may list a colleague's keys", and the route that meant "my keys" would quietly start answering "keys I am allowed to see". A trigger keeps an UPDATE to renaming and revoking, and makes revocation one-way so a revoked key cannot be replayed back into a working one.

## Tests

39 new. The ones that matter were each checked by deleting the code they guard: removing the key-cannot-manage-keys guard fails 2, removing the `user_id` filter on the list fails 1, removing the middleware branch entirely fails 8.

`tests/rls/api-keys.test.ts` covers visibility, impersonation, the trigger and the count function against a live database. It has not run locally — Docker is down on this machine — so the Row level security job here is its first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)