### PR TITLE
Say what a key can do, and what it costs to remove somebody

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,217 @@
+# The API
+
+Everything the interface does, it does through one HTTP API. There is no private
+back channel and no second set of endpoints: the web app is a client, and so is
+anything you write. This page is about reaching it from somewhere that cannot
+sign in — a script, a scheduled job, another service.
+
+## Getting a key
+
+Settings → **API keys** → **New key**. Give it a name you will recognise later,
+and copy the key when it is shown. It is shown once. Covan stores a SHA-256 hash
+of it and nothing else, so there is no screen — and no support request — that can
+produce it again. If you lose one, revoke it and make another.
+
+A key looks like this:
+
+```
+covan_sk_KJ8vQ2mR7tXbN4pL9wYcZ3aH6dF1sG5e
+```
+
+The `covan_sk_` prefix is not decoration. It is how the API tells a key from a
+session token without parsing either, and it is what a secret scanner matches on
+if the key ends up somewhere it should not.
+
+If the section is not in your Settings, this deployment has no API keys: minting
+requires the project's JWT signing secret, and an operator who has not set
+`SUPABASE_JWT_SECRET` has not turned the feature on. See
+[Self-hosting](self-hosting.md).
+
+## What a key can do
+
+**Exactly what you can do.** There are no scopes to choose, and that is a design
+decision rather than an omission.
+
+Authorization in Covan lives in Postgres — see
+[Architecture](architecture.md#authorization-is-postgres) — where every policy
+gates on `auth.uid()`. So the API does not check a key against a permission list.
+It looks the key up, mints a sixty-second token for the person who owns it, and
+makes the request as them. Postgres cannot tell your script from your browser,
+and every policy that would have applied to you still applies. A viewer's key can
+read and not write, because a viewer can read and not write.
+
+Scopes would be a second permission system standing next to that one, and two
+systems that disagree about the same question are worse than one. What a key
+gives up in granularity it gains in there being nothing to get wrong.
+
+Two things a key cannot do, both by explicit refusal:
+
+- **Create another key.** Otherwise a leaked key writes itself permanent
+  successors and revoking the original achieves nothing.
+- **Revoke a key.** Otherwise a leaked key takes down the keys you are relying
+  on.
+
+Both need a signed-in session. Everything else is open to a key.
+
+### A key belongs to a person
+
+Not to the workspace. When you leave a workspace — or an admin removes you —
+your keys stop working at the same moment your own access does, because they
+*are* your access. A script running on a departed colleague's key goes quiet.
+
+That is the correct behaviour and it is also the one that surprises people, so
+the removal dialog on the Team page says how many live keys somebody has before
+you remove them.
+
+Revoking is one-way. A revoked key cannot be restored, only replaced.
+
+## Making a request
+
+Send the key as a bearer token. The base URL for Covan Cloud is
+`https://api.covan.app`; a self-hosted install uses whatever address its API
+Worker answers on.
+
+```bash
+curl https://api.covan.app/agents \
+  -H "Authorization: Bearer $COVAN_API_KEY"
+```
+
+Bodies are JSON, and so are responses:
+
+```bash
+curl -X POST https://api.covan.app/sessions \
+  -H "Authorization: Bearer $COVAN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"agentId": "…", "title": "Nightly check"}'
+```
+
+The one endpoint that does not answer JSON is `POST /chat/stream`, which streams
+server-sent events — the same stream the chat window reads.
+
+### Errors
+
+| Status | What it means |
+| --- | --- |
+| `400` | The body failed validation. The response names the fields. |
+| `401` | No key, an unknown key, a revoked key, or a key on a deployment that cannot honour one. All four look the same on purpose. |
+| `403` | A policy refused. You are authenticated; you are not permitted. |
+| `404` | Not there, or not yours — Row Level Security returns nothing rather than admitting a row exists. |
+| `409` | A conflict, e.g. inviting somebody who is already a member. |
+| `429` | Rate limited. |
+| `501` | The deployment has not enabled this feature. |
+
+A `403` and a `404` are often the same underlying refusal seen from different
+angles: when a policy hides a row, the route cannot tell "you may not" from "it
+is not there", and it says the second because that is what it can prove.
+
+### Rate limits
+
+Two tiers, both per minute. The standard tier — 120 requests, keyed by address —
+stands in front of everything. The expensive tier — 20 requests, keyed by user —
+stands in front of the six endpoints that buy a completion or a transcription:
+`/chat/stream`, `/transcribe`, `/brainstorm/ideas/suggest`, `/persona/suggest`,
+`/routines/draft` and `/routines/:id/run`.
+
+A hosted workspace also has a monthly token allowance, which is a ceiling on the
+bill rather than on the rate. A self-hosted install has none: the operator brings
+their own OpenAI key and decides what to spend on it.
+
+## The endpoints
+
+Everything below is scoped to your active workspace unless it says otherwise.
+This is a map rather than a full reference — the request and response shapes are
+the ones `worker/src/routes/` accepts, and `src/lib/api-client.ts` is a typed
+client for all of it.
+
+### Agents
+
+| | |
+| --- | --- |
+| `GET /agents` | Every agent in the workspace |
+| `POST /agents` | Create one |
+| `PATCH /agents/:id` | Rename, re-persona, change model |
+| `DELETE /agents/:id` | Delete |
+| `POST /agents/:id/bundles/:bundleId` | Attach a knowledge bundle |
+| `DELETE /agents/:id/bundles/:bundleId` | Detach it |
+| `GET /favorites` · `POST /agents/:id/favorite` | Your own shortcuts |
+
+### Conversations
+
+| | |
+| --- | --- |
+| `GET /sessions` · `POST /sessions` | List and open conversations |
+| `PATCH /sessions/:id` · `DELETE /sessions/:id` | Rename, share, delete |
+| `GET /sessions/:id/messages` | The transcript |
+| `POST /messages` · `PATCH /messages/:id` | Write and edit your own lines |
+| `DELETE /messages/after/:id` | Truncate, for a re-ask |
+| `POST /chat/stream` | Ask. Streams SSE. |
+| `POST /transcribe` | Audio to text |
+
+A session is private to you unless its `visibility` is `shared`, in which case
+the workspace can read it. Assistant replies cannot be written by any client,
+including this one — see [Your team](team.md).
+
+### Knowledge
+
+| | |
+| --- | --- |
+| `GET /bundles` · `POST /bundles` | Subjects |
+| `PATCH /bundles/:id` · `DELETE /bundles/:id` | Rename, delete |
+| `POST /bundles/:id/documents/upload` | Upload a document |
+| `PATCH /documents/:id` · `DELETE /documents/:id` | Rename, move, delete |
+| `GET /documents/:id/download` | The original file |
+| `POST /documents/:id/reindex` | Re-chunk and re-embed |
+
+### Routines
+
+| | |
+| --- | --- |
+| `GET /routines` · `POST /routines` | Scheduled work |
+| `PATCH /routines/:id` · `DELETE /routines/:id` | Change, delete |
+| `POST /routines/:id/run` | Run now, rather than on schedule |
+| `GET /routines/:id/runs` | What happened |
+| `POST /routines/draft` | Turn a sentence into a routine |
+| `GET`/`POST`/`DELETE /delivery-channels` | Where output goes |
+
+### Workspace and people
+
+| | |
+| --- | --- |
+| `GET /me` · `PATCH /me` | You, and your display name |
+| `GET /workspaces` · `POST /workspaces` | Every workspace you are in |
+| `POST /workspace/active` | Switch which one requests are scoped to |
+| `PATCH /workspace` | Name, slug, default model. Admin. |
+| `PATCH`/`DELETE /workspace/members/:userId` | Change a role, remove somebody. Admin. |
+| `DELETE /workspace/members/me` | Leave |
+| `GET`/`POST`/`DELETE /invitations` | Invite and revoke. Admin. |
+| `GET /invitations/incoming` · `POST /invitations/:id/accept` | Yours to accept |
+
+### Usage and keys
+
+| | |
+| --- | --- |
+| `GET /usage` | Your own totals and what is left of your allowance |
+| `GET /usage/workspace` | Everyone's, by agent and by month. Admin. Never by person. |
+| `GET /api-keys` | Your own live keys. Never anyone else's. |
+| `POST /api-keys` · `DELETE /api-keys/:id` | Session only, as above |
+
+### Other
+
+`GET /health` is the only unauthenticated endpoint. It answers `{"ok": true}` and
+says nothing about anything else.
+
+`GET /notification-preferences` and `PATCH` on the same path carry your email
+preferences. `PATCH /onboarding` and `POST /onboarding/complete` back the first
+run.
+
+## Keeping a key safe
+
+A key is a password that does not expire and cannot be seen twice. Treat it that
+way: an environment variable or a secret store, never a repository, never a URL,
+never a log line. Give each job its own key so one can be revoked without
+stopping the others, and revoke anything you cannot place — the list in Settings
+shows when each key was last used precisely so a forgotten one is recognisable.
+
+If a key does leak: revoke it first, then look at what it could have reached,
+which is everything you can reach. A key cannot have created other keys, so
+revoking really is the end of it.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -108,7 +108,7 @@ every line in `.env.docker.example`, in the order it appears there.
 | `OPENAI_MODEL`                                         | _empty_                    | Optional. Forces one model for every completion, overriding the per-agent picker. Needed whenever `OPENAI_BASE_URL` is set.      |
 | `POSTGRES_PASSWORD`                                    | `covan-local-dev-password` | The database password. `auth`, `rest`, `realtime` and `migrate` all connect with it.                                             |
 | `POSTGRES_PORT`                                        | `54322`                    | **Host** port only, for `psql` or a GUI client. Inside the compose network Postgres is always on 5432.                           |
-| `JWT_SECRET`                                           | Supabase demo secret       | Signs and verifies every access token. Changing it invalidates `ANON_KEY` and `SERVICE_ROLE_KEY`, which are JWTs signed with it. |
+| `JWT_SECRET`                                           | Supabase demo secret       | Signs and verifies every access token. Changing it invalidates `ANON_KEY` and `SERVICE_ROLE_KEY`, which are JWTs signed with it. Also passed to the API as `SUPABASE_JWT_SECRET`, which is what makes API keys work — see [The API](api.md). |
 | `ANON_KEY`                                             | Supabase demo key          | The public API key. It reaches the browser by design; row level security is what protects the data behind it.                    |
 | `SERVICE_ROLE_KEY`                                     | Supabase demo key          | Bypasses row level security entirely. Server-side only — it must never reach a browser.                                          |
 | `JWT_EXPIRY`                                           | `3600`                     | Access-token lifetime in seconds. Refresh is automatic in the client.                                                            |
@@ -449,6 +449,7 @@ bunx wrangler secret put OPENAI_API_KEY
 bunx wrangler secret put ROUTINE_SECRET_KEY
 bunx wrangler secret put RESEND_API_KEY
 bunx wrangler secret put RESEND_FROM
+bunx wrangler secret put SUPABASE_JWT_SECRET
 ```
 
 `ROUTINE_SECRET_KEY` must decode to 16, 24 or 32 bytes — `openssl rand -base64
@@ -460,6 +461,15 @@ person yourself. Set one without the other and the two paths differ: an
 invitation checks for both and quietly reports that nothing was emailed, while a
 routine posts anyway and records whatever Resend answers as a failed run. So if
 you set one, set both.
+
+`SUPABASE_JWT_SECRET` is the project's JWT signing secret — Supabase dashboard,
+Settings → API — and it is what turns on [API keys](api.md). A key carries no
+identity of its own, so the API exchanges it for a sixty-second token belonging
+to the key's owner, and signing that needs this secret. Leave it out and the
+feature is simply absent: the section does not appear in Settings and the
+endpoints answer `available: false`, rather than anything failing. On a compose
+stack there is nothing to do — `docker-compose.yml` already passes the
+`JWT_SECRET` the rest of the stack uses.
 
 Pointing this deployment at a non-OpenAI endpoint works the same way as it does
 under Docker, except that neither value is a secret — add them to the `[vars]`

--- a/src/components/api-keys-section.test.tsx
+++ b/src/components/api-keys-section.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ApiKeysSection } from "./api-keys-section";
+import type { ApiKeyList } from "@/lib/api-client";
+
+const { useQuery, invalidateQueries, list, create, revoke, success, error } = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+  invalidateQueries: vi.fn(),
+  list: vi.fn(),
+  create: vi.fn(),
+  revoke: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery,
+  useQueryClient: () => ({ invalidateQueries }),
+}));
+
+// Mocked whole rather than partially: the real module constructs a Supabase
+// client at import time, which needs an origin no unit test has.
+vi.mock("@/lib/api-client", () => ({
+  api: { apiKeys: { list, create, revoke } },
+  ApiError: class ApiError extends Error {},
+}));
+
+vi.mock("sonner", () => ({ toast: { success, error } }));
+
+const KEY = {
+  id: "key-1",
+  name: "Nightly report",
+  prefix: "covan_sk_ab12cd",
+  createdAt: Date.parse("2026-08-01T00:00:00Z"),
+  lastUsedAt: null,
+};
+
+function renderWith(data: ApiKeyList | undefined, isLoading = false) {
+  useQuery.mockReturnValue({ data, isLoading });
+  render(<ApiKeysSection />);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("ApiKeysSection", () => {
+  it("lists a key by name and by the head of the key, never the whole thing", () => {
+    renderWith({ available: true, keys: [KEY] });
+
+    expect(screen.getByText("Nightly report")).toBeInTheDocument();
+    expect(screen.getByText(/covan_sk_ab12cd/)).toBeInTheDocument();
+    expect(screen.getByText(/never used/)).toBeInTheDocument();
+  });
+
+  it("says when a key was last used, once it has been", () => {
+    // "never used" is a fact worth stating; a dash where a date should be reads
+    // as data that failed to load.
+    renderWith({
+      available: true,
+      keys: [{ ...KEY, lastUsedAt: Date.now() - 60_000 }],
+    });
+
+    expect(screen.queryByText(/never used/)).not.toBeInTheDocument();
+    expect(screen.getByText(/last used/)).toBeInTheDocument();
+  });
+
+  it("renders nothing at all where the deployment cannot honour a key", () => {
+    // Not an empty list with a create button: minting needs a signing secret,
+    // and offering to make a credential nothing would accept is worse than
+    // offering nothing.
+    renderWith({ available: false, keys: [] });
+
+    expect(screen.queryByRole("button", { name: /new key/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/API keys/i)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing while the answer is still unknown", () => {
+    renderWith(undefined, true);
+
+    expect(screen.queryByRole("button", { name: /new key/i })).not.toBeInTheDocument();
+  });
+
+  it("says a key belongs to a person, not to the workspace", () => {
+    // The consequence people are surprised by, and the reason it is on the
+    // screen rather than only in the migration.
+    renderWith({ available: true, keys: [KEY] });
+
+    expect(screen.getByText(/leave this workspace and they stop working/i)).toBeInTheDocument();
+  });
+
+  it("shows the key once when it is created, and says so", async () => {
+    const user = userEvent.setup();
+    create.mockResolvedValue({ ...KEY, token: "covan_sk_thewholekey" });
+    renderWith({ available: true, keys: [] });
+
+    await user.click(screen.getByRole("button", { name: /new key/i }));
+    await user.type(screen.getByLabelText(/what is it for/i), "Nightly report");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+
+    expect(await screen.findByText("covan_sk_thewholekey")).toBeInTheDocument();
+    expect(create).toHaveBeenCalledWith("Nightly report");
+    // The promise the interface is making, and the one thing a person has to
+    // act on before closing the dialog.
+    expect(screen.getByText(/only time it is shown/i)).toBeInTheDocument();
+  });
+
+  it("copies the key rather than making it be retyped", async () => {
+    const user = userEvent.setup();
+    create.mockResolvedValue({ ...KEY, token: "covan_sk_thewholekey" });
+    renderWith({ available: true, keys: [] });
+
+    await user.click(screen.getByRole("button", { name: /new key/i }));
+    await user.type(screen.getByLabelText(/what is it for/i), "Nightly report");
+    await user.click(screen.getByRole("button", { name: /create key/i }));
+    await user.click(await screen.findByRole("button", { name: /copy key/i }));
+
+    // `userEvent.setup()` installs its own clipboard, so this reads back what
+    // the component actually put there rather than what it was asked to put.
+    await waitFor(async () =>
+      expect(await navigator.clipboard.readText()).toBe("covan_sk_thewholekey"),
+    );
+  });
+
+  it("will not create a key with no name", async () => {
+    const user = userEvent.setup();
+    renderWith({ available: true, keys: [] });
+
+    await user.click(screen.getByRole("button", { name: /new key/i }));
+
+    expect(screen.getByRole("button", { name: /create key/i })).toBeDisabled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("revokes a key and refreshes the list", async () => {
+    const user = userEvent.setup();
+    revoke.mockResolvedValue({ ok: true });
+    renderWith({ available: true, keys: [KEY] });
+
+    await user.click(screen.getByRole("button", { name: /revoke/i }));
+
+    await waitFor(() => expect(revoke).toHaveBeenCalledWith("key-1"));
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["api-keys"] });
+  });
+});

--- a/src/components/api-keys-section.tsx
+++ b/src/components/api-keys-section.tsx
@@ -1,0 +1,241 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, Copy, KeyRound } from "lucide-react";
+import { SectionHeading } from "@/components/page-container";
+import { SectionCard, DataRow, EmptyState } from "@/components/section-card";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { DocsLink } from "@/components/docs-link";
+import { api, ApiError, type ApiKey } from "@/lib/api-client";
+import { formatRelative } from "@/lib/relative-time";
+import { toast } from "sonner";
+
+/**
+ * Keys for the REST API.
+ *
+ * A key acts as **you**, which is the sentence the whole section is built
+ * around: there are no scopes to choose and no permissions to get wrong,
+ * because a key can do exactly what its owner can and every policy it meets
+ * says so. The corollary is the one people are surprised by, so it is written
+ * on the screen rather than left in a migration — leave the workspace and your
+ * keys stop working with you.
+ *
+ * Rendered only where the API can honour one. `available: false` is a
+ * deployment without `SUPABASE_JWT_SECRET`, where offering a create button
+ * would mint a credential nothing would accept.
+ */
+export function ApiKeysSection() {
+  const [creating, setCreating] = useState(false);
+  const { data, isLoading } = useQuery({ queryKey: ["api-keys"], queryFn: api.apiKeys.list });
+
+  if (isLoading || !data?.available) return null;
+
+  return (
+    <section className="mt-16">
+      <SectionHeading
+        title="API keys"
+        description="For scripts and scheduled jobs. A key does exactly what you can do — no more, and no less."
+      />
+
+      <SectionCard padded={false} className="mt-6 overflow-hidden">
+        {data.keys.length === 0 ? (
+          <EmptyState
+            title="No keys yet"
+            description="Create one to reach the API from somewhere that cannot sign in."
+          />
+        ) : (
+          <ul className="divide-y divide-hairline">
+            {data.keys.map((key) => (
+              <li key={key.id}>
+                <KeyRow apiKey={key} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </SectionCard>
+
+      <div className="mt-4 flex items-end justify-between gap-4">
+        <div className="space-y-1.5">
+          <p className="text-xs text-muted-foreground">
+            Keys are yours, not the workspace's — leave this workspace and they stop working the
+            same moment your own access does.
+          </p>
+          <DocsLink page="api">What the API accepts</DocsLink>
+        </div>
+        <Button onClick={() => setCreating(true)} className="shrink-0">
+          New key
+        </Button>
+      </div>
+
+      <CreateKeyDialog open={creating} onOpenChange={setCreating} />
+    </section>
+  );
+}
+
+function KeyRow({ apiKey }: { apiKey: ApiKey }) {
+  const queryClient = useQueryClient();
+  const [revoking, setRevoking] = useState(false);
+
+  const revoke = async () => {
+    setRevoking(true);
+    try {
+      await api.apiKeys.revoke(apiKey.id);
+      await queryClient.invalidateQueries({ queryKey: ["api-keys"] });
+      toast.success("Key revoked");
+    } catch (e) {
+      toast.error(e instanceof ApiError ? e.message : "Couldn't revoke that key");
+      setRevoking(false);
+    }
+  };
+
+  return (
+    <DataRow
+      icon={
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-hairline bg-surface">
+          <KeyRound className="h-4 w-4 text-muted-foreground" />
+        </span>
+      }
+      title={apiKey.name}
+      meta={
+        <>
+          <span className="font-mono">{apiKey.prefix}…</span>
+          {" · "}
+          {/* Never used reads as a fact; "last used —" reads as missing data. */}
+          {apiKey.lastUsedAt ? `last used ${formatRelative(apiKey.lastUsedAt)}` : "never used"}
+        </>
+      }
+      trailing={
+        <Button variant="ghost" size="sm" onClick={revoke} disabled={revoking} className="shrink-0">
+          {revoking ? "Revoking…" : "Revoke"}
+        </Button>
+      }
+    />
+  );
+}
+
+/**
+ * Create, then show the key exactly once.
+ *
+ * One dialog in two states rather than two dialogs: the second state is the
+ * result of the first, and a key that appears in a window the person did not
+ * expect is a key they close without reading. Nothing stores the plaintext, so
+ * there is no screen anywhere that can show it again — which is why closing is
+ * deliberately a button that says so.
+ */
+function CreateKeyDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [created, setCreated] = useState<string | null>(null);
+
+  const close = (v: boolean) => {
+    onOpenChange(v);
+    if (!v) {
+      setName("");
+      setCreated(null);
+    }
+  };
+
+  const submit = async () => {
+    if (!name.trim() || saving) return;
+    setSaving(true);
+    try {
+      const key = await api.apiKeys.create(name.trim());
+      await queryClient.invalidateQueries({ queryKey: ["api-keys"] });
+      setCreated(key.token);
+    } catch (e) {
+      toast.error(e instanceof ApiError ? e.message : "Couldn't create that key");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-lg">{created ? "Your new key" : "New API key"}</DialogTitle>
+        </DialogHeader>
+
+        {created ? (
+          <div className="space-y-4">
+            <RevealedKey token={created} />
+            <p className="text-xs text-muted-foreground">
+              This is the only time it is shown. Covan stores a hash of it, so nobody — including us
+              — can show it to you again. If you lose it, revoke it and make another.
+            </p>
+            <div className="flex justify-end">
+              <Button variant="ghost" onClick={() => close(false)}>
+                I've saved it
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2">
+              <Label className="text-xs" htmlFor="api-key-name">
+                What is it for
+              </Label>
+              <Input
+                id="api-key-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Nightly report script"
+                maxLength={60}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") submit();
+                }}
+              />
+              <p className="text-xs text-muted-foreground">
+                Only for you to recognise it later — a key you cannot place is a key nobody dares
+                revoke.
+              </p>
+            </div>
+
+            <div className="mt-4 flex justify-end">
+              <Button onClick={submit} disabled={saving || !name.trim()}>
+                {saving ? "Creating…" : "Create key"}
+              </Button>
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RevealedKey({ token }: { token: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard?.writeText(token).then(
+      () => {
+        setCopied(true);
+        // Long enough to be seen, short enough that the button goes back to
+        // being one — a permanently ticked button stops looking pressable.
+        setTimeout(() => setCopied(false), 2000);
+      },
+      () => toast.error("Couldn't copy — your browser blocked it."),
+    );
+  };
+
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-hairline bg-surface p-3">
+      {/* `break-all`, not truncation: a key you can only see half of is a key
+          you cannot check you pasted correctly. */}
+      <code className="min-w-0 flex-1 break-all font-mono text-xs">{token}</code>
+      <Button variant="ghost" size="sm" onClick={copy} className="shrink-0">
+        {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+        <span className="sr-only">Copy key</span>
+      </Button>
+    </div>
+  );
+}

--- a/src/components/live-key-warning.test.tsx
+++ b/src/components/live-key-warning.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LiveKeyWarning } from "./live-key-warning";
+
+const { useQuery, keyCount } = vi.hoisted(() => ({ useQuery: vi.fn(), keyCount: vi.fn() }));
+
+vi.mock("@tanstack/react-query", () => ({ useQuery }));
+vi.mock("@/lib/api-client", () => ({ api: { workspace: { members: { keyCount } } } }));
+
+function renderWith(data: { count: number | null } | undefined) {
+  useQuery.mockReturnValue({ data });
+  render(<LiveKeyWarning userId="user-2" />);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("LiveKeyWarning", () => {
+  it("says how many keys are about to stop, and what that costs", () => {
+    renderWith({ count: 2 });
+
+    expect(screen.getByText(/2 API keys that are still in use/)).toBeInTheDocument();
+    expect(screen.getByText(/go quiet/)).toBeInTheDocument();
+  });
+
+  it("reads as one sentence for one key", () => {
+    renderWith({ count: 1 });
+
+    expect(screen.getByText(/1 API key that is still in use/)).toBeInTheDocument();
+    expect(screen.queryByText(/keys that are/)).not.toBeInTheDocument();
+  });
+
+  it("says nothing when there is nothing to warn about", () => {
+    // The dialog it sits in already says what removal does. A line that says
+    // "0 keys" is a line that makes the reader stop and check.
+    renderWith({ count: 0 });
+
+    expect(screen.queryByText(/API key/)).not.toBeInTheDocument();
+  });
+
+  it("says nothing while the answer has not arrived", () => {
+    renderWith(undefined);
+
+    expect(screen.queryByText(/API key/)).not.toBeInTheDocument();
+  });
+
+  it("says nothing where the deployment cannot answer at all", () => {
+    // `count: null` is the window before 0033 is applied. A warning about a
+    // feature this install does not have would be a warning about nothing.
+    renderWith({ count: null });
+
+    expect(screen.queryByText(/API key/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/live-key-warning.tsx
+++ b/src/components/live-key-warning.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+
+/**
+ * The one thing removing somebody does destroy.
+ *
+ * The dialog this sits in says nothing is lost and invites them back to prove
+ * it, which is true of everything except this. An API key acts as its owner, so
+ * it stops the moment their membership does — and it does not come back with
+ * them, because revocation is one-way. A script running on that key simply goes
+ * quiet, at whatever hour it next runs.
+ *
+ * It asks only when the dialog is open, because that is when this component
+ * mounts. `count === null` is a deployment whose migration has not been applied
+ * yet, and an unanswerable question is one this dialog does not raise — a
+ * warning about a feature nobody here has is worse than no warning at all.
+ */
+export function LiveKeyWarning({ userId }: { userId: string }) {
+  const { data } = useQuery({
+    queryKey: ["api-keys", "count", userId],
+    queryFn: () => api.workspace.members.keyCount(userId),
+    // Admin-only on the server, and an admin is the only person who can open
+    // the dialog this lives in — but somebody who somehow does should see
+    // nothing rather than an error, so a refusal is an absent sentence.
+    retry: false,
+  });
+
+  const count = data?.count ?? 0;
+  if (count === 0) return null;
+
+  return (
+    <p className="text-sm text-muted-foreground">
+      They have {count} {count === 1 ? "API key that is" : "API keys that are"} still in use.{" "}
+      {count === 1 ? "It" : "They"} will stop working immediately, and anything scheduled against{" "}
+      {count === 1 ? "it" : "them"} will go quiet.
+    </p>
+  );
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -330,6 +330,13 @@ export const api = {
       remove: (userId: string): Promise<{ ok: true }> =>
         request("DELETE", `/workspace/members/${userId}`),
       /**
+       * How many live API keys somebody has, for the sentence in the removal
+       * dialog. `null` means the deployment cannot answer — the migration is not
+       * applied yet — which the dialog treats as "say nothing" rather than "none".
+       */
+      keyCount: (userId: string): Promise<{ count: number | null }> =>
+        request("GET", `/workspace/members/${userId}/key-count`),
+      /**
        * Leave the workspace you are currently in. `me` is a literal, not a user
        * id — the server resolves the caller from the session, so this cannot be
        * pointed at anybody else.
@@ -369,6 +376,13 @@ export const api = {
   },
   usage: (): Promise<UsageResponse> => request("GET", "/usage"),
   workspaceUsage: (): Promise<WorkspaceUsageResponse> => request("GET", "/usage/workspace"),
+  apiKeys: {
+    list: (): Promise<ApiKeyList> => request("GET", "/api-keys"),
+    /** The only response that carries the key itself. Nothing can return it again. */
+    create: (name: string): Promise<ApiKey & { token: string }> =>
+      request("POST", "/api-keys", { name }),
+    revoke: (id: string): Promise<{ ok: true }> => request("DELETE", `/api-keys/${id}`),
+  },
   notifications: {
     get: (): Promise<NotificationPreferences> => request("GET", "/notification-preferences"),
     update: (patch: Partial<NotificationPreferences>): Promise<NotificationPreferences> =>
@@ -471,3 +485,19 @@ export type WorkspaceUsageResponse = {
   totals: UsageTotals;
   months: UsageMonth[];
 };
+
+export type ApiKey = {
+  id: string;
+  name: string;
+  /** The visible head of the key. All of it that anything will ever show again. */
+  prefix: string;
+  createdAt: number;
+  lastUsedAt: number | null;
+};
+
+/**
+ * `available: false` means this deployment cannot sign the token an API key is
+ * exchanged for — no `SUPABASE_JWT_SECRET` — so keys are off rather than empty.
+ * Two different sentences, and the section renders nothing for the first.
+ */
+export type ApiKeyList = { available: boolean; keys: ApiKey[] };

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -27,6 +27,7 @@ export const DOC_SLUGS = [
   "knowledge",
   "routines",
   "team",
+  "api",
   "self-hosting",
   "architecture",
 ] as const;

--- a/src/routes/_authed.settings.tsx
+++ b/src/routes/_authed.settings.tsx
@@ -9,6 +9,7 @@ import { DeliveryChannelsCard } from "@/components/routines/delivery-channels-ca
 import { UsageSection } from "@/components/usage-section";
 import { WorkspaceUsageSection } from "@/components/workspace-usage-section";
 import { PreferencesSection } from "@/components/preferences-section";
+import { ApiKeysSection } from "@/components/api-keys-section";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -217,6 +218,12 @@ function SettingsPage() {
         {isAdmin && <WorkspaceUsageSection />}
 
         <DeliveryChannelsCard />
+
+        {/* Not gated on `isAdmin`: a key can do only what its holder can, so a
+            viewer holding one is a viewer, and there is nothing an admin needs
+            to approve. The section hides itself where the deployment cannot
+            honour a key at all. */}
+        <ApiKeysSection />
 
         {/* Both documents were reachable from exactly one place — the "I agree"
             checkbox on the sign-up form — so the moment somebody had an account

--- a/src/routes/_authed.team.tsx
+++ b/src/routes/_authed.team.tsx
@@ -32,6 +32,7 @@ import { canWriteAsRole, WORKSPACE_ROLES, type WorkspaceRole } from "@/lib/roles
 import { copyInviteText } from "@/lib/invite-text";
 import { formatRelative } from "@/lib/relative-time";
 import { InviteMemberDialog } from "@/components/invite-member-dialog";
+import { LiveKeyWarning } from "@/components/live-key-warning";
 import { toast } from "sonner";
 
 export const Route = createFileRoute("/_authed/team")({
@@ -252,6 +253,11 @@ function TeamPage() {
                                   including what the agents answered from your knowledge. Nothing is
                                   deleted: invite them back and it all returns.
                                 </AlertDialogDescription>
+                                {/* The exception to "nothing is deleted", and the
+                                    one nobody expects. A key acts as its owner, so
+                                    it stops working the moment they do — and a
+                                    script running on one just goes quiet. */}
+                                <LiveKeyWarning userId={m.id} />
                               </AlertDialogHeader>
                               <AlertDialogFooter>
                                 <AlertDialogCancel>Cancel</AlertDialogCancel>

--- a/worker/src/routes/workspace.test.ts
+++ b/worker/src/routes/workspace.test.ts
@@ -631,3 +631,79 @@ describe("DELETE /workspace/members/me", () => {
     expect((await json(app, "DELETE", "/workspace/members/me")).status).toBe(404);
   });
 });
+
+/**
+ * The one number an admin can learn about somebody else's credentials.
+ *
+ * `api_keys` is own-keys-only in 0033, deliberately and with the header to say
+ * why. This route is the exception carved for the removal dialog, and it is
+ * carved in the database rather than here — so what these tests are about is
+ * that the route does not add a second opinion on top of a definer function
+ * that already refused, and does not leak anything but the count.
+ */
+describe("GET /workspace/members/:userId/key-count", () => {
+  const rpcReturning = (result: { data: unknown; error: unknown }) => ({
+    workspace_api_key_count: () => result as never,
+  });
+
+  it("answers with the count and nothing that identifies a key", async () => {
+    const { app } = appWith({ rpc: rpcReturning({ data: 3, error: null }) });
+
+    const res = await json(app, "GET", "/workspace/members/user-2/key-count");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ count: 3 });
+  });
+
+  it("asks about the caller's own workspace, never one named in the URL", async () => {
+    let args: Record<string, unknown> = {};
+    const { app } = appWith({
+      rpc: {
+        workspace_api_key_count: (received) => {
+          args = received;
+          return { data: 0, error: null } as never;
+        },
+      },
+    });
+
+    await json(app, "GET", "/workspace/members/user-2/key-count");
+
+    expect(args.p_workspace_id).toBe(WORKSPACE);
+    expect(args.p_user_id).toBe("user-2");
+  });
+
+  it("passes the function's own refusal through as a 403", async () => {
+    // 0033 raises rather than answering zero, precisely so this is not
+    // indistinguishable from somebody who has no keys.
+    const { app } = appWith({
+      rpc: rpcReturning({ data: null, error: { code: "42501", message: "not an admin" } }),
+    });
+
+    expect((await json(app, "GET", "/workspace/members/user-2/key-count")).status).toBe(403);
+  });
+
+  it.each(["PGRST202", "42883"])(
+    "answers a null count while the migration is unapplied (%s)",
+    async (code) => {
+      // CI does not apply migrations. A count the dialog cannot get is a
+      // sentence it leaves out, not an error it puts in front of somebody
+      // trying to remove a member.
+      const { app } = appWith({
+        rpc: rpcReturning({ data: null, error: { code, message: "no such function" } }),
+      });
+
+      const res = await json(app, "GET", "/workspace/members/user-2/key-count");
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({ count: null });
+    },
+  );
+
+  it("still fails loudly on anything else", async () => {
+    const { app } = appWith({
+      rpc: rpcReturning({ data: null, error: { code: "57014", message: "canceling statement" } }),
+    });
+
+    expect((await json(app, "GET", "/workspace/members/user-2/key-count")).status).toBe(500);
+  });
+});

--- a/worker/src/routes/workspace.ts
+++ b/worker/src/routes/workspace.ts
@@ -283,4 +283,43 @@ workspace.delete("/workspace/members/:userId", async (c) => {
   return c.json({ ok: true });
 });
 
+// GET /workspace/members/:userId/key-count — how many live API keys somebody has.
+//
+// One number, for the dialog above it. A key acts as its owner, so removing
+// somebody stops their keys at the same moment it stops them — correct, and the
+// thing people are surprised by, so it is said before the button rather than
+// discovered when a script goes quiet overnight.
+//
+// The admin check is inside `workspace_api_key_count`, not here: `api_keys` is
+// own-keys-only by design and nothing else may read across it. The function
+// raises rather than answering zero, so "you are not an admin" and "they have no
+// keys" stay different answers — 0032's rule, and 0033 follows it.
+//
+// Nothing identifying comes back. A name or a prefix would put one person's
+// credentials on another person's screen for a question that only needs a count.
+workspace.get("/workspace/members/:userId/key-count", async (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+
+  const workspaceId = await getActiveWorkspaceId(db, user.id);
+  if (!workspaceId) return c.json({ error: "no workspace found for user" }, 404);
+
+  const { data, error } = await db.rpc("workspace_api_key_count", {
+    p_workspace_id: workspaceId,
+    p_user_id: c.req.param("userId"),
+  });
+
+  if (error) {
+    if (error.code === "42501") return c.json({ error: "admins only" }, 403);
+    // The window between deploying this and hand-applying 0033. A count the
+    // dialog cannot get is a sentence it leaves out, not an error it shows.
+    if (error.code === "PGRST202" || error.code === "42883") {
+      return c.json({ count: null });
+    }
+    return c.json({ error: "failed to count api keys" }, 500);
+  }
+
+  return c.json({ count: Number(data) || 0 });
+});
+
 export { workspace };


### PR DESCRIPTION
The interface for API keys, plus the reference page that could not be written until there was a credential to write about. The API half shipped in #38 with no interface on purpose.

## Settings → API keys

The list, a dialog that shows the key once and says so, a revoke per row. Each row carries the head of the key and either "last used …" or **"never used"** — a fact, where a dash would read as data that failed to load.

**Not gated on admin.** A key can do only what its holder can, so a viewer holding one is a viewer and every policy it meets says so. There is nothing for an admin to approve. The section hides itself entirely where the deployment cannot honour a key: minting needs a signing secret, and offering to create a credential nothing would accept is worse than offering nothing.

## The removal dialog now says what it destroys

That dialog says nothing is deleted and invites them back to prove it. True of everything except this — a key stops when its owner's access stops, and revocation is one-way, so it does not come back with them. A script running on a departed colleague's key just goes quiet at whatever hour it next runs.

`GET /workspace/members/:userId/key-count` backs it, and the admin check stays inside `workspace_api_key_count` rather than being repeated in the route. Nothing identifying comes back — a name or a prefix would put one person's credentials on another person's screen for a question that only needs a count.

## docs/api.md

The reference `docs/` has never had. How to get a key; **why there are no scopes** (authorization is Postgres, and a second permission system standing next to RLS is worse than one); the two things a key is refused and why; every endpoint the interface itself uses; what each status code means and why a 403 and a 404 are often the same refusal seen from different angles.

`docs/self-hosting.md` gains `SUPABASE_JWT_SECRET` in both places it belongs. On a compose stack there is nothing to do — `docker-compose.yml` already passes the `JWT_SECRET` the rest of the stack uses, so a self-hosted Covan gets API keys with no extra configuration.

## Not-yet-applied, again

`count: null` is the window before `0033` is applied. The dialog treats it as a sentence to leave out rather than an error to show — the same treatment `available: false` gets in the section, and for the same reason: nothing applies migrations for you.

## Tests

14 new. `LiveKeyWarning` came out of the route file into its own component so it could be tested at all. Both "renders nothing" guards were checked by deleting them: removing the `available` check fails 1, removing the zero-count check fails 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)