### PR TITLE
Move the half of the model traffic that reads your files

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -22,12 +22,38 @@ OPENAI_API_KEY=
 # OPENAI_API_KEY is still required — most local servers ignore it, so any
 # non-empty string will do there.
 #
-# Embeddings and audio transcription keep going to OpenAI either way. The
-# embedding column is vector(1536) and most local embedding models are not,
-# and few compatible servers implement /audio/transcriptions at all. See
-# docs/self-hosting.md.
+# This moves conversations only. Documents are a separate setting below, and
+# audio transcription is not movable at all — few compatible servers implement
+# /audio/transcriptions. See docs/self-hosting.md.
 OPENAI_BASE_URL=
 OPENAI_MODEL=
+
+# ---- Optional: send documents somewhere other than OpenAI --------------
+# Embedding is where the whole text of every uploaded document is sent, so
+# this is the setting that decides whether self-hosting keeps your files in.
+# It does not follow OPENAI_BASE_URL above, so that moving your chat does not
+# silently move your documents to an endpoint of a different width.
+#
+#   EMBEDDING_BASE_URL=http://host.docker.internal:11434/v1
+#   EMBEDDING_MODEL=nomic-embed-text
+#   EMBEDDING_DIMENSIONS=768
+#
+# EMBEDDING_DIMENSIONS must match both the model *and* the width the database
+# column was declared with — 1536 out of the box. Changing it is a schema
+# change plus a re-embed: supabase/optional/embedding_width.sql spells out the
+# whole procedure, and the API refuses to start if the number is not a
+# positive whole one.
+EMBEDDING_BASE_URL=
+EMBEDDING_MODEL=
+EMBEDDING_DIMENSIONS=
+
+# ---- Optional: retrieval's relevance floor -----------------------------
+# Cosine similarity below which a retrieved chunk is dropped as irrelevant.
+# Empty means 0.25, which was tuned against text-embedding-3-small. Another
+# model's scores sit elsewhere: too high starves real matches, too low fills
+# every prompt with noise, and neither is an error — the answers just get
+# worse. Worth revisiting if you set EMBEDDING_MODEL. 0 disables the floor.
+RAG_MIN_SIMILARITY=
 
 # ---- Local Postgres ----------------------------------------------------
 POSTGRES_PASSWORD=covan-local-dev-password

--- a/README.md
+++ b/README.md
@@ -37,10 +37,13 @@ one.
 - **Collaborative sessions.** Bring the team into one conversation, or one
   brainstorm board, when the question is shared.
 - **Bring your own endpoint.** Set `OPENAI_BASE_URL` and completions go to
-  Ollama, vLLM, LiteLLM or OpenRouter instead of OpenAI. Embeddings and
-  transcription still don't — the embedding column is `vector(1536)`, so that
-  half is a migration rather than a variable, and
-  [`docs/self-hosting.md`](docs/self-hosting.md) says so plainly.
+  Ollama, vLLM, LiteLLM or OpenRouter instead of OpenAI. Set
+  `EMBEDDING_BASE_URL` and your documents go there too — a separate variable,
+  because embedding is where the whole text of every file is sent and moving it
+  also means moving the width of the vector column
+  ([`docs/self-hosting.md`](docs/self-hosting.md) walks through both). Audio
+  transcription is the one thing that stays: hardly any compatible server
+  implements it.
 - **Two runtimes, one source.** The same code runs on Cloudflare Workers with R2
   in production and on Node with the filesystem under `docker compose`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -317,6 +317,17 @@ services:
       # what still goes there regardless.
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
       OPENAI_MODEL: ${OPENAI_MODEL:-}
