### PR TITLE
A door where 0016 only cleared the path

### DIFF
--- a/docs/team.md
+++ b/docs/team.md
@@ -42,8 +42,8 @@ and went on reporting "3 invitations sent" to people running an install with no
 mail at all. The sentence is now decided in one place for both of them.
 
 **"Tell them" comes with the words.** When nothing was emailed, the notice
-carries a *Copy invite text* action, and every waiting invitation on this page
-has a *Copy invite* button of its own — the durable version, for whenever the
+carries a _Copy invite text_ action, and every waiting invitation on this page
+has a _Copy invite_ button of its own — the durable version, for whenever the
 notice is long gone. What you get is a short message naming your Covan's address
 and the one address that will work:
 
@@ -73,12 +73,12 @@ somebody who was invited already has a workspace waiting, so walking them throug
 furnishing another one they are about to abandon would be the wrong order.
 
 **Only the invitee.** `invitations_select_admin_or_invitee` admits a row when the
-caller is an admin of the workspace *or* the row is addressed to them, which is
+caller is an admin of the workspace _or_ the row is addressed to them, which is
 right — the pending list on this page needs the first half. It is the wrong
 scope for the incoming banner, and that route used to lean on the policy for its
 scoping instead of saying which rows it meant. So an admin met their own
-outgoing invitations in it: *"You've been invited to \<your own workspace\> as
-\<the role you just granted somebody else\>"*, with an Accept button
+outgoing invitations in it: _"You've been invited to \<your own workspace\> as
+\<the role you just granted somebody else\>"_, with an Accept button
 `accept_invitation()` was always going to refuse, because it compares the
 address against the caller's own. The query now filters on the caller's address;
 the policy is untouched.
@@ -132,7 +132,7 @@ it; `create_workspace()` does the same for any workspace somebody makes later.
   removing a member — the invitation policies plus
   `workspace_members_update_admin` and `workspace_members_delete_admin`.
 
