### PR TITLE
Say the API is available, now that a key exists

### DIFF
--- a/src/routes/_authed.integrations.tsx
+++ b/src/routes/_authed.integrations.tsx
@@ -15,9 +15,10 @@ export const Route = createFileRoute("/_authed/integrations")({
   }),
 });
 
-// No "beta" rung. The REST API was the only row that ever carried it, and it
-// has moved to the roadmap; a chip nothing renders is a chip nobody notices has
-// gone wrong. It belongs back the day there is a key you can hold. (No issue
+// No "beta" rung. The REST API was the only row that ever carried it; it went to
+// the roadmap on the day there was no key you could hold, and came back on the
+// day there was. It came back as "Available" rather than as a beta, because a
+// chip nothing else renders is a chip nobody notices has gone wrong. (No issue
 // number here on purpose: this file is byte-identical in covan-ai/covan, where
 // the same number is a different thing entirely.)
 type Status = "available" | "soon";
@@ -31,17 +32,21 @@ type Integration = {
 
 const items: Integration[] = [
   {
-    // On the roadmap even though the API exists and every screen in Covan runs
-    // on it, because what a caller needs is a credential they can hold, and
-    // there isn't one. `worker/src/middleware/auth.ts` accepts a Supabase JWT
-    // and nothing else; no migration defines an api_keys table, no route issues
-    // or revokes anything. So the only way in is to lift your own session token
-    // out of a browser, and it expires in an hour. That is not something a
-    // cron job can do, and listing it as available asked people to try.
+    // This row said "soon" for one reason — a caller needs a credential they
+    // can hold, and the only way in was a session token lifted out of a browser
+    // that expired in an hour. That reason is gone: `api_keys` exists,
+    // `worker/src/middleware/auth.ts` accepts a `covan_sk_` bearer token beside
+    // the Supabase JWT, and Settings mints and revokes them.
+    //
+    // Still "Call any shared agent", not "do anything": a key mints a short
+    // token for the person who owns it, so every policy that applies to them
+    // applies to it. The two things it cannot do — mint another key, revoke one
+    // — are refusals in `routes/api-keys.ts` rather than a smaller status, and
+    // `docs/api.md` is where a caller reads about them.
     name: "REST API",
-    desc: "Call any shared agent programmatically, once there is a key you can hold.",
+    desc: "Call any shared agent programmatically, with a key you mint in Settings.",
     icon: Code2,
-    status: "soon",
+    status: "available",
   },
   {
     // Shipped, but narrower than "Slack" sounds: an incoming-webhook URL you
@@ -97,7 +102,10 @@ function IntegrationsPage() {
   return (
     <AppShell>
       <PageContainer width="list">
-        <PageHeader badge="Integrations" title="One thing is wired." turn="The rest is coming." />
+        {/* The count is written out, so it has to be edited when a row moves.
+            It said "One thing" while two were live, which is the same mistake
+            the REST API row was making three lines up. */}
+        <PageHeader badge="Integrations" title="Two things are wired." turn="The rest is coming." />
 
         <section className="mt-14">
           <SectionHeading title="Available now" />


### PR DESCRIPTION
The REST API row said **"Coming soon"** and its comment said *no migration defines an `api_keys` table*. Both were true when written; neither has been since the key shipped:

- `supabase/migrations/0033_a_key_that_is_a_person.sql` and `0034_the_grant_0023_asked_for.sql`
- `worker/src/middleware/auth.ts` accepts a `covan_sk_` bearer token beside the Supabase JWT
- `worker/src/routes/api-keys.ts` + `src/components/api-keys-section.tsx` mint and revoke them

`docs/api.md` has described all of it correctly the whole time, so this page was the only place still saying the feature was not built.

**That is the same failure this row was created to fix, running the other way.** It was moved to the roadmap because listing an API nobody could hold a key to asked people to try something that could not work. Leaving it there once the key exists hides a feature from the people it was built for.

The description keeps its narrower claim — a key mints a short token for the person who owns it, so every policy that applies to them applies to it, and the two things it cannot do (mint another key, revoke one) are refusals in `routes/api-keys.ts` rather than a smaller status.

**The header was wrong the same way and by the same amount:** it read *"One thing is wired"* while two rows were live. The count is written out rather than derived — a deliberate choice about tone — so it now carries a comment saying it has to be edited when a row moves.

This file is byte-identical in `covan-ai/covan-cloud`; the same change goes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)