### PR TITLE
Grant on api_keys, and a tripwire for the next table

### DIFF
--- a/src/components/api-keys-section.test.tsx
+++ b/src/components/api-keys-section.test.tsx
@@ -36,8 +36,8 @@ const KEY = {
   lastUsedAt: null,
 };
 
-function renderWith(data: ApiKeyList | undefined, isLoading = false) {
-  useQuery.mockReturnValue({ data, isLoading });
+function renderWith(data: ApiKeyList | undefined, isLoading = false, isError = false) {
+  useQuery.mockReturnValue({ data, isLoading, isError });
   render(<ApiKeysSection />);
 }
 
@@ -72,6 +72,18 @@ describe("ApiKeysSection", () => {
 
     expect(screen.queryByRole("button", { name: /new key/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/API keys/i)).not.toBeInTheDocument();
+  });
+
+  it("says something broke rather than hiding, when the request fails", () => {
+    // The two used to be one branch, and that is why a missing table grant on
+    // production looked like a feature that had never shipped. "Not available"
+    // and "not working" are different sentences.
+    renderWith(undefined, false, true);
+
+    expect(screen.getByText(/couldn't load your keys/i)).toBeInTheDocument();
+    expect(screen.getByText(/fault rather than a setting/i)).toBeInTheDocument();
+    // And no create button, because there is nothing to create against.
+    expect(screen.queryByRole("button", { name: /new key/i })).not.toBeInTheDocument();
   });
 
   it("renders nothing while the answer is still unknown", () => {

--- a/src/components/api-keys-section.tsx
+++ b/src/components/api-keys-section.tsx
@@ -28,9 +28,34 @@ import { toast } from "sonner";
  */
 export function ApiKeysSection() {
   const [creating, setCreating] = useState(false);
-  const { data, isLoading } = useQuery({ queryKey: ["api-keys"], queryFn: api.apiKeys.list });
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["api-keys"],
+    queryFn: api.apiKeys.list,
+  });
 
-  if (isLoading || !data?.available) return null;
+  if (isLoading) return null;
+
+  // A failure is not the same as "this deployment does not do that", and the
+  // first version of this component treated them alike — one `!data?.available`
+  // covered both, so when the API answered 500 the section rendered nothing and
+  // the feature looked unshipped rather than broken. It took a probe against
+  // production to find out otherwise. Whatever went wrong, say that something
+  // did.
+  if (isError) {
+    return (
+      <section className="mt-16">
+        <SectionHeading title="API keys" />
+        <SectionCard className="mt-6">
+          <p className="text-sm text-muted-foreground">
+            Couldn't load your keys. This is a fault rather than a setting — try again, and tell
+            whoever runs this deployment if it persists.
+          </p>
+        </SectionCard>
+      </section>
+    );
+  }
+
+  if (!data?.available) return null;
 
   return (
     <section className="mt-16">

--- a/src/lib/migration-grants.test.ts
+++ b/src/lib/migration-grants.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * A table without a grant is invisible to every test we have.
+ *
+ * `0023_grants_supabase_no_longer_gives.sql` records the platform change behind
+ * this: Supabase used to give `anon`, `authenticated` and `service_role` full
+ * DML on any table added to `public`, and stopped. A migration that creates a
+ * table and does not grant for it produces a schema whose policies are all
+ * correct and whose every request answers `42501 permission denied`.
+ *
+ * 0023 closed it and wrote the rule — grant in the same file — and 0033, the
+ * first migration to add a table afterwards, broke it anyway. Nothing failed.
+ * Not the unit tests, and not `tests/rls/api-keys.test.ts`, which inserts and
+ * reads those very rows: both the compose stack and the Supabase CLI stack ship
+ * the old permissive default, so the missing grant is invisible to any database
+ * we are willing to test against. The one that shows it is production.
+ *
+ * So this checks the files rather than a database. It reads
+ * `supabase/migrations/` on disk, needs nothing running, and is right in CI, on
+ * a laptop, and in either repository — which is exactly what a guard for
+ * "something is different about production" has to be.
+ */
+
+const MIGRATIONS = join(process.cwd(), "supabase", "migrations");
+
+/**
+ * Tables that are deliberately reachable by no client role.
+ *
+ * `routine_deliveries` is written and read only by the scheduled Worker through
+ * the service-role client — 0023 revokes it from `anon` and `authenticated` on
+ * purpose, and `tests/rls/structure.test.ts` carries the same name in its own
+ * service-role-only list. An entry here is a decision, not an exemption from
+ * thinking.
+ */
+const NO_CLIENT_GRANT = new Set(["routine_deliveries"]);
+
+/**
+ * The one migration that creates a table and grants in a later file.
+ *
+ * 0033 is why this test exists. It reached production before the omission was
+ * found, and an applied migration is not rewritten — every database that ran it
+ * has it recorded — so the grant lives in 0034 and this entry says so out loud.
+ *
+ * It is a record of one mistake, not a mechanism. A second entry here would mean
+ * somebody chose to split a table from its grant, which is the arrangement 0023
+ * wrote its closing paragraph against.
+ */
+const GRANTED_LATE = new Map([["0033_a_key_that_is_a_person.sql", "granted by 0034"]]);
+
+/** `create table [if not exists] [public.]<name>`, across every migration. */
+function tablesCreatedIn(sql: string): string[] {
+  const matches = sql.matchAll(/create\s+table\s+(?:if\s+not\s+exists\s+)?(?:public\.)?(\w+)/gi);
+  return [...matches].map((m) => m[1]);
+}
+
+/** Whether this file grants something on that table to a client role. */
+function grantsFor(sql: string, table: string): boolean {
+  // Both shapes count: `grant ... on public.api_keys to authenticated` and
+  // 0023's `grant ... on all tables in schema public`.
+  const specific = new RegExp(`grant[\\s\\S]*?on\\s+(?:table\\s+)?(?:public\\.)?${table}\\b`, "i");
+  const blanket = /grant[\s\S]{0,80}on\s+all\s+tables\s+in\s+schema\s+public/i;
+  return specific.test(sql) || blanket.test(sql);
+}
+
+function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+}
+
+/** Every migration, oldest first, as `[filename, contents]`. */
+function migrations(): [string, string][] {
+  return migrationFiles().map((f) => [f, readFileSync(join(MIGRATIONS, f), "utf8")]);
+}
+
+describe("table grants", () => {
+  it("finds the migrations it is meant to be reading", () => {
+    // A guard on the guard: an empty directory would pass everything below.
+    expect(migrationFiles().length).toBeGreaterThan(20);
+  });
+
+  it("is granted by the same migration that creates the table", () => {
+    // The rule 0023 wrote, enforced. Everything before 0023 inherited the old
+    // platform default and is correct as it stands; re-litigating those files
+    // would only produce noise, so the rule starts where the rule started.
+    const offenders: string[] = [];
+
+    for (const [file, sql] of migrations()) {
+      if (file < "0023") continue;
+      if (GRANTED_LATE.has(file)) continue;
+      for (const table of tablesCreatedIn(sql)) {
+        if (NO_CLIENT_GRANT.has(table)) continue;
+        if (!grantsFor(sql, table)) offenders.push(`${file} creates ${table} and grants nothing`);
+      }
+    }
+
+    expect(
+      offenders,
+      "Supabase no longer grants DML on a new table — see 0023. Add " +
+        "`grant select, insert, update, delete on public.<table> to authenticated" +
+        "[, service_role];` to the same migration, or name the table in " +
+        "NO_CLIENT_GRANT if no client should ever reach it.",
+    ).toEqual([]);
+  });
+
+  it("grants for every table that exists today, somewhere", () => {
+    // The rule above only looks forward. This looks at the whole set, so a table
+    // created before 0023 and still ungranted anywhere would be caught too —
+    // 0023's blanket statement satisfies all of them, which is the point.
+    const all = migrations();
+    const created = new Set(all.flatMap(([, sql]) => tablesCreatedIn(sql)));
+
+    const ungranted = [...created]
+      .filter((t) => !NO_CLIENT_GRANT.has(t))
+      .filter((t) => !all.some(([, sql]) => grantsFor(sql, t)))
+      .sort();
+
+    expect(ungranted).toEqual([]);
+  });
+
+  it("keeps the late-grant list to the one mistake it records", () => {
+    // The exception above is a record, not a door. If this list grows, the rule
+    // it is an exception to has stopped being a rule.
+    expect([...GRANTED_LATE.keys()]).toEqual(["0033_a_key_that_is_a_person.sql"]);
+  });
+
+  it("names api_keys, which is the table this test exists because of", () => {
+    // Explicit rather than implied: the general rules above would keep passing
+    // if 0034 were reverted and 0033 rewritten, and this would not.
+    const all = migrations();
+    expect(all.some(([, sql]) => /grant[\s\S]*?on\s+public\.api_keys/i.test(sql))).toBe(true);
+  });
+});

--- a/supabase/migrations/0034_the_grant_0023_asked_for.sql
+++ b/supabase/migrations/0034_the_grant_0023_asked_for.sql
@@ -1,0 +1,45 @@
+-- 0034_the_grant_0023_asked_for.sql
+--
+-- `api_keys` was created in 0033 without the table grants it needs, and 0033 is
+-- the first migration to add a table since 0023 wrote the rule it broke:
+--
+--   "From here on a migration that adds a table grants for it, in the same file.
+--    Forgetting is loud — PostgREST returns 42501 — and a loud failure is worth
+--    more than an inherited grant nobody re-reads."
+--
+-- It was loud in the wrong place. Supabase stopped handing new tables to `anon`,
+-- `authenticated` and `service_role` — 0023 has the details — so on the hosted
+-- project every request to `api_keys` came back `42501 permission denied`, which
+-- routes/api-keys.ts turns into a 500, which the Settings section renders as
+-- nothing at all. The feature looked unshipped rather than broken.
+--
+-- ---- why nothing caught it -----------------------------------------------
+--
+-- The whole test suite is green, including tests/rls/api-keys.test.ts, which
+-- inserts and reads these rows for real. 0023 says why: the compose stack's
+-- Postgres image "still sets the wide default", and so does the Supabase CLI
+-- stack that CI runs the RLS job against. Both hand out the grant this file
+-- restores, so both hide its absence.
+--
+-- That is not something the RLS suite can be made to catch — it would have to
+-- run against a database configured the way production is, which is the one
+-- database it must never run against. So the tripwire is a static one over these
+-- files instead: src/lib/migration-grants.test.ts fails on a migration that
+-- creates a table in `public` and does not grant for it in the same file. It
+-- reads the directory, not a database, so it is right wherever it runs.
+--
+-- ---- the grant -----------------------------------------------------------
+--
+-- Not `anon`, which 0023's blanket statement did include. An API key belongs to
+-- a person and every policy on this table gates on `auth.uid()`, so there is no
+-- row a signed-out caller could ever be shown — and a grant that permits a read
+-- RLS will always refuse is a grant that only makes the next reader wonder.
+--
+-- `service_role` does need it: the key lookup in worker/src/lib/api-keys.ts runs
+-- before there is a caller for RLS to resolve, and BYPASSRLS skips the policies,
+-- not the grants.
+--
+-- Idempotent, like 0023: a database that already holds these is unchanged.
+
+grant select, insert, update, delete on public.api_keys to authenticated;
+grant select, insert, update, delete on public.api_keys to service_role;


### PR DESCRIPTION
`api_keys` was created without table grants, so on a Supabase project created after the platform change every request to it answers `42501 permission denied for table api_keys`. `routes/api-keys.ts` turns that into a 500 and the Settings section renders nothing — so the feature looks unshipped rather than broken.

`0023_grants_supabase_no_longer_gives.sql` had already written the rule this breaks, in its closing paragraph:

> From here on a migration that adds a table grants for it, in the same file. Forgetting is loud — PostgREST returns 42501 — and a loud failure is worth more than an inherited grant nobody re-reads.

`0033` is the first migration to add a table since, and it forgot.

## Why the whole suite stayed green

The same file says why. The compose stack's Postgres image and the Supabase CLI stack CI runs against both still ship the old permissive default, so they hand out the grant that is missing. `tests/rls/api-keys.test.ts` inserts and reads these rows for real, against a database where the omission cannot show.

So the guard cannot be a database test. `src/lib/migration-grants.test.ts` reads `supabase/migrations/` off disk and fails a migration that creates a table in `public` without granting for it in the same file. It needs nothing running, so it is right in CI, on a laptop, and on a fresh clone. It fails against `0033` as written — which is how I know it would have caught this.

`0033` is already applied on deployed installs, so it is not rewritten. `0034` carries the grant, and a one-entry `GRANTED_LATE` list records that split, with a test of its own that the list stays one entry long.

## Not `anon`

0023's blanket statement included it; this does not. Every policy on `api_keys` gates on `auth.uid()`, so there is no row a signed-out caller could be shown, and a grant permitting a read RLS will always refuse only makes the next reader wonder. `service_role` does need it — the key lookup runs before there is a caller for RLS to resolve, and BYPASSRLS skips policies, not grants.

## The reason this was invisible

One branch covered two different things:

```tsx
if (isLoading || !data?.available) return null;
```

A 500 and "this deployment does not do that" rendered identically. They are separate now, and a failure says so.

## To apply

`supabase/migrations/0034_the_grant_0023_asked_for.sql`. A compose stack does not need it — its image still grants by default — but running it changes nothing there, and a project on hosted Supabase does need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)