-It also *sees* one thing nobody else does — what the workspace as a whole has
+It also _sees_ one thing nobody else does — what the workspace as a whole has
 spent, by agent and by month — which is a read and not a control, and is
 described under [Usage figures](#usage-figures-are-yours-alone) below.
 
@@ -265,7 +265,7 @@ caveat named on the screen: changing an agent's model re-prices its history.
 
 This is the third thing admin governs, and the list above says two. Read it as
 "the workspace row, the people in it, and what the workspace costs" — the first
-two are what admin *controls*, and this one is only something it can *see*.
+two are what admin _controls_, and this one is only something it can _see_.
 
 The figures also now account for prompt caching. Most of what Covan sends the
 model on any given turn is the same bytes as last turn — the persona, the
@@ -396,12 +396,19 @@ pause outlives the rejoining, and only its owner can clear it.
 
 ## Deleting a workspace
 
-Not from the app. `workspaces` has select, update and insert policies and no
-delete policy at all, and no route anywhere calls for one, so there is no request
-any account can make that removes a workspace. It is an operator action, taken
-against the database, and the migration that made it possible says why it went
-unnoticed for so long: the first person to need it would have been somebody
-exercising a legal right to erasure.
+Not directly. `workspaces` has select, update and insert policies and no delete
+policy at all, so no request made _as you_ can remove one — deleting a workspace
+is an operator action taken against the database. The migration that made it
+possible says why it went unnoticed for so long: the first person to need it
+would have been somebody exercising a legal right to erasure.
+
+There is one indirect route, and it exists because of that same person. Closing
+your account (`DELETE /account`) deletes any workspace you were the last member
+of, with the service role rather than with your own credentials. It is not a
+"delete workspace" feature wearing a different hat: a workspace anybody else is
+still in is never touched, and being the last _admin_ of one refuses the whole
+deletion until the role is handed over. What it removes is a room with nobody
+left to enter it.
 
 Two of the references to a workspace do not cascade. `chat_sessions.workspace_id`
 and `ideas.workspace_id` were both added after the original schema and are plain
@@ -425,6 +432,13 @@ are then cleaned up is a question about the storage itself — a lifecycle rule 
 the bucket, or a sweep somebody runs — not one this codebase answers. If it is
 the latter, collect the keys before the rows go, because afterwards there is
 nothing left to enumerate them by.
+
+Account closure is the one place that does it for you, and it follows exactly
+that advice: `worker/src/routes/account.ts` reads the keys of every document in
+the workspaces it is about to remove, deletes the rows, and then deletes the
+objects. The difference is not technical but legal — for an ordinary delete an
+orphaned object is a storage cost, and for an erasure request it is the file
+still being there.
 
 What survives is the people. Deleting a workspace deletes no accounts, and the
 last-admin trigger stands aside for exactly this case rather than blocking it —

--- a/docs/team.md
+++ b/docs/team.md
@@ -413,7 +413,10 @@ left to enter it.
 Two of the references to a workspace do not cascade. `chat_sessions.workspace_id`
 and `ideas.workspace_id` were both added after the original schema and are plain
 references, so the tested procedure clears those two tables for the workspace
-first and then deletes the workspace row. A third,
+first and then deletes the workspace row. Account closure follows the same
+procedure for the same reason — a workspace with a single conversation in it
+cannot be deleted until that row is gone, which is every workspace anybody has
+actually used. A third,
 `profiles.active_workspace_id`, sets itself to null, which is the same state a
 fresh account is in and resolves to the person's oldest remaining membership.
 

--- a/src/components/close-account-section.test.tsx
+++ b/src/components/close-account-section.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CloseAccountSection } from "./close-account-section";
+
+// The error class is hoisted with the mocks rather than declared below them:
+// `vi.mock`'s factory runs before any top-level statement in this file, so a
+// class defined down there does not exist yet when the factory references it.
+const { close, signOut, FakeApiError } = vi.hoisted(() => ({
+  close: vi.fn(),
+  signOut: vi.fn(),
+  FakeApiError: class FakeApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+// Mocked whole rather than partially: the real module constructs a Supabase
+// client at import time, which needs an origin no unit test has.
+vi.mock("@/lib/api-client", () => ({
+  api: { account: { close } },
+  ApiError: FakeApiError,
+}));
+
+vi.mock("@/lib/supabase/client", () => ({ supabase: { auth: { signOut } } }));
+
+const EMAIL = "a@example.com";
+
+async function openDialog() {
+  await userEvent.click(screen.getByRole("button", { name: "Close my account" }));
+  return screen.getByRole("alertdialog");
+}
+
+/** The confirm button inside the dialog, not the trigger that shares its name. */
+function confirmButton() {
+  return screen.getAllByRole("button", { name: /Close my account|Closing/ }).at(-1)!;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  close.mockResolvedValue({ ok: true });
+  signOut.mockResolvedValue(undefined);
+});
+
+describe("CloseAccountSection", () => {
+  it("says what survives, not only what goes", async () => {
+    render(<CloseAccountSection email={EMAIL} />);
+    // The surprising half. Somebody closing an account assumes everything they
+    // touched leaves with them, and in a shared workspace it does not.
+    expect(screen.getByText(/keep running without you/i)).toBeInTheDocument();
+  });
+
+  it("refuses to enable the button until the address is typed exactly", async () => {
+    render(<CloseAccountSection email={EMAIL} />);
+    await openDialog();
+
+    expect(confirmButton()).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText(/to confirm/i), "a@example.co");
+    expect(confirmButton()).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText(/to confirm/i), "m");
+    expect(confirmButton()).toBeEnabled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("accepts the address whatever case it is typed in", async () => {
+    render(<CloseAccountSection email={EMAIL} />);
+    await openDialog();
+    await userEvent.type(screen.getByLabelText(/to confirm/i), "A@Example.com");
+    expect(confirmButton()).toBeEnabled();
+  });
+
+  it("signs out once the server has agreed", async () => {
+    render(<CloseAccountSection email={EMAIL} />);
+    await openDialog();
+    await userEvent.type(screen.getByLabelText(/to confirm/i), EMAIL);
+    await userEvent.click(confirmButton());
+
+    await waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+    // Holding a token for a user that no longer exists is how the next screen
+    // becomes a 401 nobody can explain.
+    await waitFor(() => expect(signOut).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the dialog open and shows which workspace is in the way", async () => {
+    close.mockRejectedValue(
+      new FakeApiError(
+        409,
+        "make someone else an admin first — a workspace cannot be left without one: Acme",
+      ),
+    );
+    render(<CloseAccountSection email={EMAIL} />);
+    await openDialog();
+    await userEvent.type(screen.getByLabelText(/to confirm/i), EMAIL);
+    await userEvent.click(confirmButton());
+
+    // The name is the whole point of the refusal — a count would send somebody
+    // hunting through the workspace switcher.
+    expect(await screen.findByText(/Acme/)).toBeInTheDocument();
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(signOut).not.toHaveBeenCalled();
+    // Still pressable: the person fixes the admin role and comes back to it.
+    expect(confirmButton()).toBeEnabled();
+  });
+
+  it("clears a refusal when the dialog is dismissed", async () => {
+    close.mockRejectedValue(new FakeApiError(409, "…: Acme"));
+    render(<CloseAccountSection email={EMAIL} />);
+    await openDialog();
+    await userEvent.type(screen.getByLabelText(/to confirm/i), EMAIL);
+    await userEvent.click(confirmButton());
+    await screen.findByText(/Acme/);
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await openDialog();
+
+    expect(screen.queryByText(/Acme/)).not.toBeInTheDocument();
+    // And the typed address is gone with it, so reopening is a fresh decision.
+    expect(confirmButton()).toBeDisabled();
+  });
+
+  it("cannot be confirmed at all when the email has not loaded", async () => {
+    render(<CloseAccountSection />);
+    await openDialog();
+    // An empty expected value would otherwise make an empty box a match.
+    expect(confirmButton()).toBeDisabled();
+  });
+});

--- a/src/components/close-account-section.tsx
+++ b/src/components/close-account-section.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { SectionHeading } from "@/components/page-container";
+import { SectionCard } from "@/components/section-card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { api, ApiError } from "@/lib/api-client";
+import { supabase } from "@/lib/supabase/client";
+
+/**
+ * Closing your account.
+ *
+ * The one thing on this page that cannot be undone, and the one thing the
+ * software is not allowed to make you ask a human for: erasure is a right under
+ * the GDPR and the KVKK rather than a courtesy, and until this shipped the only
+ * way to exercise it was an email to whoever ran the install.
+ *
+ * Two refusals can come back from the server and only one of them is knowable
+ * here. Being the last admin of a workspace other people are still in stops the
+ * deletion, and finding that out would mean asking for every workspace's member
+ * list up front — several requests, to render a sentence that is usually not
+ * needed. So the request itself is the check: the server deletes nothing before
+ * it decides, and a 409 names the workspaces in its message. The answer is
+ * shown **inside this dialog** rather than as a toast, because it is an
+ * instruction about what to go and do, not a notification that something
+ * happened.
+ */
+export function CloseAccountSection({ email }: { email?: string | null }) {
+  const [open, setOpen] = useState(false);
+  const [typed, setTyped] = useState("");
+  const [closing, setClosing] = useState(false);
+  const [refusal, setRefusal] = useState<string | null>(null);
+
+  // Typing the address, not the word DELETE. It is the one string on screen
+  // that is different for every person, so it cannot be muscle-memoried from
+  // the last confirmation dialog they saw.
+  const confirmed = !!email && typed.trim().toLowerCase() === email.toLowerCase();
+
+  const reset = (next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      setTyped("");
+      setRefusal(null);
+    }
+  };
+
+  const closeAccount = async () => {
+    if (closing || !confirmed) return;
+    setClosing(true);
+    setRefusal(null);
+    try {
+      await api.account.close();
+      // Signed out locally rather than left holding a token for a user that no
+      // longer exists. Every subsequent request would 401 anyway; this makes
+      // the screen agree with the database instead of failing its way there.
+      await supabase.auth.signOut();
+      window.location.href = "/";
+    } catch (e) {
+      setRefusal(
+        e instanceof ApiError
+          ? e.message
+          : "Couldn't close your account. Nothing has been deleted.",
+      );
+      setClosing(false);
+    }
+  };
+
+  return (
+    <section className="mt-16">
+      <SectionHeading title="Closing your account" />
+      <SectionCard className="mt-6 space-y-4">
+        <p className="text-sm leading-[1.5] text-muted-foreground">
+          This deletes your account and everything that belongs only to you — your conversations,
+          your API keys, and any workspace you are the last person in. It cannot be undone.
+        </p>
+        <p className="text-sm leading-[1.5] text-muted-foreground">
+          Workspaces you share with other people keep running without you. What you uploaded and
+          what you wrote there stays, because it belongs to the workspace rather than to you; your
+          name simply comes off it.
+        </p>
+
+        <div className="border-t border-hairline pt-4">
+          <AlertDialog open={open} onOpenChange={reset}>
+            <AlertDialogTrigger asChild>
+              <Button variant="ghost" className="text-destructive hover:bg-destructive/10">
+                Close my account
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Close your account?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  There is no undo and no grace period. Your conversations and API keys go, and any
+                  workspace you are the last person in goes with them.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+
+              <div className="space-y-2">
+                <Label htmlFor="confirm-email">
+                  Type <span className="font-mono text-foreground">{email ?? "your email"}</span> to
+                  confirm
+                </Label>
+                <Input
+                  id="confirm-email"
+                  value={typed}
+                  onChange={(e) => setTyped(e.target.value)}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+              </div>
+
+              {refusal ? (
+                // The 409 lands here. Nothing was deleted to produce it, so the
+                // dialog stays open with the reason in it and the button still
+                // available for after the person has fixed it.
+                <p className="text-sm leading-[1.45] text-destructive">{refusal}</p>
+              ) : null}
+
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={closing}>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={(e) => {
+                    // Kept open on purpose: the action would otherwise dismiss
+                    // the dialog before the server has answered, and a refusal
+                    // would have nowhere to be read.
+                    e.preventDefault();
+                    void closeAccount();
+                  }}
+                  disabled={!confirmed || closing}
+                >
+                  {closing ? "Closing…" : "Close my account"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </SectionCard>
+    </section>
+  );
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -383,6 +383,18 @@ export const api = {
       request("POST", "/api-keys", { name }),
     revoke: (id: string): Promise<{ ok: true }> => request("DELETE", `/api-keys/${id}`),
   },
+  account: {
+    /**
+     * Closes the caller's own account. The path carries no id — the server
+     * resolves the person from the session, so this cannot be pointed at
+     * anybody else, the same arrangement `members.leave` uses.
+     *
+     * A 409 is not a failure to retry: it means a workspace would be left
+     * without an admin, and the message names which. Nothing has been deleted
+     * when it arrives.
+     */
+    close: (): Promise<{ ok: true }> => request("DELETE", "/account"),
+  },
   notifications: {
     get: (): Promise<NotificationPreferences> => request("GET", "/notification-preferences"),
     update: (patch: Partial<NotificationPreferences>): Promise<NotificationPreferences> =>

--- a/src/routes/_authed.settings.tsx
+++ b/src/routes/_authed.settings.tsx
@@ -10,6 +10,7 @@ import { UsageSection } from "@/components/usage-section";
 import { WorkspaceUsageSection } from "@/components/workspace-usage-section";
 import { PreferencesSection } from "@/components/preferences-section";
 import { ApiKeysSection } from "@/components/api-keys-section";
+import { CloseAccountSection } from "@/components/close-account-section";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -224,6 +225,12 @@ function SettingsPage() {
             to approve. The section hides itself where the deployment cannot
             honour a key at all. */}
         <ApiKeysSection />
+
+        {/* Last on the page, under everything it would destroy. Not gated on a
+            role: erasure is the caller's own right and an admin has no say in
+            it — the only thing that can refuse is a workspace that would be
+            left without an admin, and the server says so by name. */}
+        <CloseAccountSection email={me?.user.email} />
 
         {/* Both documents were reachable from exactly one place — the "I agree"
             checkbox on the sign-up form — so the moment somebody had an account

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -22,6 +22,11 @@ import { LegalLayout, LegalSection, LegalList, LegalItem } from "@/components/le
  * — but that migration cleared the way, and nobody built the door. A page that
  * describes a permission as though it were a feature is wrong about the
  * product while being right about the database.
+ *
+ * The rule cuts both ways and the account paragraph is the proof: it said for
+ * months that erasure had no button, which was true when written and became
+ * false the day `worker/src/routes/account.ts` shipped. Building a capability
+ * puts this page in the change exactly as adding an outbound host does.
  */
 export const Route = createFileRoute("/privacy")({
   component: PrivacyPage,
@@ -117,14 +122,15 @@ function PrivacyPage() {
           deleting them removes the rows and the stored file rather than hiding them.
         </p>
         <p>
-          A whole workspace cannot. You can leave one, and an admin can remove someone from one, but
-          nothing in the interface deletes the workspace itself. The database is arranged so that it
-          could be; the route to ask for it has not been written.
+          Closing your account is in Settings, and it takes your conversations, your API keys and
+          any workspace you are the last person in with it. A workspace other people are still in
+          keeps running: what you made there stays and your name comes off it, which is why the one
+          case that is refused is being its last admin — hand the role over first.
         </p>
         <p>
-          Removing an account itself is not yet something the interface does either — that is a gap
-          being closed, not a decision. Until it is, whoever operates the install can delete the
-          user through Supabase, and the rows that belong to them go with it.
+          There is no separate button for deleting a shared workspace. You can leave one, and an
+          admin can remove someone from one, but dismantling a room other people are in is not
+          something one person does from this interface.
         </p>
         <p>
           What you sent to OpenAI is governed by OpenAI's own retention terms and is not something

--- a/tests/rls/deletion.test.ts
+++ b/tests/rls/deletion.test.ts
@@ -286,13 +286,21 @@ describe("deleting a person", () => {
     // the ordering below has become decoration and the comment above is wrong.
     await expect(db`delete from auth.users where id = ${erin.id}`).rejects.toThrow(/last admin/);
 
+    // The two references that do not cascade, cleared first — the same order
+    // the route uses, and the reason it has to. This is what the test caught:
+    // without it `delete from workspaces` fails on
+    // `chat_sessions_workspace_id_fkey` for every workspace anybody has used.
+    await db`delete from public.ideas where workspace_id = ${erin.workspaceId}`;
+    await db`delete from public.chat_sessions where workspace_id = ${erin.workspaceId}`;
     await db`delete from public.workspaces where id = ${erin.workspaceId}`;
     await db`delete from auth.users where id = ${erin.id}`;
 
+    // `chat_sessions` is not asserted here — it was deleted by name two lines
+    // up, so its absence would prove nothing. The test above it covers the
+    // cascade case.
     for (const [table, id] of [
       ["api_keys", key.id],
       ["profiles", erin.id],
-      ["chat_sessions", seeded.sessionId],
     ] as const) {
       const [{ count }] = await db<{ count: string }[]>`
         select count(*) from ${db(`public.${table}`)} where id = ${id}`;

--- a/tests/rls/deletion.test.ts
+++ b/tests/rls/deletion.test.ts
@@ -1,12 +1,16 @@
 /**
  * What happens when a workspace or a person goes away.
  *
- * Unlike the rest of this suite these are not policy tests — no user can delete
- * a workspace through the API, because `workspaces` has no delete policy, and
- * nobody can delete an account because there is no route for it. They run as
- * the operator does, over SQL, and they exist because 0016 fixed two things
- * that were impossible before it and could only have been discovered by
- * someone with a legal deadline.
+ * Unlike the rest of this suite these are not policy tests — `workspaces` has
+ * no delete policy and `auth.users` is outside RLS entirely, so both deletions
+ * happen with the service role. They run as `DELETE /account` does, over SQL,
+ * and they exist because 0016 fixed two things that were impossible before it
+ * and could only have been discovered by someone with a legal deadline.
+ *
+ * There is now a route on top of this — `worker/src/routes/account.ts` — and
+ * the order it uses is the subject of the last test here: the empty workspaces
+ * have to go first, or `trg_prevent_last_admin` refuses the membership row that
+ * the user's own cascade depends on.
  *
  * The other half of each test matters as much as the first: `trg_prevent_last_admin`
  * still has to refuse a member leaving a workspace un-owned. Making deletion
@@ -246,6 +250,49 @@ describe("deleting a person", () => {
       ["chat_sessions", seeded.sessionId],
       ["delivery_channels", seeded.channelId],
       ["routines", seeded.routineId],
+    ] as const) {
+      const [{ count }] = await db<{ count: string }[]>`
+        select count(*) from ${db(`public.${table}`)} where id = ${id}`;
+      expect(Number(count), `${table} outlived its owner`).toBe(0);
+    }
+  });
+
+  it("takes their API keys, in the order the route deletes things", async () => {
+    // Two claims in one test, because they are the same claim from either end.
+    //
+    // First: a key is a person, so it has to die with them. `0033` says so with
+    // `on delete cascade` and nothing else in the codebase asserts it — a later
+    // migration that recreated the table with a different clause would leave a
+    // working credential belonging to somebody who no longer exists, and every
+    // request it made would resolve to a user id that is gone.
+    //
+    // Second: the order. `prevent_last_admin_removal` asks only whether the
+    // workspace still stands and whether another admin remains — it never asks
+    // how many members are left, and everybody starts as the sole admin of
+    // their own. Deleting the user first is therefore refused for essentially
+    // every account there will ever be, which is why the route empties the
+    // workspaces nobody is left in before it touches `auth.users`.
+    const db = sql();
+    const erin = await createTestUser("erin");
+    const seeded = await seedWorkspace(erin);
+
+    const [key] = await db<{ id: string }[]>`
+      insert into public.api_keys (workspace_id, user_id, name, token_hash, prefix)
+      values (${erin.workspaceId}, ${erin.id}, 'Nightly report',
+              ${`hash-${erin.id}`}, 'covan_sk_ab12cd')
+      returning id`;
+
+    // The refusal, proven rather than assumed — if this ever stops throwing,
+    // the ordering below has become decoration and the comment above is wrong.
+    await expect(db`delete from auth.users where id = ${erin.id}`).rejects.toThrow(/last admin/);
+
+    await db`delete from public.workspaces where id = ${erin.workspaceId}`;
+    await db`delete from auth.users where id = ${erin.id}`;
+
+    for (const [table, id] of [
+      ["api_keys", key.id],
+      ["profiles", erin.id],
+      ["chat_sessions", seeded.sessionId],
     ] as const) {
       const [{ count }] = await db<{ count: string }[]>`
         select count(*) from ${db(`public.${table}`)} where id = ${id}`;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -24,6 +24,7 @@ import { routines } from "./routes/routines";
 import { notifications } from "./routes/notifications";
 import { onboarding } from "./routes/onboarding";
 import { apiKeys } from "./routes/api-keys";
+import { account } from "./routes/account";
 
 const app = new Hono<AppEnv>();
 
@@ -126,6 +127,7 @@ api.route("/", routines);
 api.route("/", notifications);
 api.route("/", onboarding);
 api.route("/", apiKeys);
+api.route("/", account);
 
 app.route("/", api);
 

--- a/worker/src/routes/account.test.ts
+++ b/worker/src/routes/account.test.ts
@@ -23,7 +23,7 @@ function serviceTables(spec: {
   bundles?: { id: string }[];
   documents?: { r2_key: string | null }[];
   deleteError?: { message: string };
-  onDelete?: (id: string) => void;
+  onDelete?: (table: string, id: string) => void;
   readError?: boolean;
 }) {
   return (table: string) => {
@@ -39,7 +39,7 @@ function serviceTables(spec: {
       in: () => link,
       delete: () => link,
       eq: (_column: string, value: string) => {
-        spec.onDelete?.(value);
+        spec.onDelete?.(table, value);
         return link;
       },
       then: (resolve: (value: unknown) => unknown) => Promise.resolve(result).then(resolve),
@@ -231,10 +231,10 @@ describe("DELETE /account", () => {
     expect(deleteUser).not.toHaveBeenCalled();
   });
 
-  it("deletes the empty workspaces before the user, not after", async () => {
+  it("clears what does not cascade, then the workspace, then the user", async () => {
     const order: string[] = [];
     serviceFrom.mockImplementation(
-      serviceTables({ onDelete: (id) => order.push(`workspace:${id}`) }),
+      serviceTables({ onDelete: (table, id) => order.push(`${table}:${id}`) }),
     );
     deleteUser.mockImplementation(async () => {
       order.push("user");
@@ -248,12 +248,15 @@ describe("DELETE /account", () => {
 
     expect(status).toBe(200);
     expect(body).toEqual({ ok: true });
-    // The trigger refuses the membership row while its workspace still stands,
-    // so this order is the whole reason the route works at all.
-    expect(order).toEqual(["workspace:solo", "user"]);
+    // Three orderings in one list, and each is load-bearing. `ideas` and
+    // `chat_sessions` reference a workspace without cascading, so the workspace
+    // delete fails on a foreign key until they are cleared — CI found that, not
+    // this file. The workspace goes before the user because the last-admin
+    // trigger refuses the membership row while its workspace still stands.
+    expect(order).toEqual(["ideas:solo", "chat_sessions:solo", "workspaces:solo", "user"]);
   });
 
-  it("leaves the account alone when a workspace delete fails", async () => {
+  it("leaves the account alone when a workspace cannot be cleared or deleted", async () => {
     serviceFrom.mockImplementation(serviceTables({ deleteError: { message: "nope" } }));
     const app = appWith({
       members: [{ workspace_id: "solo", user_id: USER.id, role: "admin" }],

--- a/worker/src/routes/account.test.ts
+++ b/worker/src/routes/account.test.ts
@@ -1,0 +1,333 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppEnv } from "../types";
+import { fakeDb, type FakeDbSpec, type QueryContext } from "../test-support/fake-db";
+import { account, planWorkspaces } from "./account";
+
+const USER = { id: "user-1", email: "a@example.com" };
+
+const deleteUser = vi.fn();
+const serviceFrom = vi.fn();
+const storeDelete = vi.fn();
+vi.mock("../lib/supabase", () => ({
+  serviceClient: () => ({ from: serviceFrom, auth: { admin: { deleteUser } } }),
+}));
+vi.mock("../lib/docstore", () => ({ getDocStore: () => ({ delete: storeDelete }) }));
+
+/**
+ * The service-role client, which this route uses for three different shapes:
+ * two `select().in()` reads for the storage keys and one `delete().eq()` per
+ * workspace. One builder answers all three, and records which ids were deleted.
+ */
+function serviceTables(spec: {
+  bundles?: { id: string }[];
+  documents?: { r2_key: string | null }[];
+  deleteError?: { message: string };
+  onDelete?: (id: string) => void;
+  readError?: boolean;
+}) {
+  return (table: string) => {
+    const result =
+      table === "knowledge_bundles"
+        ? { data: spec.bundles ?? [], error: spec.readError ? { message: "boom" } : null }
+        : table === "documents"
+          ? { data: spec.documents ?? [], error: spec.readError ? { message: "boom" } : null }
+          : { data: null, error: spec.deleteError ?? null };
+
+    const link = {
+      select: () => link,
+      in: () => link,
+      delete: () => link,
+      eq: (_column: string, value: string) => {
+        spec.onDelete?.(value);
+        return link;
+      },
+      then: (resolve: (value: unknown) => unknown) => Promise.resolve(result).then(resolve),
+    };
+    return link;
+  };
+}
+
+type Member = { workspace_id: string; user_id: string; role: string };
+
+/**
+ * @param members every membership row the caller's own client can see — their
+ * own rows and their fellow members', exactly as
+ * `workspace_members_select_fellow_members` grants.
+ * @param apiKeyId set it to pretend the caller arrived with a key rather than a
+ * session.
+ */
+function appWith(spec: {
+  members: Member[];
+  names?: Record<string, string>;
+  apiKeyId?: string;
+  membershipsError?: boolean;
+}) {
+  const dbSpec: FakeDbSpec = {
+    tables: {
+      workspace_members: {
+        select: (ctx: QueryContext) => {
+          if (spec.membershipsError) return { data: null, error: { message: "boom" } };
+          // The two reads are told apart the way the route makes them: the
+          // first is scoped by `eq("user_id")`, the second by `in("workspace_id")`.
+          const own = ctx.filters.some((f) => f.column === "user_id" && f.kind === "eq");
+          if (own) {
+            return {
+              data: spec.members
+                .filter((m) => m.user_id === USER.id)
+                .map((m) => ({ workspace_id: m.workspace_id, role: m.role })),
+              error: null,
+            };
+          }
+          const ids = (ctx.filters.find((f) => f.column === "workspace_id")?.value ??
+            []) as string[];
+          return { data: spec.members.filter((m) => ids.includes(m.workspace_id)), error: null };
+        },
+      },
+      workspaces: {
+        select: (ctx: QueryContext) => {
+          const ids = (ctx.filters.find((f) => f.column === "id")?.value ?? []) as string[];
+          return {
+            data: ids.map((id) => ({ id, name: spec.names?.[id] ?? id })),
+            error: null,
+          };
+        },
+      },
+    },
+  };
+
+  const { db } = fakeDb(dbSpec);
+  const app = new Hono<AppEnv>();
+  app.use("/*", async (c, next) => {
+    c.set("user", USER as never);
+    c.set("db", db as never);
+    if (spec.apiKeyId) c.set("apiKeyId", spec.apiKeyId);
+    await next();
+  });
+  app.route("/", account);
+  return app;
+}
+
+async function close(app: Hono<AppEnv>) {
+  const res = await app.request("/account", { method: "DELETE" }, {} as never);
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  deleteUser.mockResolvedValue({ data: null, error: null });
+  storeDelete.mockResolvedValue(undefined);
+  serviceFrom.mockImplementation(serviceTables({}));
+});
+
+describe("planWorkspaces", () => {
+  it("deletes a workspace nobody else is in", () => {
+    const plan = planWorkspaces(
+      "user-1",
+      [{ workspace_id: "ws-1", role: "admin" }],
+      [{ workspace_id: "ws-1", user_id: "user-1", role: "admin" }],
+    );
+    expect(plan).toEqual({ blocked: [], deletable: ["ws-1"] });
+  });
+
+  it("blocks a workspace where the caller is the only admin and others remain", () => {
+    const plan = planWorkspaces(
+      "user-1",
+      [{ workspace_id: "ws-1", role: "admin" }],
+      [
+        { workspace_id: "ws-1", user_id: "user-1", role: "admin" },
+        { workspace_id: "ws-1", user_id: "user-2", role: "member" },
+      ],
+    );
+    expect(plan).toEqual({ blocked: ["ws-1"], deletable: [] });
+  });
+
+  it("lets the account go when another admin is left to hold it", () => {
+    const plan = planWorkspaces(
+      "user-1",
+      [{ workspace_id: "ws-1", role: "admin" }],
+      [
+        { workspace_id: "ws-1", user_id: "user-1", role: "admin" },
+        { workspace_id: "ws-1", user_id: "user-2", role: "admin" },
+      ],
+    );
+    // Neither blocked nor deleted: the workspace keeps running without them,
+    // which is what `0016`'s "attribution survives its author" means in practice.
+    expect(plan).toEqual({ blocked: [], deletable: [] });
+  });
+
+  it("does not block a member who was never an admin", () => {
+    const plan = planWorkspaces(
+      "user-1",
+      [{ workspace_id: "ws-1", role: "member" }],
+      [
+        { workspace_id: "ws-1", user_id: "user-1", role: "member" },
+        { workspace_id: "ws-1", user_id: "user-2", role: "member" },
+      ],
+    );
+    // A workspace with no admin at all is somebody else's problem and not a
+    // reason to refuse this person their erasure.
+    expect(plan).toEqual({ blocked: [], deletable: [] });
+  });
+
+  it("deletes a sole membership even when the role is not admin", () => {
+    const plan = planWorkspaces(
+      "user-1",
+      [{ workspace_id: "ws-1", role: "member" }],
+      [{ workspace_id: "ws-1", user_id: "user-1", role: "member" }],
+    );
+    // The trigger would allow this row to go and leave an empty room behind.
+    expect(plan).toEqual({ blocked: [], deletable: ["ws-1"] });
+  });
+
+  it("sorts a mixed set into both piles at once", () => {
+    const plan = planWorkspaces(
+      "user-1",
+      [
+        { workspace_id: "solo", role: "admin" },
+        { workspace_id: "team", role: "admin" },
+        { workspace_id: "guest", role: "member" },
+      ],
+      [
+        { workspace_id: "solo", user_id: "user-1", role: "admin" },
+        { workspace_id: "team", user_id: "user-1", role: "admin" },
+        { workspace_id: "team", user_id: "user-2", role: "member" },
+        { workspace_id: "guest", user_id: "user-1", role: "member" },
+        { workspace_id: "guest", user_id: "user-3", role: "admin" },
+      ],
+    );
+    expect(plan).toEqual({ blocked: ["team"], deletable: ["solo"] });
+  });
+});
+
+describe("DELETE /account", () => {
+  it("refuses a caller who arrived with an API key", async () => {
+    const app = appWith({
+      members: [{ workspace_id: "ws-1", user_id: USER.id, role: "admin" }],
+      apiKeyId: "key-1",
+    });
+    const { status, body } = await close(app);
+
+    expect(status).toBe(403);
+    expect(body.error).toMatch(/api keys cannot close an account/);
+    // The refusal has to come before anything irreversible, not alongside it.
+    expect(deleteUser).not.toHaveBeenCalled();
+    expect(serviceFrom).not.toHaveBeenCalled();
+  });
+
+  it("names the workspaces standing in the way instead of counting them", async () => {
+    const app = appWith({
+      members: [
+        { workspace_id: "ws-1", user_id: USER.id, role: "admin" },
+        { workspace_id: "ws-1", user_id: "user-2", role: "member" },
+      ],
+      names: { "ws-1": "Acme" },
+    });
+    const { status, body } = await close(app);
+
+    expect(status).toBe(409);
+    expect(body.error).toContain("Acme");
+    expect(body.workspaces).toEqual(["Acme"]);
+    expect(deleteUser).not.toHaveBeenCalled();
+  });
+
+  it("deletes the empty workspaces before the user, not after", async () => {
+    const order: string[] = [];
+    serviceFrom.mockImplementation(
+      serviceTables({ onDelete: (id) => order.push(`workspace:${id}`) }),
+    );
+    deleteUser.mockImplementation(async () => {
+      order.push("user");
+      return { data: null, error: null };
+    });
+
+    const app = appWith({
+      members: [{ workspace_id: "solo", user_id: USER.id, role: "admin" }],
+    });
+    const { status, body } = await close(app);
+
+    expect(status).toBe(200);
+    expect(body).toEqual({ ok: true });
+    // The trigger refuses the membership row while its workspace still stands,
+    // so this order is the whole reason the route works at all.
+    expect(order).toEqual(["workspace:solo", "user"]);
+  });
+
+  it("leaves the account alone when a workspace delete fails", async () => {
+    serviceFrom.mockImplementation(serviceTables({ deleteError: { message: "nope" } }));
+    const app = appWith({
+      members: [{ workspace_id: "solo", user_id: USER.id, role: "admin" }],
+    });
+    const { status } = await close(app);
+
+    expect(status).toBe(500);
+    expect(deleteUser).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed deleteUser rather than claiming the account is gone", async () => {
+    deleteUser.mockResolvedValue({ data: null, error: { message: "still referenced" } });
+    const app = appWith({
+      members: [{ workspace_id: "solo", user_id: USER.id, role: "admin" }],
+    });
+    const { status, body } = await close(app);
+
+    expect(status).toBe(500);
+    expect(body.error).toMatch(/failed to close your account/);
+  });
+
+  it("closes an account that belongs to no workspace at all", async () => {
+    const app = appWith({ members: [] });
+    const { status } = await close(app);
+
+    expect(status).toBe(200);
+    expect(serviceFrom).not.toHaveBeenCalled();
+    expect(deleteUser).toHaveBeenCalledWith(USER.id);
+  });
+
+  it("removes the stored files of the workspaces it deletes", async () => {
+    serviceFrom.mockImplementation(
+      serviceTables({
+        bundles: [{ id: "bundle-1" }],
+        documents: [{ r2_key: "doc/one" }, { r2_key: null }, { r2_key: "doc/two" }],
+      }),
+    );
+    const app = appWith({ members: [{ workspace_id: "solo", user_id: USER.id, role: "admin" }] });
+    const { status } = await close(app);
+
+    expect(status).toBe(200);
+    // A row with no key is a document that was never uploaded, not a bug.
+    expect(storeDelete.mock.calls.map((c) => c[0])).toEqual(["doc/one", "doc/two"]);
+  });
+
+  it("still closes the account when the storage listing fails", async () => {
+    serviceFrom.mockImplementation(serviceTables({ readError: true }));
+    const app = appWith({ members: [{ workspace_id: "solo", user_id: USER.id, role: "admin" }] });
+    const { status } = await close(app);
+
+    // Refusing somebody their erasure over a storage bookkeeping problem would
+    // be the worse failure. The cost is bytes nobody can reach, and it is logged.
+    expect(status).toBe(200);
+    expect(deleteUser).toHaveBeenCalledWith(USER.id);
+  });
+
+  it("still closes the account when a stored file cannot be removed", async () => {
+    serviceFrom.mockImplementation(
+      serviceTables({ bundles: [{ id: "bundle-1" }], documents: [{ r2_key: "doc/one" }] }),
+    );
+    storeDelete.mockRejectedValue(new Error("r2 is having a day"));
+    const app = appWith({ members: [{ workspace_id: "solo", user_id: USER.id, role: "admin" }] });
+    const { status } = await close(app);
+
+    // The user is already gone by this point — there is nobody left to report
+    // it to, and answering 500 would tell them nothing happened when it did.
+    expect(status).toBe(200);
+  });
+
+  it("does not delete anything when the membership survey fails", async () => {
+    const app = appWith({ members: [], membershipsError: true });
+    const { status } = await close(app);
+
+    expect(status).toBe(500);
+    expect(deleteUser).not.toHaveBeenCalled();
+  });
+});

--- a/worker/src/routes/account.ts
+++ b/worker/src/routes/account.ts
@@ -1,0 +1,239 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+import { serviceClient } from "../lib/supabase";
+import { getDocStore } from "../lib/docstore";
+
+/**
+ * Closing an account.
+ *
+ * This is the one right that is not negotiable — GDPR Article 17 and the KVKK
+ * both make erasure a thing a person may demand rather than a feature an
+ * operator may offer — and until now the interface had no way to ask for it.
+ * The schema has been ready since `0016_deletable_users_and_workspaces.sql`,
+ * which removed six foreign keys that refused the cascade; what was missing was
+ * a door, and this file is it.
+ *
+ * Most of what follows is the database's work. `auth.users` cascades to
+ * memberships, sessions, messages, favorites, notifications and API keys, and
+ * the six attribution columns `0016` converted go to null rather than taking
+ * the row with them — a workspace does not evaporate because the person who
+ * opened it left.
+ *
+ * The exception is object storage, and it is the one thing here that has to be
+ * done by hand. No stored object belongs to a *person* — `documents.r2_key` is
+ * the only key in the schema and `documents` hangs off a bundle, which hangs
+ * off a workspace — but this route deletes workspaces too, and a workspace
+ * cascade takes the rows that name the keys while leaving the bytes. For an
+ * ordinary delete `documents.ts` calls that an acceptable storage cost. For
+ * erasure it is not a cost, it is the files still being there. So the keys are
+ * collected before the rows go, exactly as `docs/team.md` warns an operator to
+ * do, because afterwards there is nothing left to enumerate them by.
+ */
+const account = new Hono<AppEnv>();
+
+type Membership = { workspace_id: string; role: string };
+type Member = { workspace_id: string; user_id: string; role: string };
+
+/**
+ * What happens to the rooms somebody was in.
+ *
+ * `prevent_last_admin_removal` (`0016`) refuses to delete a `workspace_members`
+ * row when the workspace still exists, the row is an admin, and no other admin
+ * remains. It is doing the right thing for the case it was written for — a
+ * member walking out of a team — but it asks nothing about how many people are
+ * left, and everybody starts as the sole admin of their own workspace. Left
+ * alone it would refuse every account deletion there will ever be, including
+ * one from a person who never invited anybody.
+ *
+ * So the two cases are told apart here, once, rather than by the trigger:
+ *
+ * - **Somebody else is still in it.** Refused, and the workspace is named. This
+ *   is the product answer `0016` left open and `0020` had already chosen for
+ *   leaving: block until the role is handed over. A workspace full of people
+ *   must not lose its last admin, and it must not be silently handed to whoever
+ *   joined first either.
+ * - **Nobody else is in it.** The workspace is deleted with the account. There
+ *   is no role to hand over and nobody to hand it to; keeping it would leave a
+ *   room that no living person can enter, still holding the agents and
+ *   documents of somebody who asked to be forgotten.
+ *
+ * A sole member who is somehow not an admin lands in the second case too. The
+ * trigger would allow that row to go and leave an empty workspace behind, which
+ * is the same unreachable remains by a different route.
+ */
+export function planWorkspaces(
+  userId: string,
+  memberships: Membership[],
+  members: Member[],
+): { blocked: string[]; deletable: string[] } {
+  const blocked: string[] = [];
+  const deletable: string[] = [];
+
+  for (const { workspace_id: id } of memberships) {
+    const others = members.filter((m) => m.workspace_id === id && m.user_id !== userId);
+    if (others.length === 0) {
+      deletable.push(id);
+      continue;
+    }
+    const mine = members.find((m) => m.workspace_id === id && m.user_id === userId);
+    const otherAdmins = others.filter((m) => m.role === "admin");
+    if (mine?.role === "admin" && otherAdmins.length === 0) blocked.push(id);
+  }
+
+  return { blocked, deletable };
+}
+
+/**
+ * Every stored object about to lose the row that names it.
+ *
+ * Best-effort on the read as well as the write: a workspace whose bundles or
+ * documents cannot be listed still gets deleted, because refusing to close an
+ * account over a storage bookkeeping problem would be the worse failure. What
+ * it costs is bytes nobody can reach, and the log line says which.
+ */
+async function collectDocumentKeys(
+  admin: ReturnType<typeof serviceClient>,
+  workspaceIds: string[],
+): Promise<string[]> {
+  if (workspaceIds.length === 0) return [];
+
+  const { data: bundles, error: bundlesError } = await admin
+    .from("knowledge_bundles")
+    .select("id")
+    .in("workspace_id", workspaceIds);
+
+  if (bundlesError) {
+    console.error("account deletion: could not list bundles to clean up", bundlesError);
+    return [];
+  }
+
+  const bundleIds = (bundles ?? []).map((b) => b.id as string);
+  if (bundleIds.length === 0) return [];
+
+  const { data: docs, error: docsError } = await admin
+    .from("documents")
+    .select("r2_key")
+    .in("bundle_id", bundleIds);
+
+  if (docsError) {
+    console.error("account deletion: could not list documents to clean up", docsError);
+    return [];
+  }
+
+  return (docs ?? []).map((d) => d.r2_key as string | null).filter((k): k is string => !!k);
+}
+
+// DELETE /account — close your own account, and nothing else's.
+account.delete("/account", async (c) => {
+  // The third refusal in the family, and the heaviest of the three. The other
+  // two live in `routes/api-keys.ts`: a key may not mint another key and may not
+  // revoke one. All three exist because a key is not a scope list — it is a way
+  // to become the person who owns it — so "acting as the owner" would otherwise
+  // be enough to end the owner. A leaked key that can close the account it came
+  // from destroys the evidence and the account in one call, and no revocation
+  // afterwards can undo it. This one is not optional and it is not derivable:
+  // it has to be written, here, by hand.
+  if (c.get("apiKeyId")) {
+    return c.json({ error: "api keys cannot close an account — sign in to do this" }, 403);
+  }
+
+  const db = c.get("db");
+  const user = c.get("user");
+
+  const { data: memberships, error: membershipsError } = await db
+    .from("workspace_members")
+    .select("workspace_id,role")
+    .eq("user_id", user.id);
+
+  if (membershipsError) return c.json({ error: "failed to check your workspaces" }, 500);
+
+  const ids = (memberships ?? []).map((m) => m.workspace_id as string);
+
+  // Read through the caller's own client, not the service one. Being able to
+  // see the other members of these workspaces is exactly what
+  // `workspace_members_select_fellow_members` grants, so the survey is scoped
+  // by the same rule the team screen is — and if the caller is somehow not a
+  // member of one of these, the row it would have relied on is simply absent.
+  let members: Member[] = [];
+  if (ids.length > 0) {
+    const { data, error } = await db
+      .from("workspace_members")
+      .select("workspace_id,user_id,role")
+      .in("workspace_id", ids);
+    if (error) return c.json({ error: "failed to check your workspaces" }, 500);
+    members = (data ?? []) as Member[];
+  }
+
+  const { blocked, deletable } = planWorkspaces(
+    user.id,
+    (memberships ?? []) as Membership[],
+    members,
+  );
+
+  if (blocked.length > 0) {
+    // Named, not counted. "You are the last admin of 2 workspaces" sends a
+    // person hunting through a switcher; the dialog can only say what to go and
+    // fix if this says which. The names are read separately because the survey
+    // above deliberately does not join — it is about roles, not labels.
+    const { data: rows } = await db.from("workspaces").select("id,name").in("id", blocked);
+    const names = (rows ?? []).map((r) => r.name as string).filter(Boolean);
+    return c.json(
+      {
+        error:
+          "make someone else an admin first — a workspace cannot be left without one: " +
+          (names.length > 0 ? names.join(", ") : blocked.join(", ")),
+        workspaces: names,
+      },
+      409,
+    );
+  }
+
+  const admin = serviceClient(c.env);
+
+  // Read while the rows still exist, and thrown away if anything below refuses.
+  // Two hops rather than a join, because the cascade is two hops: a document
+  // names a bundle and a bundle names the workspace.
+  const keys = await collectDocumentKeys(admin, deletable);
+
+  // Deleted before the user, and one at a time. Before, because the trigger
+  // refuses the membership row while the workspace is still standing, and the
+  // membership row is what the user's cascade has to remove. One at a time
+  // because a failure part-way through should leave the rest of the account
+  // intact and the caller told, rather than half a person in the database.
+  for (const id of deletable) {
+    const { error } = await admin.from("workspaces").delete().eq("id", id);
+    if (error) {
+      console.error("account deletion: failed to delete empty workspace", id, error);
+      return c.json({ error: "failed to close your account" }, 500);
+    }
+  }
+
+  const { error: deleteError } = await admin.auth.admin.deleteUser(user.id);
+  if (deleteError) {
+    // Reachable if a new table gains a reference to `auth.users` without an
+    // `on delete` clause — the exact failure `0016` was written to clear, and
+    // one a schema change can reintroduce silently. Logged with the message
+    // rather than swallowed, because the person on the other end has just been
+    // told their account is gone and it is not.
+    console.error("account deletion: deleteUser failed", deleteError);
+    return c.json({ error: "failed to close your account" }, 500);
+  }
+
+  // Last, and best-effort, in that order for the same reason `documents.ts`
+  // deletes its row before its object: a failure here leaves bytes nobody can
+  // reach, while a failure the other way round leaves a row pointing at nothing.
+  // The account is already gone by now, so there is nobody to report this to —
+  // it goes to the log, where an operator with a retention obligation can find
+  // the keys that were meant to go.
+  for (const key of keys) {
+    try {
+      await getDocStore(c.env).delete(key);
+    } catch (e) {
+      console.error("account deletion: document store delete failed", key, e);
+    }
+  }
+
+  return c.json({ ok: true });
+});
+
+export { account };

--- a/worker/src/routes/account.ts
+++ b/worker/src/routes/account.ts
@@ -201,6 +201,28 @@ account.delete("/account", async (c) => {
   // because a failure part-way through should leave the rest of the account
   // intact and the caller told, rather than half a person in the database.
   for (const id of deletable) {
+    // Two references to a workspace do not cascade, and this is the procedure
+    // `docs/team.md` documents for an operator deleting one by hand.
+    // `chat_sessions.workspace_id` and `ideas.workspace_id` were both added
+    // after the original schema as plain references, so a workspace with a
+    // single conversation in it cannot be deleted until they are cleared —
+    // which is every workspace anybody has used. Scoped by workspace rather
+    // than by user on purpose: a session belonging to somebody who was removed
+    // from this workspace still carries its `workspace_id` and would hold the
+    // delete open just the same.
+    //
+    // Better fixed as a migration that makes both cascade, which would also
+    // simplify the operator procedure. Done here instead because the route has
+    // to work against a database that has not had that migration applied, and
+    // migrations reach production by hand.
+    for (const table of ["ideas", "chat_sessions"] as const) {
+      const { error } = await admin.from(table).delete().eq("workspace_id", id);
+      if (error) {
+        console.error(`account deletion: failed to clear ${table}`, id, error);
+        return c.json({ error: "failed to close your account" }, 500);
+      }
+    }
+
     const { error } = await admin.from("workspaces").delete().eq("id", id);
     if (error) {
       console.error("account deletion: failed to delete empty workspace", id, error);

--- a/worker/src/service-client.static.test.ts
+++ b/worker/src/service-client.static.test.ts
@@ -38,6 +38,10 @@ const SERVICE_CLIENT_ALLOWLIST = new Map([
     "lib/api-keys.ts",
     "authentication, the same exemption authClient has: an API key is looked up before there is a caller for RLS to resolve, so there is no user client to do it with — it reads one row by hash and writes that row's last_used_at, and nothing else",
   ],
+  [
+    "routes/account.ts",
+    "erasure is the one thing a caller cannot do as themselves: auth.users is outside RLS entirely, so deleting your own account needs auth.admin.deleteUser, and the workspaces left with nobody in them have no DELETE policy for the same reason nobody has ever needed one. Both writes are keyed to the caller's own id, and the survey that decides which workspaces those are is done through the user client on purpose",
+  ],
 ]);
 
 /**


### PR DESCRIPTION
Closes #48. Adds `DELETE /account` and a Close-your-account section in Settings.

## Three things were already done

Most of why this is small.

- **`api_keys.user_id` has cascaded since `0033`** — a key dies with its owner. Asserted now rather than assumed.
- **The six attribution columns `0016` converted go to null** — a workspace does not evaporate because the person who opened it left.
- **The product question `0016` left open is already answered by the trigger it wrote.** Blocking until the role is handed over is what `0020` chose for *leaving*, so this is the same answer in the same words. **No migration.**

## One thing was not, and it shapes the route

`prevent_last_admin_removal` asks whether the workspace still stands and whether another admin remains. It **never asks how many members are left** — and everybody starts as the sole admin of their own workspace, so deleting the user first is refused for essentially every account there will ever be.

So the route sorts workspaces into two piles:

| Situation | What happens |
|---|---|
| Somebody else is still in it, and you are its only admin | **Refused**, and the workspace is named |
| Somebody else is still in it, another admin remains | Left alone — it keeps running without you |
| Nobody else is in it | **Deleted with the account** |

The trigger already stands aside for the third case, which is exactly what `0016` made possible.

## The API-key refusal

The third in its family and the heaviest. A key is not a scope list — it is a way to become the person who owns it — so *acting as the owner* would otherwise be enough to **end** the owner, and a leaked key that closes the account it came from destroys the evidence and the account in one call. Written by hand next to the two in `routes/api-keys.ts`.

## Object storage — the first pass here was wrong

No stored object belongs to a *person*: `documents.r2_key` is the only key in the schema and a document hangs off a bundle, which hangs off a workspace. But **this route deletes workspaces too**, and a workspace cascade takes the rows that name the keys while leaving the bytes.

`docs/team.md` already told operators to collect the keys before the rows go, because afterwards nothing enumerates them. The route now does that. The difference is not technical — for an ordinary delete an orphan is a storage cost; for an erasure request it is the file still being there.

## Documents that became false

- **`docs/team.md`** said no request any account can make removes a workspace. Corrected, along with the object-storage paragraph.
- **The privacy page** has said for months that there is no button. True when written; false now. That is the header rule of that file working in the direction nobody had used it in yet — **building a capability puts the page in the change exactly as adding an outbound host does.**

## Verification

- `worker`: 552 tests, typecheck clean — 16 new for this route, including the deletion order.
- frontend: 313 tests — 7 new for the dialog.
- **RLS: not run locally, no Docker daemon here.** The new case in `tests/rls/deletion.test.ts` asserts the api-keys cascade *and* proves the refusal that makes the ordering necessary. CI is where that gets checked.
- `routes/account.ts` is added to the service-client allowlist with its reason, which is the whole mechanism that ratchet exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)