+      # Documents, separately. Empty means api.openai.com — and it means that
+      # even when OPENAI_BASE_URL above is set, which is the point: moving your
+      # conversations is not the same decision as moving every file you upload.
+      # EMBEDDING_DIMENSIONS must match the width document_chunks.embedding was
+      # declared with; see supabase/optional/embedding_width.sql.
+      EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-}
+      EMBEDDING_DIMENSIONS: ${EMBEDDING_DIMENSIONS:-}
+      # Retrieval's relevance floor. Empty means 0.25, tuned for
+      # text-embedding-3-small; another embedding model wants its own.
+      RAG_MIN_SIMILARITY: ${RAG_MIN_SIMILARITY:-}
       ROUTINE_SECRET_KEY: ${ROUTINE_SECRET_KEY:?set ROUTINE_SECRET_KEY in .env}
       ALLOWED_ORIGIN: ${ALLOWED_ORIGIN:-http://localhost:3000}
       # No R2 binding off Cloudflare, so getDocStore falls to the filesystem

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,7 +162,13 @@ word boundary. A hard cut happens only when there is no boundary at all, such as
 one unbroken token.
 
 Embeddings are `text-embedding-3-small`, 1536 dimensions, stored in
-`document_chunks.embedding` as `vector(1536)`.
+`document_chunks.embedding` as `vector(1536)` — all three by default rather than
+by construction. `EMBEDDING_BASE_URL` and `EMBEDDING_MODEL` move them to any
+OpenAI-compatible endpoint, and the column width follows via
+`supabase/optional/embedding_width.sql`; `EMBEDDING_DIMENSIONS` is what keeps the
+two in agreement, and `lib/embeddings.ts` refuses a vector that disagrees with it
+rather than letting Postgres refuse the insert later. See
+[self-hosting](self-hosting.md).
 
 ### Retrieval, at chat time
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -132,7 +132,9 @@ under in the document store, and an excerpt of the extracted text — the first
 The searchable form is separate. At upload the text is split into chunks of up to
 1000 characters with roughly 150 characters of overlap, and each chunk is
 embedded with `text-embedding-3-small` and stored as a `vector(1536)` in
-`document_chunks`. That step is best-effort: if chunking or embedding fails the
+`document_chunks` — the default, and changeable together if you self-host and
+would rather your documents were not embedded by OpenAI at all
+([self-hosting](self-hosting.md)). That step is best-effort: if chunking or embedding fails the
 document still exists, and it stays unindexed until somebody re-embeds it. The
 accepted file types and the reason PDFs are handled in the browser are in the
 [Quickstart](quickstart.md).

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -159,6 +159,12 @@ The floor drops them instead. `text-embedding-3-small` puts genuinely on-topic
 content well above 0.25 and clearly unrelated content below it, so the effect in
 practice is to remove noise rather than to starve real matches.
 
+0.25 is therefore a fact about that model, not about retrieval, and a
+self-hosted Covan that embeds with something else needs its own — which is what
+`RAG_MIN_SIMILARITY` is for. It is worth setting deliberately: a floor that is
+wrong for the model in use produces no error at all, only answers that are
+vaguer or emptier than they should be.
+
 What survives is assembled in similarity order under a 4000-character budget and
 sent as its own system message, positioned after the earlier turns and just
 before the latest one. Two details of that block matter when you read a reply.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -106,6 +106,10 @@ every line in `.env.docker.example`, in the order it appears there.
 | `OPENAI_API_KEY`                                       | _empty — you must set it_  | Chat completions and `text-embedding-3-small`. Nothing else needs an account.                                                    |
 | `OPENAI_BASE_URL`                                      | _empty — means OpenAI_     | Optional. Sends completions to an OpenAI-compatible endpoint instead. See below — it does not move everything.                   |
 | `OPENAI_MODEL`                                         | _empty_                    | Optional. Forces one model for every completion, overriding the per-agent picker. Needed whenever `OPENAI_BASE_URL` is set.      |
+| `EMBEDDING_BASE_URL`                                   | _empty — means OpenAI_     | Optional. Sends document embeddings to an OpenAI-compatible endpoint. Deliberately does **not** follow `OPENAI_BASE_URL`.        |
+| `EMBEDDING_MODEL`                                      | _empty_                    | Optional. Defaults to `text-embedding-3-small`. Set it whenever `EMBEDDING_BASE_URL` is set.                                     |
+| `EMBEDDING_DIMENSIONS`                                 | _empty — means 1536_       | Optional. The width `document_chunks.embedding` was declared with. Changing it is a schema change — see below. Refuses to boot on anything but a positive whole number. |
+| `RAG_MIN_SIMILARITY`                                   | _empty — means 0.25_       | Optional. Cosine-similarity floor below which a retrieved chunk is dropped. `0` disables it. Tuned for `text-embedding-3-small`; another model wants its own. |
 | `POSTGRES_PASSWORD`                                    | `covan-local-dev-password` | The database password. `auth`, `rest`, `realtime` and `migrate` all connect with it.                                             |
 | `POSTGRES_PORT`                                        | `54322`                    | **Host** port only, for `psql` or a GUI client. Inside the compose network Postgres is always on 5432.                           |
 | `JWT_SECRET`                                           | Supabase demo secret       | Signs and verifies every access token. Changing it invalidates `ANON_KEY` and `SERVICE_ROLE_KEY`, which are JWTs signed with it. Also passed to the API as `SUPABASE_JWT_SECRET`, which is what makes API keys work — see [The API](api.md). |
@@ -161,22 +165,69 @@ It still shows OpenAI's models; ignore it.
 `OPENAI_API_KEY` stays required either way. Most local servers ignore the value,
 so any non-empty string works there.
 
-**Two things this does not move, and you should know before you rely on it:**
+**`OPENAI_BASE_URL` moves conversations, and only conversations.** Documents
+have a setting of their own, immediately below, and audio transcription cannot
+be moved at all: most OpenAI-compatible servers do not implement
+`/audio/transcriptions`, so routing voice notes there would trade a working
+feature for a 404. Voice notes go to OpenAI.
 
-- **Embeddings.** Every document you upload is still embedded by OpenAI's
-  `text-embedding-3-small`. This is not an oversight: `knowledge_chunks.embedding`
-  is declared `vector(1536)` and both retrieval functions take that width, so an
-  endpoint serving a 768-dimension model would not fail at the request — it
-  would fail at the insert, after the upload appeared to succeed. Changing it is
-  a migration and a re-index of everything already stored, not a variable.
-- **Audio transcription.** Voice notes go to OpenAI too. Most
-  OpenAI-compatible servers do not implement `/audio/transcriptions`, so routing
-  it there would trade a working feature for a 404.
+### Keeping your documents off OpenAI too
 
-So `OPENAI_BASE_URL` keeps your conversations off OpenAI. It does not yet keep
-your documents off OpenAI. If that distinction matters for your deployment —
-and for some teams it is the whole question — the honest answer today is that
-Covan is not there yet.
+Embedding is where the whole text of an uploaded document is sent. A deployment
+that routes its chat to a local model and still embeds at OpenAI has kept its
+conversations in-house and shipped every contract, policy and meeting note out
+anyway — which for some teams is the entire reason they were self-hosting.
+
+`EMBEDDING_BASE_URL` closes that:
+
+```bash
+EMBEDDING_BASE_URL=http://host.docker.internal:11434/v1
+EMBEDDING_MODEL=nomic-embed-text
+EMBEDDING_DIMENSIONS=768
+```
+
+**It does not inherit from `OPENAI_BASE_URL`, on purpose.** Two reasons pointing
+the same way. An install that has had `OPENAI_BASE_URL` set for months works
+today — chat local, embeddings at OpenAI — and inheriting would move its
+documents to a new endpoint on an upgrade nobody asked for. And serving
+completions is table stakes for a compatible server, while serving embeddings at
+the width your database column expects is not. So you set both, knowingly.
+
+That width is the part that takes work. pgvector fixes a vector column's
+dimension at declaration time, and migration 0004 declared
+`document_chunks.embedding` as `vector(1536)` because that is what
+`text-embedding-3-small` returns. Common local models do not match:
+`nomic-embed-text` is 768, `mxbai-embed-large` and `bge-m3` are 1024. The
+column, its HNSW index and the `match_chunks` function all have to move
+together, and existing vectors cannot come with them — there is no arithmetic
+that converts a vector from one model's space into another's.
+
+`supabase/optional/embedding_width.sql` does the schema half and documents the
+whole procedure. Deliberately **not** a migration: it is outside
+`supabase/migrations/`, `migrate` never mounts it, and the number in it is a
+fact about the model you chose rather than about Covan. In short:
+
+1. Set `EMBEDDING_BASE_URL` and `EMBEDDING_MODEL`, then upload one small
+   document. It will fail, and the error names the width your model actually
+   returned — use that number rather than one from a README, since several
+   models serve more than one.
+2. Edit `v_dims` in that file and run it. It refuses to run twice on the same
+   width, so it cannot quietly discard your embeddings for nothing.
+3. Set `EMBEDDING_DIMENSIONS` to the same number and restart the API.
+4. Re-embed: `POST /admin/backfill-embeddings` with your `ADMIN_API_KEY`. It
+   walks every document that has stored text and no chunks, so running it again
+   is safe and picks up only what was missed. Until it finishes, answers fall
+   back to the agent's persona alone — degraded, not broken.
+5. Revisit `RAG_MIN_SIMILARITY`. It defaults to 0.25, chosen against
+   `text-embedding-3-small`. Another model's similarity scores sit somewhere
+   else, and a floor that is wrong for it never errors — too high starves
+   genuine matches, too low fills every prompt with noise. Both just look like
+   the answers got worse.
+
+The API refuses to start on an `EMBEDDING_DIMENSIONS` that is not a positive
+whole number, or a `RAG_MIN_SIMILARITY` outside 0–1, naming the variable. A
+width that is merely *wrong* rather than malformed is caught at the first
+embedding call instead, which is why step 1 is an upload rather than a restart.
 
 ## Terms and privacy
 
@@ -480,9 +531,17 @@ OPENAI_BASE_URL = "https://openrouter.ai/api/v1"
 OPENAI_MODEL = "meta-llama/llama-3.3-70b-instruct"
 ```
 
-The same two exceptions apply — embeddings and transcription still go to
-OpenAI. Set them on the routine engine too, or scheduled work will keep using
-OpenAI while chat does not.
+Set them on the routine engine too, or scheduled work will keep using OpenAI
+while chat does not. Documents are separate, and go in the same `[vars]` block:
+
+```toml
+EMBEDDING_BASE_URL = "https://your-endpoint.example/v1"
+EMBEDDING_MODEL    = "nomic-embed-text"
+EMBEDDING_DIMENSIONS = "768"
+```
+
+Those three belong on the API Worker only — nothing the routine engine does
+embeds. Transcription remains at OpenAI regardless.
 
 Check the build, then ship it:
 

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -83,7 +83,11 @@ function PrivacyPage() {
             <strong className="font-medium text-foreground">OpenAI</strong> — your messages, the
             persona of the agent, and the passages retrieved from your documents are sent so a reply
             can be generated. Document text is sent when it is first indexed. Audio is sent when you
-            dictate. This is the one call the product cannot work without.
+            dictate. This is the one call the product cannot work without — though where it goes is
+            the operator's to change: <code>OPENAI_BASE_URL</code> moves the conversation and{" "}
+            <code>EMBEDDING_BASE_URL</code> moves the document text, each to any OpenAI-compatible
+            endpoint, and they are set independently. Dictation cannot be moved. Ask whoever runs
+            this install which of them are set; nothing on this page can tell you.
           </LegalItem>
           <LegalItem>
             <strong className="font-medium text-foreground">Resend</strong> — invitation emails and

--- a/supabase/optional/embedding_width.sql
+++ b/supabase/optional/embedding_width.sql
@@ -1,0 +1,150 @@
+-- embedding_width.sql — store vectors of a width other than 1536.
+--
+-- This is not a migration, and it deliberately does not live in
+-- supabase/migrations/. That directory is a linear sequence every Covan runs,
+-- including the hosted one, and the number below is not a fact about Covan —
+-- it is a fact about the embedding model *you* chose. A migration cannot hold
+-- an operator's choice. So this file sits outside the sequence, `migrate`
+-- never mounts it (docker-compose.yml mounts ./supabase/migrations only), and
+-- nothing applies it unless you do.
+--
+-- ---------------------------------------------------------------------------
+-- WHY YOU WOULD RUN THIS
+--
+-- Covan embeds with `text-embedding-3-small`, which returns 1536 dimensions,
+-- and migration 0004 declared `document_chunks.embedding` as `vector(1536)` to
+-- match. Point EMBEDDING_BASE_URL at a local server and you are almost
+-- certainly on a different width: nomic-embed-text is 768, mxbai-embed-large
+-- and bge-m3 are 1024. pgvector fixes the width at DDL time, so the column, the
+-- HNSW index and `match_chunks` all have to move together. This file moves all
+-- three.
+--
+-- ---------------------------------------------------------------------------
+-- WHAT IT COSTS: EVERY EMBEDDING YOU HAVE
+--
+-- A 768-wide vector cannot be stored in a 1536-wide column and cannot be
+-- converted into one either — the numbers mean different things, there is no
+-- arithmetic that translates between two models' vector spaces. So the stored
+-- chunks are deleted, not migrated. Nothing else is: `documents` keeps its
+-- rows, its `content`, and its files.
+--
+-- Full procedure, in order:
+--
+--   1. Set EMBEDDING_BASE_URL and EMBEDDING_MODEL, and upload one small
+--      document. It will fail, and the error names the width the model
+--      actually returned. Use that number below rather than a number from a
+--      README — several models serve more than one width.
+--   2. Edit v_dims here and run this file against your database.
+--   3. Set EMBEDDING_DIMENSIONS to the same number and restart the API.
+--   4. Re-embed: POST /admin/backfill-embeddings with your ADMIN_API_KEY. It
+--      walks every document that has stored text and no chunks, so a second
+--      run is safe and only picks up what the first missed.
+--   5. Reconsider RAG_MIN_SIMILARITY. It defaults to 0.25, which was chosen
+--      against text-embedding-3-small. A different model's scores sit
+--      somewhere else, and a floor that is wrong for it does not error — it
+--      quietly returns the wrong chunks, or none.
+--
+-- Step 4 re-embeds from `documents.content`, which every upload stores. A
+-- document whose text was never stored — an older row, or a PDF the browser
+-- could not extract — is skipped there and needs POST /documents/:id/reindex
+-- instead, which re-reads the original file from object storage.
+--
+-- How long step 4 takes is a function of your endpoint, not of Covan: it is one
+-- embedding request per 128 chunks, sequential, and a thousand ordinary
+-- documents is on the order of a few thousand chunks. On a local GPU that is
+-- minutes. Retrieval is degraded until it finishes — answers fall back to the
+-- agent's persona alone, which is what happens today when a document has no
+-- chunks, so nothing breaks; it just stops being grounded.
+--
+-- Run it inside a transaction if your client does not already (`begin;` …
+-- `commit;`). The re-embedding in step 4 is the part that cannot be rolled
+-- back, and it is deliberately outside this file.
+-- ---------------------------------------------------------------------------
+
+do $outer$
+declare
+  -- The only line to edit. It must equal the width your embedding model
+  -- returns, and EMBEDDING_DIMENSIONS must equal it too.
+  v_dims constant int := 1536;
+  v_current text;
+  v_chunks bigint;
+begin
+  select format_type(atttypid, atttypmod)
+    into v_current
+    from pg_attribute
+   where attrelid = 'public.document_chunks'::regclass
+     and attname = 'embedding';
+
+  -- Refusing a no-op matters here more than it usually does: running this file
+  -- unchanged would delete every embedding in the database and rebuild the
+  -- column exactly as it was, which looks like nothing happened until somebody
+  -- asks a question.
+  if v_current = format('vector(%s)', v_dims) then
+    raise notice 'embedding is already %, nothing to do', v_current;
+    return;
+  end if;
+
+  select count(*) into v_chunks from public.document_chunks;
+  raise notice 'changing % to vector(%), discarding % chunks', v_current, v_dims, v_chunks;
+
+  delete from public.document_chunks;
+
+  -- Dropped rather than left to be rebuilt: an HNSW index is built for a
+  -- specific width, and rebuilding it after the column is empty is both correct
+  -- and instant.
+  drop index if exists public.idx_document_chunks_embedding;
+
+  execute format(
+    'alter table public.document_chunks alter column embedding type vector(%s)',
+    v_dims
+  );
+
+  create index idx_document_chunks_embedding on public.document_chunks
+    using hnsw (embedding vector_cosine_ops);
+
+  -- The retrieval function takes the query vector by the same width, so it has
+  -- to be replaced too. Body copied from 0005 — if that migration ever changes
+  -- this file has to change with it, which is the cost of living outside the
+  -- sequence.
+  drop function if exists public.match_chunks(uuid, vector, int, float);
+
+  execute format($fmt$
+    create function public.match_chunks(
+      p_agent_id uuid,
+      p_query_embedding vector(%s),
+      p_match_count int,
+      p_min_similarity float default 0
+    )
+    returns table (document_id uuid, document_name text, content text, similarity float)
+    language sql
+    stable
+    security invoker
+    set search_path = pg_catalog, public
+    as $body$
+      select dc.document_id,
+             d.name as document_name,
+             dc.content,
+             1 - (dc.embedding <=> p_query_embedding) as similarity
+      from public.document_chunks dc
+      join public.documents d on d.id = dc.document_id
+      where dc.embedding is not null
+        and (1 - (dc.embedding <=> p_query_embedding)) >= p_min_similarity
+        and dc.bundle_id in (
+          select ab.bundle_id from public.agent_bundles ab where ab.agent_id = p_agent_id
+        )
+      order by dc.embedding <=> p_query_embedding
+      limit p_match_count;
+    $body$
+  $fmt$, v_dims);
+
+  -- Stated rather than inherited, which is what 0023 asked every later change
+  -- to do. `security invoker` means document_chunks RLS still decides what
+  -- comes back; this only says who may ask.
+  execute format(
+    'grant execute on function public.match_chunks(uuid, vector(%s), int, float) to authenticated, service_role',
+    v_dims
+  );
+
+  raise notice 'done — set EMBEDDING_DIMENSIONS=% and run POST /admin/backfill-embeddings', v_dims;
+end
+$outer$;

--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -12,10 +12,26 @@ OPENAI_API_KEY=replace-with-openai-api-key
 
 # Optional. Sends completions to an OpenAI-compatible endpoint instead of
 # OpenAI. Set OPENAI_MODEL alongside it — the shipped model list is OpenAI's,
-# so on its own every agent would ask your endpoint for `gpt-4o`. Embeddings
-# and transcription still go to OpenAI; docs/self-hosting.md says why.
+# so on its own every agent would ask your endpoint for `gpt-4o`. Transcription
+# still goes to OpenAI; docs/self-hosting.md says why.
 # OPENAI_BASE_URL=http://localhost:11434/v1
 # OPENAI_MODEL=llama3.3:70b
+
+# Optional, and separate from the two above on purpose: this is where the text
+# of every uploaded document goes, which is a bigger decision than where the
+# conversation goes, so it does not inherit from OPENAI_BASE_URL.
+# EMBEDDING_DIMENSIONS must match both the model and the width
+# document_chunks.embedding was declared with — 1536 unless you ran
+# supabase/optional/embedding_width.sql, which is also where the procedure for
+# changing it lives.
+# EMBEDDING_BASE_URL=http://localhost:11434/v1
+# EMBEDDING_MODEL=nomic-embed-text
+# EMBEDDING_DIMENSIONS=768
+
+# Optional. Cosine-similarity floor for retrieval; unset means 0.25, which was
+# tuned for text-embedding-3-small. Set your own if you change the embedding
+# model — a wrong floor does not error, it just returns the wrong chunks.
+# RAG_MIN_SIMILARITY=0.3
 
 # Comma-separated EXACT frontend origins. Never a wildcard or a pattern —
 # docs/self-hosting.md explains what that costs. localhost is allowed in code.

--- a/worker/src/lib/embeddings.test.ts
+++ b/worker/src/lib/embeddings.test.ts
@@ -7,7 +7,27 @@ vi.mock("openai", () => ({
   },
 }));
 
-const { chunkText, embedTexts, EMBED_BATCH_SIZE } = await import("./embeddings");
+const {
+  chunkText,
+  embedTexts,
+  embeddingModel,
+  embeddingDimensions,
+  EMBED_BATCH_SIZE,
+  DEFAULT_EMBEDDING_MODEL,
+  DEFAULT_EMBEDDING_DIMENSIONS,
+} = await import("./embeddings");
+
+/**
+ * Every mocked response below returns one-element vectors, so the tests declare
+ * a one-dimensional database. Stating it beats making the guard tolerant: a
+ * width check that let short vectors through would pass every test here and
+ * still let a 768-dimension model reach a 1536-wide column in production.
+ */
+const env = (extra: Record<string, string> = {}) => ({
+  OPENAI_API_KEY: "sk-test",
+  EMBEDDING_DIMENSIONS: "1",
+  ...extra,
+});
 
 describe("chunkText", () => {
   it("returns [] for empty or whitespace-only text", () => {
@@ -91,8 +111,18 @@ describe("chunkText", () => {
   });
 });
 
+/**
+ * Braces, not a bare arrow. `mockReset()` returns the mock, an arrow body
+ * returns it, and Vitest treats anything a `beforeEach` returns as a teardown
+ * function — so `() => create.mockReset()` quietly registers the mock itself as
+ * a cleanup hook and calls it with no arguments after every test. Harmless
+ * while every implementation ignores its arguments, and a TypeError from inside
+ * a cleanup hook the moment one destructures them.
+ */
 describe("embedTexts", () => {
-  beforeEach(() => create.mockReset());
+  beforeEach(() => {
+    create.mockReset();
+  });
 
   it("returns vectors in input order, however the API orders them", async () => {
     create.mockResolvedValue({
@@ -103,7 +133,7 @@ describe("embedTexts", () => {
       usage: { total_tokens: 42 },
     });
 
-    const { vectors } = await embedTexts("sk-test", ["first", "second"]);
+    const { vectors } = await embedTexts(env(), ["first", "second"]);
 
     expect(vectors).toEqual([[0.1], [0.2]]);
   });
@@ -116,17 +146,17 @@ describe("embedTexts", () => {
       usage: { total_tokens: 42 },
     });
 
-    await expect(embedTexts("sk-test", ["hello"])).resolves.toMatchObject({ tokens: 42 });
+    await expect(embedTexts(env(), ["hello"])).resolves.toMatchObject({ tokens: 42 });
   });
 
   it("reports zero when the API omits usage", async () => {
     create.mockResolvedValue({ data: [{ index: 0, embedding: [0.1] }] });
 
-    await expect(embedTexts("sk-test", ["hello"])).resolves.toMatchObject({ tokens: 0 });
+    await expect(embedTexts(env(), ["hello"])).resolves.toMatchObject({ tokens: 0 });
   });
 
   it("costs nothing and calls nothing for an empty input", async () => {
-    await expect(embedTexts("sk-test", [])).resolves.toEqual({ vectors: [], tokens: 0 });
+    await expect(embedTexts(env(), [])).resolves.toEqual({ vectors: [], tokens: 0 });
     expect(create).not.toHaveBeenCalled();
   });
 });
@@ -144,7 +174,7 @@ describe("embedTexts batching", () => {
     }));
 
     const texts = Array.from({ length: 300 }, (_, i) => String(i));
-    const res = await embedTexts("key", texts);
+    const res = await embedTexts(env(), texts);
 
     expect(create).toHaveBeenCalledTimes(3); // 128 + 128 + 44
     expect(res.vectors).toHaveLength(300);
@@ -161,7 +191,7 @@ describe("embedTexts batching", () => {
     }));
 
     await embedTexts(
-      "key",
+      env(),
       Array.from({ length: 1500 }, (_, i) => String(i)),
     );
 
@@ -176,9 +206,113 @@ describe("embedTexts batching", () => {
       usage: { total_tokens: 7 },
     });
 
-    const res = await embedTexts("key", ["only one"]);
+    const res = await embedTexts(env(), ["only one"]);
 
     expect(create).toHaveBeenCalledTimes(1);
     expect(res).toEqual({ vectors: [[1]], tokens: 7 });
+  });
+});
+
+describe("which model embeds", () => {
+  beforeEach(() => {
+    create.mockReset();
+    create.mockResolvedValue({ data: [{ index: 0, embedding: [0.1] }], usage: {} });
+  });
+
+  it("is OpenAI's unless the operator names another", async () => {
+    await embedTexts(env(), ["hello"]);
+    expect(create.mock.calls[0][0].model).toBe(DEFAULT_EMBEDDING_MODEL);
+  });
+
+  it("is whatever the operator named", async () => {
+    await embedTexts(env({ EMBEDDING_MODEL: "nomic-embed-text" }), ["hello"]);
+    expect(create.mock.calls[0][0].model).toBe("nomic-embed-text");
+  });
+
+  it("treats an empty EMBEDDING_MODEL as unset, the way a .env line does", () => {
+    // A variable declared and left blank arrives as "", not undefined, and ""
+    // as a model name is a 400 from every endpoint there is.
+    expect(embeddingModel({ EMBEDDING_MODEL: "" })).toBe(DEFAULT_EMBEDDING_MODEL);
+    expect(embeddingModel({ EMBEDDING_MODEL: "  " })).toBe(DEFAULT_EMBEDDING_MODEL);
+  });
+});
+
+describe("the width this database stores", () => {
+  it("is 1536 unless the operator changed the column", () => {
+    expect(embeddingDimensions({})).toBe(DEFAULT_EMBEDDING_DIMENSIONS);
+    expect(embeddingDimensions({ EMBEDDING_DIMENSIONS: "" })).toBe(DEFAULT_EMBEDDING_DIMENSIONS);
+  });
+
+  it("is whatever they set it to", () => {
+    expect(embeddingDimensions({ EMBEDDING_DIMENSIONS: "768" })).toBe(768);
+    expect(embeddingDimensions({ EMBEDDING_DIMENSIONS: " 1024 " })).toBe(1024);
+  });
+
+  it.each(["nope", "768.5", "-1", "0"])("refuses %s rather than falling back", (value) => {
+    // Falling back would be the dangerous kindness: a typo'd width silently
+    // reverting to 1536 is how a 768-dimension model gets as far as the insert.
+    expect(() => embeddingDimensions({ EMBEDDING_DIMENSIONS: value })).toThrow(
+      /EMBEDDING_DIMENSIONS/,
+    );
+  });
+});
+
+/**
+ * The guard the whole change hangs on.
+ *
+ * Without it a mismatched model does not fail at the request — it fails at the
+ * insert, and both upload paths log an insert failure and still report the
+ * document as saved. The operator's symptom is documents that upload cleanly
+ * and answer nothing.
+ */
+describe("a model of the wrong width", () => {
+  beforeEach(() => {
+    create.mockReset();
+  });
+
+  it("is refused, naming both numbers and the endpoint", async () => {
+    create.mockResolvedValue({
+      data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }],
+      usage: { total_tokens: 5 },
+    });
+
+    await expect(
+      embedTexts(
+        env({ EMBEDDING_DIMENSIONS: "1536", EMBEDDING_BASE_URL: "http://ollama:11434/v1" }),
+        ["hello"],
+      ),
+    ).rejects.toThrow(/returned 3 dimensions, but this database stores 1536/);
+  });
+
+  it("says where the request went, because that is the setting to change", async () => {
+    create.mockResolvedValue({ data: [{ index: 0, embedding: [0.1, 0.2] }], usage: {} });
+
+    await expect(
+      embedTexts(env({ EMBEDDING_BASE_URL: "http://ollama:11434/v1" }), ["hello"]),
+    ).rejects.toThrow(/http:\/\/ollama:11434\/v1/);
+  });
+
+  it("names OpenAI when no endpoint was configured", async () => {
+    create.mockResolvedValue({ data: [{ index: 0, embedding: [0.1, 0.2] }], usage: {} });
+
+    await expect(embedTexts(env(), ["hello"])).rejects.toThrow(/api\.openai\.com/);
+  });
+
+  it("is caught on a later batch too, not just the first", async () => {
+    // A server that serves two models behind one name, or truncates under load,
+    // would otherwise put short vectors into a column that accepted the first
+    // batch. Checking every vector costs nothing next to the request itself.
+    create.mockImplementation(async ({ input }: { input: string[] }) => ({
+      data: input.map((_, i) => ({ index: i, embedding: input[0] === "128" ? [1, 2] : [1] })),
+      usage: { total_tokens: input.length },
+    }));
+
+    await expect(
+      embedTexts(
+        env(),
+        Array.from({ length: 200 }, (_, i) => String(i)),
+      ),
+    ).rejects.toThrow(/returned 2 dimensions/);
+    expect(create).toHaveBeenCalledTimes(2);
   });
 });

--- a/worker/src/lib/embeddings.ts
+++ b/worker/src/lib/embeddings.ts
@@ -1,6 +1,56 @@
-import OpenAI from "openai";
+import { createEmbeddingClient } from "./openai";
 
-export const EMBEDDING_MODEL = "text-embedding-3-small";
+/**
+ * What an install that has never thought about this gets: OpenAI's model, at
+ * the width `public.document_chunks.embedding` is declared with in migration
+ * 0004. Both are defaults rather than constants now, because a self-hosted
+ * Covan that keeps its completions in-house and ships every uploaded document
+ * to OpenAI anyway has only solved the smaller half of the problem.
+ */
+export const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
+export const DEFAULT_EMBEDDING_DIMENSIONS = 1536;
+
+/** Everything `embedTexts` reads off the environment. */
+export type EmbeddingConfig = {
+  OPENAI_API_KEY: string;
+  EMBEDDING_BASE_URL?: string;
+  EMBEDDING_MODEL?: string;
+  EMBEDDING_DIMENSIONS?: string;
+};
+
+/** Which model embeds. Unset means OpenAI's, whatever the endpoint is. */
+export function embeddingModel(env: { EMBEDDING_MODEL?: string }): string {
+  return env.EMBEDDING_MODEL?.trim() || DEFAULT_EMBEDDING_MODEL;
+}
+
+/**
+ * How wide a vector this database can store.
+ *
+ * Not a preference — a fact about the schema. `document_chunks.embedding` is
+ * `vector(N)` and the HNSW index and `match_chunks` are both declared at that
+ * same N, so this number and the SQL have to agree or nothing works. It is a
+ * variable rather than a constant only because the operator can change the SQL:
+ * `supabase/optional/embedding_width.sql`.
+ *
+ * Throws rather than falling back, and `lib/env.ts` calls it at boot so a
+ * Docker stack fails on startup instead of on somebody's first upload. A
+ * typo'd width that silently reverted to 1536 would let a 768-dimension model
+ * through as far as the insert, which is exactly the failure this whole change
+ * exists to remove.
+ */
+export function embeddingDimensions(env: { EMBEDDING_DIMENSIONS?: string }): number {
+  const raw = (env.EMBEDDING_DIMENSIONS ?? "").trim();
+  if (raw === "") return DEFAULT_EMBEDDING_DIMENSIONS;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(
+      `EMBEDDING_DIMENSIONS must be a positive whole number (got ${JSON.stringify(raw)}). ` +
+        `It has to match the width public.document_chunks.embedding was declared with — ` +
+        `see supabase/optional/embedding_width.sql.`,
+    );
+  }
+  return n;
+}
 
 // Return the index just past the latest occurrence of `sep` in [from, hardEnd),
 // or -1 if it doesn't occur there. Breaking *after* the separator keeps it with
@@ -108,19 +158,42 @@ export const EMBED_BATCH_SIZE = 128;
  * spend — a large document costs more to index than a long conversation costs
  * to answer — and a usage counter that ignored it would leave uploads free.
  * Batches are summed, so the caller still records one total.
+ *
+ * Takes the environment rather than a bare key, which is the whole point: the
+ * key alone cannot say where the request goes, and "where the request goes" is
+ * the difference between a self-hosted Covan that keeps its documents and one
+ * that only keeps its conversations.
  */
-export async function embedTexts(apiKey: string, texts: string[]): Promise<EmbeddingResult> {
+export async function embedTexts(env: EmbeddingConfig, texts: string[]): Promise<EmbeddingResult> {
   if (texts.length === 0) return { vectors: [], tokens: 0 };
-  const openai = new OpenAI({ apiKey });
+  const openai = createEmbeddingClient(env);
+  const model = embeddingModel(env);
+  const dimensions = embeddingDimensions(env);
 
   const vectors: number[][] = [];
   let tokens = 0;
 
   for (let i = 0; i < texts.length; i += EMBED_BATCH_SIZE) {
     const batch = texts.slice(i, i + EMBED_BATCH_SIZE);
-    const res = await openai.embeddings.create({ model: EMBEDDING_MODEL, input: batch });
+    const res = await openai.embeddings.create({ model, input: batch });
     for (const d of res.data.slice().sort((a, b) => a.index - b.index)) {
-      vectors.push(d.embedding as number[]);
+      const vector = d.embedding as number[];
+      // Checked here, where the endpoint is still nameable, rather than left to
+      // Postgres. A vector of the wrong width does not fail at the request — it
+      // fails at the insert, and both callers that upload treat an insert
+      // failure as "document saved, just not indexed". So the operator's real
+      // symptom would be documents that upload fine and answer nothing, with a
+      // constraint error in a log they have no reason to be reading.
+      if (vector.length !== dimensions) {
+        throw new Error(
+          `Embedding model ${model} at ${env.EMBEDDING_BASE_URL || "api.openai.com"} returned ` +
+            `${vector.length} dimensions, but this database stores ${dimensions}. ` +
+            `Either point EMBEDDING_MODEL at a model of that width, or change the width — ` +
+            `supabase/optional/embedding_width.sql, then set EMBEDDING_DIMENSIONS to match ` +
+            `and re-embed via POST /admin/backfill-embeddings.`,
+        );
+      }
+      vectors.push(vector);
     }
     tokens += res.usage?.total_tokens ?? 0;
   }

--- a/worker/src/lib/env.test.ts
+++ b/worker/src/lib/env.test.ts
@@ -61,6 +61,42 @@ describe("loadEnv", () => {
     expect(env.OPENAI_MODEL).toBeUndefined();
   });
 
+  it("carries the embedding endpoint through separately from the completions one", () => {
+    const env = loadEnv({
+      ...complete,
+      OPENAI_BASE_URL: "http://localhost:11434/v1",
+      EMBEDDING_BASE_URL: "http://localhost:8080/v1",
+      EMBEDDING_MODEL: "nomic-embed-text",
+      EMBEDDING_DIMENSIONS: "768",
+      RAG_MIN_SIMILARITY: "0.35",
+    });
+    expect(env.EMBEDDING_BASE_URL).toBe("http://localhost:8080/v1");
+    expect(env.EMBEDDING_MODEL).toBe("nomic-embed-text");
+    expect(env.EMBEDDING_DIMENSIONS).toBe("768");
+    expect(env.RAG_MIN_SIMILARITY).toBe("0.35");
+  });
+
+  it("leaves embeddings on OpenAI when only the completions endpoint moved", () => {
+    // The upgrade case. An install that has had OPENAI_BASE_URL set for months
+    // must not find its documents going somewhere new because this shipped.
+    const env = loadEnv({ ...complete, OPENAI_BASE_URL: "http://localhost:11434/v1" });
+    expect(env.EMBEDDING_BASE_URL).toBeUndefined();
+    expect(env.EMBEDDING_DIMENSIONS).toBeUndefined();
+  });
+
+  // Both of these are wrong in ways that produce no error later — a width that
+  // fails at the insert, a floor that returns nothing — so they are worth a
+  // refusal at boot rather than a discovery in a week.
+  it("refuses to start on a width that is not a positive whole number", () => {
+    expect(() => loadEnv({ ...complete, EMBEDDING_DIMENSIONS: "768.5" })).toThrow(
+      /EMBEDDING_DIMENSIONS/,
+    );
+  });
+
+  it("refuses to start on a similarity floor outside 0..1", () => {
+    expect(() => loadEnv({ ...complete, RAG_MIN_SIMILARITY: "25" })).toThrow(/RAG_MIN_SIMILARITY/);
+  });
+
   it("carries the rate limits through when the operator sets them", () => {
     const env = loadEnv({
       ...complete,

--- a/worker/src/lib/env.ts
+++ b/worker/src/lib/env.ts
@@ -1,4 +1,6 @@
 import type { Bindings } from "../types";
+import { embeddingDimensions } from "./embeddings";
+import { ragMinSimilarity } from "./rag";
 
 /** Absent or empty means unset — a blank line in a .env file is not a value. */
 const REQUIRED = [
@@ -88,6 +90,14 @@ export function loadEnv(source: Record<string, string | undefined> = process.env
     );
   }
 
+  // Same reasoning as the key above, one step earlier: a bad retrieval number
+  // does not announce itself. A wrong width surfaces as documents that upload
+  // and answer nothing; a wrong floor surfaces as answers that got vaguer.
+  // Both resolvers throw with the correction in the message, so the operator
+  // reads it at `docker compose up` instead of inferring it a week later.
+  embeddingDimensions(source);
+  ragMinSimilarity(source);
+
   return {
     SUPABASE_URL: source.SUPABASE_URL!,
     SUPABASE_ANON_KEY: source.SUPABASE_ANON_KEY!,
@@ -97,6 +107,12 @@ export function loadEnv(source: Record<string, string | undefined> = process.env
     // list, which is what an operator who has not thought about it should get.
     OPENAI_BASE_URL: source.OPENAI_BASE_URL,
     OPENAI_MODEL: source.OPENAI_MODEL,
+    // Separate from the two above on purpose — `lib/openai` explains why an
+    // endpoint for completions is not automatically an endpoint for documents.
+    EMBEDDING_BASE_URL: source.EMBEDDING_BASE_URL,
+    EMBEDDING_MODEL: source.EMBEDDING_MODEL,
+    EMBEDDING_DIMENSIONS: source.EMBEDDING_DIMENSIONS,
+    RAG_MIN_SIMILARITY: source.RAG_MIN_SIMILARITY,
     ROUTINE_SECRET_KEY: source.ROUTINE_SECRET_KEY!,
     RESEND_API_KEY: source.RESEND_API_KEY ?? "",
     RESEND_FROM: source.RESEND_FROM ?? "",

--- a/worker/src/lib/openai.test.ts
+++ b/worker/src/lib/openai.test.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { createOpenAI } from "./openai";
+import { createOpenAI, createEmbeddingClient } from "./openai";
 
 const OPENAI = "https://api.openai.com/v1";
 
@@ -40,6 +40,49 @@ describe("createOpenAI", () => {
   });
 });
 
+describe("createEmbeddingClient", () => {
+  it("talks to OpenAI when no embedding endpoint is configured", () => {
+    const client = createEmbeddingClient({ OPENAI_API_KEY: "sk-test" });
+    expect(client.baseURL).toBe(OPENAI);
+  });
+
+  it("talks to the configured endpoint instead", () => {
+    const client = createEmbeddingClient({
+      OPENAI_API_KEY: "sk-test",
+      EMBEDDING_BASE_URL: "http://localhost:11434/v1",
+    });
+    expect(client.baseURL).toBe("http://localhost:11434/v1");
+  });
+
+  it("treats an empty EMBEDDING_BASE_URL as unset", () => {
+    const client = createEmbeddingClient({ OPENAI_API_KEY: "sk-test", EMBEDDING_BASE_URL: "" });
+    expect(client.baseURL).toBe(OPENAI);
+  });
+
+  /**
+   * The one that is easy to get wrong and impossible to notice.
+   *
+   * Moving completions is not the same decision as moving every document you
+   * own, so the two variables do not inherit from each other. Two ways that
+   * could silently stop being true: reading OPENAI_BASE_URL as a fallback, or
+   * passing no baseURL at all and letting the SDK read process.env for it —
+   * which would make the Docker stack disagree with Cloudflare, since compose
+   * puts OPENAI_BASE_URL in the environment and Workers has no process.env.
+   */
+  it("does not inherit the completions endpoint, from the argument or the environment", () => {
+    vi.stubEnv("OPENAI_BASE_URL", "http://localhost:11434/v1");
+
+    const client = createEmbeddingClient({
+      OPENAI_API_KEY: "sk-test",
+      // @ts-expect-error deliberately passing the wrong variable, the way an
+      // operator's environment does when only OPENAI_BASE_URL is set.
+      OPENAI_BASE_URL: "http://localhost:11434/v1",
+    });
+
+    expect(client.baseURL).toBe(OPENAI);
+  });
+});
+
 /**
  * The factory only closes the hole if everything goes through it. A sixth
  * completion call site added later with a bare `new OpenAI({ apiKey })` would
@@ -48,8 +91,12 @@ describe("createOpenAI", () => {
  */
 const SRC = join(import.meta.dirname, "..");
 
-/** Routed to OpenAI on purpose. `lib/openai.ts` explains what blocks each. */
-const EXEMPT = new Set(["lib/embeddings.ts", "lib/transcribe.ts", "lib/openai.ts"]);
+/**
+ * Routed to OpenAI on purpose, and down to one: `lib/transcribe.ts`, because
+ * `/audio/transcriptions` is missing from most OpenAI-compatible servers.
+ * `lib/embeddings.ts` was here until embeddings got a seam of their own.
+ */
+const EXEMPT = new Set(["lib/transcribe.ts", "lib/openai.ts"]);
 
 function sourceFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
@@ -60,7 +107,7 @@ function sourceFiles(dir: string): string[] {
 }
 
 describe("the OpenAI client factory", () => {
-  it("is the only way production code constructs a client, apart from the two documented exceptions", () => {
+  it("is the only way production code constructs a client, apart from transcription", () => {
     const direct = sourceFiles(SRC)
       .filter((f) => readFileSync(f, "utf8").includes("new OpenAI("))
       .map((f) => relative(SRC, f))

--- a/worker/src/lib/openai.ts
+++ b/worker/src/lib/openai.ts
@@ -10,19 +10,14 @@ import OpenAI from "openai";
  * point it at Ollama, vLLM, LiteLLM, OpenRouter, or an Azure-style gateway and
  * the completions go there instead.
  *
- * Two things this does not cover, deliberately:
+ * One thing this does not cover, deliberately: **transcription**.
+ * `/audio/transcriptions` is absent from most OpenAI-compatible servers, so
+ * routing it would trade a working feature for a 404. It is stated in
+ * docs/self-hosting.md rather than left for someone to discover.
  *
- * - **Embeddings.** `knowledge_chunks.embedding` is `vector(1536)` (migration
- *   0004) and both match RPCs take that width, so an endpoint serving a
- *   768-dimension model would not fail at the call — it would fail at the
- *   insert, after the upload. Embeddings stay on OpenAI until that is a
- *   migration rather than a variable.
- * - **Transcription.** `/audio/transcriptions` is absent from most
- *   OpenAI-compatible servers, so routing it would trade a working feature for
- *   a 404.
- *
- * Both are stated in docs/self-hosting.md rather than left for someone to
- * discover.
+ * Embeddings used to be a second exception and are not any more — see
+ * `createEmbeddingClient` below for why they get a variable of their own
+ * instead of sharing this one.
  *
  * The SDK reads `process.env.OPENAI_BASE_URL` by itself, which quietly worked
  * on the Node runtime and never on Workers. Passing it explicitly is what makes
@@ -34,5 +29,46 @@ export function createOpenAI(env: { OPENAI_API_KEY: string; OPENAI_BASE_URL?: st
     // `|| undefined`, not `??`: an unset variable arrives as "" from a .env
     // file, and "" as a baseURL resolves against the Worker's own origin.
     baseURL: env.OPENAI_BASE_URL || undefined,
+  });
+}
+
+/**
+ * The same seam for embeddings, on a variable of its own.
+ *
+ * Embedding is where the whole text of a document is sent, so a deployment that
+ * routes completions away from OpenAI and still embeds there has not kept its
+ * documents in-house — it has kept its conversations in-house, which is the
+ * smaller half. `EMBEDDING_BASE_URL` is what closes that.
+ *
+ * It deliberately does **not** fall back to `OPENAI_BASE_URL`, for two reasons
+ * that point the same way:
+ *
+ * - An install that today sets `OPENAI_BASE_URL=…ollama…` works: completions go
+ *   to Ollama, embeddings go to OpenAI. Inheriting would move its embeddings on
+ *   upgrade, to an endpoint whose model almost certainly has a different width,
+ *   and the first thing the operator would notice is uploads arriving with no
+ *   chunks.
+ * - The two are not one decision. Serving completions is table stakes for an
+ *   OpenAI-compatible server; serving embeddings at the width your database
+ *   column was declared with is not. Somebody may legitimately want one moved
+ *   and not the other.
+ *
+ * So the operator sets both, knowingly, and `docs/self-hosting.md` says so.
+ */
+export function createEmbeddingClient(env: {
+  OPENAI_API_KEY: string;
+  EMBEDDING_BASE_URL?: string;
+}): OpenAI {
+  return new OpenAI({
+    apiKey: env.OPENAI_API_KEY,
+    // Spelled out rather than left `undefined`, which is where "does not
+    // inherit" would have quietly stopped being true. The SDK falls back to
+    // `process.env.OPENAI_BASE_URL` when given no baseURL — harmless on
+    // Workers, where there is no process.env, and not harmless at all in the
+    // Docker stack, where compose puts OPENAI_BASE_URL there. An operator who
+    // pointed completions at Ollama would have found their documents going to
+    // Ollama too, on one runtime out of two, having configured nothing of the
+    // sort. Naming the default is what makes the two behave the same.
+    baseURL: env.EMBEDDING_BASE_URL || "https://api.openai.com/v1",
   });
 }

--- a/worker/src/lib/rag.test.ts
+++ b/worker/src/lib/rag.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildContextBlock } from "./rag";
+import { buildContextBlock, ragMinSimilarity, DEFAULT_RAG_MIN_SIMILARITY } from "./rag";
 
 describe("buildContextBlock", () => {
   it("returns empty string when no chunks", () => {
@@ -26,5 +26,30 @@ describe("buildContextBlock", () => {
     // second chunk's full content should not fully fit
     expect(out.length).toBeLessThanOrEqual(6000 + 500); // + framing overhead
     expect(out).toContain("a");
+  });
+});
+
+describe("the similarity floor", () => {
+  it("is 0.25 unless the operator says otherwise", () => {
+    expect(ragMinSimilarity({})).toBe(DEFAULT_RAG_MIN_SIMILARITY);
+    expect(ragMinSimilarity({ RAG_MIN_SIMILARITY: "" })).toBe(DEFAULT_RAG_MIN_SIMILARITY);
+  });
+
+  it("is whatever they set it to", () => {
+    expect(ragMinSimilarity({ RAG_MIN_SIMILARITY: "0.4" })).toBe(0.4);
+    expect(ragMinSimilarity({ RAG_MIN_SIMILARITY: " 0.15 " })).toBe(0.15);
+  });
+
+  it("takes 0, which means no floor at all", () => {
+    // The behaviour before migration 0005 added the argument, and a legitimate
+    // thing to want while tuning a new model — so it must not be read as unset.
+    expect(ragMinSimilarity({ RAG_MIN_SIMILARITY: "0" })).toBe(0);
+  });
+
+  it.each(["nope", "-0.1", "1.5", "25%"])("refuses %s", (value) => {
+    // 25 is the shape of the mistake worth catching: someone reading 0.25 as a
+    // percentage sets 25, and every chunk falls below a floor no chunk can
+    // reach. Retrieval then returns nothing, forever, without erroring once.
+    expect(() => ragMinSimilarity({ RAG_MIN_SIMILARITY: value })).toThrow(/RAG_MIN_SIMILARITY/);
   });
 });

--- a/worker/src/lib/rag.ts
+++ b/worker/src/lib/rag.ts
@@ -1,5 +1,35 @@
 export type RetrievedChunk = { documentName: string; content: string };
 
+/**
+ * The cosine-similarity floor, below which a chunk is treated as irrelevant.
+ *
+ * 0.25 is not a universal constant — it was chosen against
+ * `text-embedding-3-small`, which scores on-topic content well above it and
+ * clearly-unrelated content below it. Another model's scores are distributed
+ * differently: too high a floor starves genuine matches, too low a one puts the
+ * six nearest-but-irrelevant chunks into every prompt. Neither shows up as an
+ * error. Both look like "the answers got worse", which is the hardest kind of
+ * regression to attribute, so an operator who moves the model is given the dial
+ * that goes with it.
+ *
+ * `0` is a legitimate value and means no floor at all — the behaviour before
+ * migration 0005 added the argument.
+ */
+export const DEFAULT_RAG_MIN_SIMILARITY = 0.25;
+
+export function ragMinSimilarity(env: { RAG_MIN_SIMILARITY?: string }): number {
+  const raw = (env.RAG_MIN_SIMILARITY ?? "").trim();
+  if (raw === "") return DEFAULT_RAG_MIN_SIMILARITY;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 1) {
+    throw new Error(
+      `RAG_MIN_SIMILARITY must be a number between 0 and 1 (got ${JSON.stringify(raw)}). ` +
+        `It is a cosine similarity, not a percentage.`,
+    );
+  }
+  return n;
+}
+
 const HEADER =
   "The team has shared the following knowledge. Use it to ground your answers. " +
   "Answer naturally in your own words — do not cite, quote, or mention the document " +

--- a/worker/src/routes/bundles.ts
+++ b/worker/src/routes/bundles.ts
@@ -231,7 +231,7 @@ bundles.post("/bundles/:id/documents/upload", async (c) => {
   try {
     const chunks = chunkText(fullText);
     if (chunks.length > 0) {
-      const embedded = await embedTexts(c.env.OPENAI_API_KEY, chunks);
+      const embedded = await embedTexts(c.env, chunks);
       const vectors = embedded.vectors;
       await recordQuota(c, embeddingCost(embedded.tokens));
       const rows = chunks.map((ch, i) => ({
@@ -303,7 +303,7 @@ bundles.post("/admin/backfill-embeddings", async (c) => {
     try {
       // Not charged to anyone's quota: this is the operator repairing their own
       // data, not a user asking for work. It is gated by ADMIN_API_KEY above.
-      const { vectors } = await embedTexts(c.env.OPENAI_API_KEY, chunks);
+      const { vectors } = await embedTexts(c.env, chunks);
       const rows = chunks.map((ch, i) => ({
         document_id: d.id,
         bundle_id: d.bundle_id,

--- a/worker/src/routes/chat.ts
+++ b/worker/src/routes/chat.ts
@@ -7,7 +7,7 @@ import { serviceClient } from "../lib/supabase";
 import { resolveModel } from "../lib/models";
 import { createOpenAI } from "../lib/openai";
 import { embedTexts } from "../lib/embeddings";
-import { buildContextBlock } from "../lib/rag";
+import { buildContextBlock, ragMinSimilarity } from "../lib/rag";
 import { selectHistory } from "../lib/history";
 import { buildSystemPrefix, temperatureFor, maxTokensFor } from "../lib/prompt";
 import { effectiveMode } from "../lib/session-mode";
@@ -32,14 +32,12 @@ const MSG_HISTORY_LIMIT = 40;
 const HISTORY_CHAR_BUDGET = 16000;
 const PER_MESSAGE_CHAR_CAP = 4000;
 
-// How many chunks to retrieve, and the cosine-similarity floor below which a
-// chunk is treated as irrelevant and dropped. text-embedding-3-small scores
-// on-topic content well above this and clearly-unrelated content below it, so
-// the floor removes noise without starving genuine matches. The RAG block is
-// re-sent every turn and rides after the cacheable prefix, so it never caches —
-// keeping the count tight cuts recurring input directly.
+// How many chunks to retrieve. The RAG block is re-sent every turn and rides
+// after the cacheable prefix, so it never caches — keeping the count tight cuts
+// recurring input directly. The floor that goes with it is `ragMinSimilarity`,
+// which is configurable because it is a property of the embedding model rather
+// than of this route.
 const RAG_MATCH_COUNT = 6;
-const RAG_MIN_SIMILARITY = 0.25;
 
 // POST /chat/stream
 chat.post("/chat/stream", async (c) => {
@@ -143,10 +141,14 @@ chat.post("/chat/stream", async (c) => {
   const hasKnowledge = docNames.length > 0;
 
   // Semantic retrieval over the bundles attached to this agent. Best-effort:
-  // any failure falls back to persona-only so the reply is never blocked.
+  // any failure falls back to persona-only so the reply is never blocked. That
+  // includes a misconfigured EMBEDDING_DIMENSIONS or RAG_MIN_SIMILARITY, which
+  // land here as a throw and are logged rather than 500'd — an ungrounded
+  // answer beats no answer, and `loadEnv` is where a bad value is meant to be
+  // caught, at boot, before anybody asks anything.
   if (hasKnowledge) {
     try {
-      const embedded = await embedTexts(c.env.OPENAI_API_KEY, [lastMessage.content]);
+      const embedded = await embedTexts(c.env, [lastMessage.content]);
       embeddingTokens += embedded.tokens;
       const [queryEmbedding] = embedded.vectors;
       if (queryEmbedding) {
@@ -154,7 +156,7 @@ chat.post("/chat/stream", async (c) => {
           p_agent_id: session.agent_id,
           p_query_embedding: queryEmbedding,
           p_match_count: RAG_MATCH_COUNT,
-          p_min_similarity: RAG_MIN_SIMILARITY,
+          p_min_similarity: ragMinSimilarity(c.env),
         });
         if (matchError) {
           console.error("match_chunks failed", matchError);

--- a/worker/src/routes/documents.ts
+++ b/worker/src/routes/documents.ts
@@ -241,7 +241,7 @@ documents.post("/documents/:id/reindex", async (c) => {
   // a failure never leaves the document worse off than before.
   let vectors: number[][];
   try {
-    const embedded = await embedTexts(c.env.OPENAI_API_KEY, chunks);
+    const embedded = await embedTexts(c.env, chunks);
     vectors = embedded.vectors;
     await recordQuota(c, embeddingCost(embedded.tokens));
   } catch (e) {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -22,8 +22,9 @@ export type RoutineEnv = {
   /**
    * Where completions go. Unset means api.openai.com; set it to any
    * OpenAI-compatible endpoint (Ollama, vLLM, LiteLLM, OpenRouter) to keep the
-   * conversation on infrastructure you control. Embeddings and transcription
-   * are not routed through it — see `lib/openai` for why.
+   * conversation on infrastructure you control. Transcription is not routed
+   * through it, and embeddings have a variable of their own — see `lib/openai`
+   * for why they are two decisions rather than one.
    */
   OPENAI_BASE_URL?: string;
   /**
@@ -63,6 +64,32 @@ export type RoutineEnv = {
  */
 export type Bindings = RoutineEnv & {
   SUPABASE_ANON_KEY: string;
+  /**
+   * Where document embeddings go. Unset means api.openai.com, which is also
+   * what `OPENAI_BASE_URL` on its own leaves them at — the two do not inherit
+   * from each other, deliberately (`lib/openai`).
+   *
+   * On `Bindings` rather than `RoutineEnv` because nothing the cron Worker does
+   * embeds: it summarises and delivers, and retrieval belongs to a request.
+   */
+  EMBEDDING_BASE_URL?: string;
+  /** Unset means `text-embedding-3-small`. Set it whenever the endpoint is. */
+  EMBEDDING_MODEL?: string;
+  /**
+   * The width of `document_chunks.embedding`. Unset means 1536, which is what
+   * migration 0004 declares. Changing this without changing the column — or the
+   * other way round — is caught at the first embedding call rather than at the
+   * insert; see `lib/embeddings`.
+   */
+  EMBEDDING_DIMENSIONS?: string;
+  /**
+   * The cosine-similarity floor below which a retrieved chunk is dropped as
+   * irrelevant. Unset means 0.25, which is tuned against
+   * `text-embedding-3-small` — an operator who changes the embedding model
+   * needs their own floor, because a wrong one does not break retrieval, it
+   * quietly makes it worse.
+   */
+  RAG_MIN_SIMILARITY?: string;
   /**
    * The project's JWT signing secret, and the one thing that makes API keys
    * possible: a key is exchanged for a short-lived JWT for its owner, so the


### PR DESCRIPTION
`OPENAI_BASE_URL` moved completions and nothing else. Embedding — where the whole text of every uploaded document is sent — kept going to OpenAI, so a team self-hosting specifically to keep its files in-house watched every one of them leave on upload. Chat in-house, documents out.

`EMBEDDING_BASE_URL`, `EMBEDDING_MODEL` and `EMBEDDING_DIMENSIONS` close that. All three default to today's exact behaviour; nothing moves for anyone who does not set them.

### It does not inherit from `OPENAI_BASE_URL`, and that needed saying twice

An install that has had `OPENAI_BASE_URL` set for months works today — chat local, embeddings at OpenAI — and inheriting would relocate its documents on upgrade to an endpoint of a different width. They are also not one decision: serving completions is table stakes for a compatible server; serving embeddings at the width your column expects is not.

The second place it needed saying: `new OpenAI({ baseURL: undefined })` makes the SDK read `process.env.OPENAI_BASE_URL` itself — nothing on Workers, everything under compose. So the embedding client names `https://api.openai.com/v1` outright. Left implicit, an operator who moved only their chat would have found their documents at Ollama too, **on one runtime out of two**, having configured nothing of the sort. Tested.

### The width is not a variable

pgvector fixes a column's dimension at DDL time. `nomic-embed-text` is 768, `mxbai-embed-large` and `bge-m3` are 1024. `supabase/optional/embedding_width.sql` moves the column, the HNSW index and `match_chunks` together — **not** a migration on purpose: that directory is a linear sequence the hosted deployment runs too, and the number in this file is a fact about the operator's model. `migrate` mounts only `supabase/migrations`, so nothing applies it by accident.

`embedTexts` now checks every returned vector and refuses on a mismatch, naming the model, endpoint, both numbers and the fix. Without it a mismatch does not fail at the request — it fails at the *insert*, and both upload paths log that and still report the document saved. The symptom would be documents that upload cleanly and answer nothing.

The re-embed path this needs already existed: `POST /admin/backfill-embeddings` walks every document with stored text and no chunks. That is what makes the width change affordable instead of a re-upload of everything.

### `RAG_MIN_SIMILARITY`

0.25 is a fact about `text-embedding-3-small`, not about retrieval. Wrong for another model it never errors — too high starves real matches, too low fills every prompt with noise. Both look like the answers got worse. `loadEnv` refuses to boot on a malformed width or floor.

### Also

- `lib/embeddings.ts` leaves `openai.test.ts`'s exemption list; it is down to transcription alone.
- #41, `lib/openai.ts` and `docs/self-hosting.md` all named `knowledge_chunks` — a table that does not exist. It is `document_chunks`.

### Verification

580 worker tests, 313 frontend, typecheck and lint clean. The SQL was run against a scratch Postgres: the DO block compiles (all three dollar-quote levels), the guard and notices fire in order, and the generated `create function` is 0005's body with the width substituted — it compiles and takes the grant. **Not executed:** the pgvector-specific statements, since there is no pgvector locally.

Closes #41