### PR TITLE
Let a workspace be taken away in one file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ one.
   Slack.
 - **Collaborative sessions.** Bring the team into one conversation, or one
   brainstorm board, when the question is shared.
+- **Take it with you.** One button in Settings downloads the whole workspace
+  as an archive — agents, documents and their files, chats, routines — with
+  the SQL to replay it into a Covan you run yourself. "Nothing is held
+  hostage" should be checkable by the team, not only by whoever runs the
+  server ([`docs/export.md`](docs/export.md)).
 - **Bring your own endpoint.** Set `OPENAI_BASE_URL` and completions go to
   Ollama, vLLM, LiteLLM or OpenRouter instead of OpenAI. Set
   `EMBEDDING_BASE_URL` and your documents go there too — a separate variable,
@@ -57,7 +62,7 @@ that it answers, but that you can check it.
 
 [`yc-software/qm`](https://github.com/yc-software/qm) (MIT) is the obvious
 alternative and a good project. It describes itself as a multiplayer agent
-*harness* for work: an isolated agent workspace per employee, shared channels
+_harness_ for work: an isolated agent workspace per employee, shared channels
 and projects, Slack and web, and a pluggable choice of model. If your team is
 mostly engineers, that is very likely what you want, and it is better to say so
 than to pretend the comparison isn't there.
@@ -142,25 +147,26 @@ See [`docs/architecture.md`](docs/architecture.md) for detail.
 `docs/` is the whole of it. The same files are rendered at
 <https://covan.app/docs> if you would rather read them there.
 
-| Page                                          | What it answers                                                             |
-| --------------------------------------------- | --------------------------------------------------------------------------- |
-| [Quickstart](docs/quickstart.md)              | From an empty account to an answer that names the file it came from         |
-| [Core concepts](docs/concepts.md)             | Workspace, agent, bundle, session, routine — what each is and how they nest |
-| [Knowledge bundles](docs/knowledge.md)        | Uploading, grouping, attaching, and why a question finds the passage it does |
-| [Routines](docs/routines.md)                  | Scheduled work, what it can reach, and what it does with the secret you give it |
-| [Your team](docs/team.md)                     | Invitations, what a role actually gates, shared sessions, deletion          |
-| [Self-hosting](docs/self-hosting.md)          | Running it on your own machine, and deploying it somewhere real             |
-| [Architecture](docs/architecture.md)          | How a request reaches a row, and the two seams that serve both runtimes     |
+| Page                                   | What it answers                                                                 |
+| -------------------------------------- | ------------------------------------------------------------------------------- |
+| [Quickstart](docs/quickstart.md)       | From an empty account to an answer that names the file it came from             |
+| [Core concepts](docs/concepts.md)      | Workspace, agent, bundle, session, routine — what each is and how they nest     |
+| [Knowledge bundles](docs/knowledge.md) | Uploading, grouping, attaching, and why a question finds the passage it does    |
+| [Routines](docs/routines.md)           | Scheduled work, what it can reach, and what it does with the secret you give it |
+| [Your team](docs/team.md)              | Invitations, what a role actually gates, shared sessions, deletion              |
+| [Taking it with you](docs/export.md)   | Exporting a workspace, and putting it back into a Covan you run                 |
+| [Self-hosting](docs/self-hosting.md)   | Running it on your own machine, and deploying it somewhere real                 |
+| [Architecture](docs/architecture.md)   | How a request reaches a row, and the two seams that serve both runtimes         |
 
 ## Repository layout
 
-| Path                   | What it is                                              |
-| ---------------------- | ------------------------------------------------------- |
-| `src/`                 | TanStack Start frontend — file-based routes, shadcn/ui  |
+| Path                   | What it is                                                 |
+| ---------------------- | ---------------------------------------------------------- |
+| `src/`                 | TanStack Start frontend — file-based routes, shadcn/ui     |
 | `worker/`              | Hono API; `src/index.ts` is the Worker, `src/node.ts` Node |
-| `supabase/migrations/` | Numbered SQL, applied in order                          |
-| `docker/`              | Compose support files (Kong config, DB init hooks)      |
-| `docs/`                | The documentation above, in markdown                    |
+| `supabase/migrations/` | Numbered SQL, applied in order                             |
+| `docker/`              | Compose support files (Kong config, DB init hooks)         |
+| `docs/`                | The documentation above, in markdown                       |
 
 ## Development
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,20 +44,26 @@ Scopes would be a second permission system standing next to that one, and two
 systems that disagree about the same question are worse than one. What a key
 gives up in granularity it gains in there being nothing to get wrong.
 
-Two things a key cannot do, both by explicit refusal:
+Three things a key cannot do, each by explicit refusal:
 
 - **Create another key.** Otherwise a leaked key writes itself permanent
   successors and revoking the original achieves nothing.
 - **Revoke a key.** Otherwise a leaked key takes down the keys you are relying
   on.
+- **Close the account.** Otherwise a leaked key ends the account it came from in
+  one call, destroying the evidence and the account together, and no revocation
+  afterwards can undo it.
 
-Both need a signed-in session. Everything else is open to a key.
+All three need a signed-in session. Everything else is open to a key —
+including `GET /workspaces/:id/export`, which is not refused because it is a
+read: a key that can reach `/agents` and `/messages` can already assemble the
+same archive with a loop, so a refusal would be a gate with a door beside it.
 
 ### A key belongs to a person
 
 Not to the workspace. When you leave a workspace — or an admin removes you —
 your keys stop working at the same moment your own access does, because they
-*are* your access. A script running on a departed colleague's key goes quiet.
+_are_ your access. A script running on a departed colleague's key goes quiet.
 
 That is the correct behaviour and it is also the one that surprises people, so
 the removal dialog on the Team page says how many live keys somebody has before
@@ -90,15 +96,15 @@ server-sent events — the same stream the chat window reads.
 
 ### Errors
 
-| Status | What it means |
-| --- | --- |
-| `400` | The body failed validation. The response names the fields. |
-| `401` | No key, an unknown key, a revoked key, or a key on a deployment that cannot honour one. All four look the same on purpose. |
-| `403` | A policy refused. You are authenticated; you are not permitted. |
-| `404` | Not there, or not yours — Row Level Security returns nothing rather than admitting a row exists. |
-| `409` | A conflict, e.g. inviting somebody who is already a member. |
-| `429` | Rate limited. |
-| `501` | The deployment has not enabled this feature. |
+| Status | What it means                                                                                                              |
+| ------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `400`  | The body failed validation. The response names the fields.                                                                 |
+| `401`  | No key, an unknown key, a revoked key, or a key on a deployment that cannot honour one. All four look the same on purpose. |
+| `403`  | A policy refused. You are authenticated; you are not permitted.                                                            |
+| `404`  | Not there, or not yours — Row Level Security returns nothing rather than admitting a row exists.                           |
+| `409`  | A conflict, e.g. inviting somebody who is already a member.                                                                |
+| `429`  | Rate limited.                                                                                                              |
+| `501`  | The deployment has not enabled this feature.                                                                               |
 
 A `403` and a `404` are often the same underlying refusal seen from different
 angles: when a policy hides a row, the route cannot tell "you may not" from "it
@@ -125,27 +131,27 @@ client for all of it.
 
 ### Agents
 
-| | |
-| --- | --- |
-| `GET /agents` | Every agent in the workspace |
-| `POST /agents` | Create one |
-| `PATCH /agents/:id` | Rename, re-persona, change model |
-| `DELETE /agents/:id` | Delete |
-| `POST /agents/:id/bundles/:bundleId` | Attach a knowledge bundle |
-| `DELETE /agents/:id/bundles/:bundleId` | Detach it |
-| `GET /favorites` · `POST /agents/:id/favorite` | Your own shortcuts |
+|                                                |                                  |
+| ---------------------------------------------- | -------------------------------- |
+| `GET /agents`                                  | Every agent in the workspace     |
+| `POST /agents`                                 | Create one                       |
+| `PATCH /agents/:id`                            | Rename, re-persona, change model |
+| `DELETE /agents/:id`                           | Delete                           |
+| `POST /agents/:id/bundles/:bundleId`           | Attach a knowledge bundle        |
+| `DELETE /agents/:id/bundles/:bundleId`         | Detach it                        |
+| `GET /favorites` · `POST /agents/:id/favorite` | Your own shortcuts               |
 
 ### Conversations
 
-| | |
-| --- | --- |
-| `GET /sessions` · `POST /sessions` | List and open conversations |
-| `PATCH /sessions/:id` · `DELETE /sessions/:id` | Rename, share, delete |
-| `GET /sessions/:id/messages` | The transcript |
-| `POST /messages` · `PATCH /messages/:id` | Write and edit your own lines |
-| `DELETE /messages/after/:id` | Truncate, for a re-ask |
-| `POST /chat/stream` | Ask. Streams SSE. |
-| `POST /transcribe` | Audio to text |
+|                                                |                               |
+| ---------------------------------------------- | ----------------------------- |
+| `GET /sessions` · `POST /sessions`             | List and open conversations   |
+| `PATCH /sessions/:id` · `DELETE /sessions/:id` | Rename, share, delete         |
+| `GET /sessions/:id/messages`                   | The transcript                |
+| `POST /messages` · `PATCH /messages/:id`       | Write and edit your own lines |
+| `DELETE /messages/after/:id`                   | Truncate, for a re-ask        |
+| `POST /chat/stream`                            | Ask. Streams SSE.             |
+| `POST /transcribe`                             | Audio to text                 |
 
 A session is private to you unless its `visibility` is `shared`, in which case
 the workspace can read it. Assistant replies cannot be written by any client,
@@ -153,47 +159,49 @@ including this one — see [Your team](team.md).
 
 ### Knowledge
 
-| | |
-| --- | --- |
-| `GET /bundles` · `POST /bundles` | Subjects |
-| `PATCH /bundles/:id` · `DELETE /bundles/:id` | Rename, delete |
-| `POST /bundles/:id/documents/upload` | Upload a document |
-| `PATCH /documents/:id` · `DELETE /documents/:id` | Rename, move, delete |
-| `GET /documents/:id/download` | The original file |
-| `POST /documents/:id/reindex` | Re-chunk and re-embed |
+|                                                  |                       |
+| ------------------------------------------------ | --------------------- |
+| `GET /bundles` · `POST /bundles`                 | Subjects              |
+| `PATCH /bundles/:id` · `DELETE /bundles/:id`     | Rename, delete        |
+| `POST /bundles/:id/documents/upload`             | Upload a document     |
+| `PATCH /documents/:id` · `DELETE /documents/:id` | Rename, move, delete  |
+| `GET /documents/:id/download`                    | The original file     |
+| `POST /documents/:id/reindex`                    | Re-chunk and re-embed |
 
 ### Routines
 
-| | |
-| --- | --- |
-| `GET /routines` · `POST /routines` | Scheduled work |
-| `PATCH /routines/:id` · `DELETE /routines/:id` | Change, delete |
-| `POST /routines/:id/run` | Run now, rather than on schedule |
-| `GET /routines/:id/runs` | What happened |
-| `POST /routines/draft` | Turn a sentence into a routine |
-| `GET`/`POST`/`DELETE /delivery-channels` | Where output goes |
+|                                                |                                  |
+| ---------------------------------------------- | -------------------------------- |
+| `GET /routines` · `POST /routines`             | Scheduled work                   |
+| `PATCH /routines/:id` · `DELETE /routines/:id` | Change, delete                   |
+| `POST /routines/:id/run`                       | Run now, rather than on schedule |
+| `GET /routines/:id/runs`                       | What happened                    |
+| `POST /routines/draft`                         | Turn a sentence into a routine   |
+| `GET`/`POST`/`DELETE /delivery-channels`       | Where output goes                |
 
 ### Workspace and people
 
-| | |
-| --- | --- |
-| `GET /me` · `PATCH /me` | You, and your display name |
-| `GET /workspaces` · `POST /workspaces` | Every workspace you are in |
-| `POST /workspace/active` | Switch which one requests are scoped to |
-| `PATCH /workspace` | Name, slug, default model. Admin. |
-| `PATCH`/`DELETE /workspace/members/:userId` | Change a role, remove somebody. Admin. |
-| `DELETE /workspace/members/me` | Leave |
-| `GET`/`POST`/`DELETE /invitations` | Invite and revoke. Admin. |
-| `GET /invitations/incoming` · `POST /invitations/:id/accept` | Yours to accept |
+|                                                              |                                                                                                                |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `GET /me` · `PATCH /me`                                      | You, and your display name                                                                                     |
+| `GET /workspaces` · `POST /workspaces`                       | Every workspace you are in                                                                                     |
+| `POST /workspace/active`                                     | Switch which one requests are scoped to                                                                        |
+| `PATCH /workspace`                                           | Name, slug, default model. Admin.                                                                              |
+| `PATCH`/`DELETE /workspace/members/:userId`                  | Change a role, remove somebody. Admin.                                                                         |
+| `DELETE /workspace/members/me`                               | Leave                                                                                                          |
+| `GET`/`POST`/`DELETE /invitations`                           | Invite and revoke. Admin.                                                                                      |
+| `GET /invitations/incoming` · `POST /invitations/:id/accept` | Yours to accept                                                                                                |
+| `GET /workspaces/:id/export`                                 | The whole workspace as one zip — [Taking it with you](export.md)                                               |
+| `DELETE /account`                                            | Close your own account. Session only. Refused while you are the last admin of a workspace others are still in. |
 
 ### Usage and keys
 
-| | |
-| --- | --- |
-| `GET /usage` | Your own totals and what is left of your allowance |
-| `GET /usage/workspace` | Everyone's, by agent and by month. Admin. Never by person. |
-| `GET /api-keys` | Your own live keys. Never anyone else's. |
-| `POST /api-keys` · `DELETE /api-keys/:id` | Session only, as above |
+|                                           |                                                            |
+| ----------------------------------------- | ---------------------------------------------------------- |
+| `GET /usage`                              | Your own totals and what is left of your allowance         |
+| `GET /usage/workspace`                    | Everyone's, by agent and by month. Admin. Never by person. |
+| `GET /api-keys`                           | Your own live keys. Never anyone else's.                   |
+| `POST /api-keys` · `DELETE /api-keys/:id` | Session only, as above                                     |
 
 ### Other
 

--- a/docs/export.md
+++ b/docs/export.md
@@ -39,11 +39,19 @@ routines and their run history.
   become one of its members. An archive carrying them would be a key store that
   people email to each other.
 - **Delivery secrets.** `delivery_channels` comes back with its label and its
-  kind, and without `secret_ciphertext`. That column is encrypted with the
-  install's `ROUTINE_SECRET_KEY` and would be undecryptable noise anywhere else
-  — and the export could not read it even if it wanted to, because migration
-  0023 withholds that column from `authenticated`. **Any routine that posts to
-  Slack or a webhook needs its credential entered again after a restore.**
+  kind, and without a real `secret_ciphertext`. That column is encrypted with
+  the install's `ROUTINE_SECRET_KEY` and would be undecryptable noise anywhere
+  else — and the export could not read it even if it wanted to, because
+  migration 0023 withholds that column from `authenticated`.
+
+  The column is `not null`, so the restore writes a placeholder that is visibly
+  not a credential. **Every routine therefore comes back paused**, with the
+  reason on its own row: re-enter the channel's credential, then resume it. A
+  routine restored still running would fail on a schedule, somewhere nobody is
+  looking. Skipping the channels instead was not an option —
+  `routines.delivery_channel_id` is `not null` too, so a workspace with any
+  routine would have had nothing to restore at all.
+
 - **Invitations, notification preferences and onboarding state.** An invitation
   is an offer to somebody who has not accepted, scoped to an install's tokens.
   The other two follow a person rather than a workspace.

--- a/docs/export.md
+++ b/docs/export.md
@@ -97,6 +97,14 @@ the filenames under `documents/` still match their rows. Every statement is
 `on conflict do nothing`, so a restore interrupted half way can simply be run
 again.
 
+The same clause has a consequence worth knowing: **restoring into a database
+that already holds a row with the same id keeps the row that is already there.**
+Usually that is what you want — a delivery channel outlives the workspace it was
+added from (migration 0019), so re-restoring in the same install keeps the real
+channel with its real secret rather than replacing it with this archive's
+stand-in. It also means a restore is not a way to roll a workspace back to an
+earlier state: for that, restore into an empty database.
+
 ### The documents
 
 `workspace.sql` restores the rows. The files are separate, and where they go

--- a/docs/export.md
+++ b/docs/export.md
@@ -1,0 +1,142 @@
+# Taking a workspace with you
+
+Settings → **Take it with you** → _Download the archive_. One zip, containing
+everything the workspace holds and the SQL to put it back into a Covan you run
+yourself.
+
+The point of it is that the README's claim should be checkable by the person the
+claim is aimed at. "Self-host it, nothing is held hostage" has always been true
+of the licence and of the database — and `pg_dump` is an answer for whoever runs
+the server, not for the team using their install. This is the same answer, made
+available to the people whose work it is.
+
+## What is in it
+
+```
+manifest.json                  what this file is, whose view it holds, what was left out
+workspace.sql                  every row, as inserts, in one transaction
+restore.sh                     the two commands, in order
+data/<table>.json              the same rows as JSON, for reading rather than replaying
+documents/<id>-<name>          the original file of every document
+data/export-warnings.json      anything that could not be collected
+```
+
+The tables: the workspace itself, its members and their profiles, agents and
+their personas, knowledge bundles and what they are attached to, documents,
+chat sessions and messages, brainstorm ideas, favourites, delivery channels,
+routines and their run history.
+
+## What is not, and why
+
+- **Retrieval chunks.** Every chunk carries a 1536-dimension vector, so a
+  workspace with ten thousand of them is tens of megabytes of numbers that say
+  nothing a human can read — and they are derived. The documents are in the
+  archive; `POST /admin/backfill-embeddings` rebuilds the chunks from them after
+  a restore, with whatever embedding model the new install is configured for,
+  which is more useful than replaying the old one's. See
+  [self-hosting](self-hosting.md#keeping-your-documents-off-openai-too).
+- **API keys.** A key is not a record of what a workspace holds; it is a way to
+  become one of its members. An archive carrying them would be a key store that
+  people email to each other.
+- **Delivery secrets.** `delivery_channels` comes back with its label and its
+  kind, and without `secret_ciphertext`. That column is encrypted with the
+  install's `ROUTINE_SECRET_KEY` and would be undecryptable noise anywhere else
+  — and the export could not read it even if it wanted to, because migration
+  0023 withholds that column from `authenticated`. **Any routine that posts to
+  Slack or a webhook needs its credential entered again after a restore.**
+- **Invitations, notification preferences and onboarding state.** An invitation
+  is an offer to somebody who has not accepted, scoped to an install's tokens.
+  The other two follow a person rather than a workspace.
+
+`manifest.json` repeats all of this, so the file explains itself in two years
+when nobody remembers this page.
+
+## Whose view it is
+
+An export is a read like any other and goes through your own client, so what is
+in it is what you could see by clicking around. **An admin's export and a
+member's export are different files.** Somebody else's private chat sessions are
+not in your copy, and the manifest says so rather than letting a filename imply
+the archive is the whole workspace.
+
+One consequence worth knowing: if a row in your export points at something you
+could not see — an idea cited from a message in somebody else's private session
+— that reference is dropped rather than left to fail the restore. The manifest's
+`droppedReferences` counts each one.
+
+## Putting it back
+
+```sh
+unzip covan-acme-2026-08-31.zip -d acme
+cd acme
+./restore.sh "postgres://..." "<the user id it should belong to>"
+```
+
+Or, without the script:
+
+```sh
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -v owner="'<user-id>'" -f workspace.sql
+```
+
+`owner` is required and psql stops if it is missing. **Every person in the
+original workspace becomes that one account.** Accounts cannot be carried
+between installs — there is no id to bring across — and inventing users for
+people who did not ask to be recreated would be worse than saying so plainly.
+The membership rows collapse to a single admin: the account you named.
+
+Ids are preserved, so the restore is comparable to the export row for row, and
+the filenames under `documents/` still match their rows. Every statement is
+`on conflict do nothing`, so a restore interrupted half way can simply be run
+again.
+
+### The documents
+
+`workspace.sql` restores the rows. The files are separate, and where they go
+depends on how the target install stores them:
+
+- **Docker / any Node host.** Documents live under `DOCS_DIR`, keyed by the
+  `r2_key` column. Copy each file there under its key:
+
+  ```sh
+  jq -r '.[] | select(.r2_key) | "\(.id)\t\(.r2_key)"' data/documents.json |
+  while IFS=$'\t' read -r id key; do
+    dest="$DOCS_DIR/$key"
+    mkdir -p "$(dirname "$dest")"
+    cp documents/$id-* "$dest"
+  done
+  ```
+
+- **Cloudflare.** The same keys, in the R2 bucket bound as `DOCS`:
+
+  ```sh
+  jq -r '.[] | select(.r2_key) | "\(.id)\t\(.r2_key)"' data/documents.json |
+  while IFS=$'\t' read -r id key; do
+    npx wrangler r2 object put "covan-docs/$key" --file documents/$id-*
+  done
+  ```
+
+Skip this step and the workspace restores with documents it lists and cannot
+open. `data/export-warnings.json` names anything that was already unreadable at
+export time.
+
+### Then rebuild retrieval
+
+```sh
+curl -X POST "$API/admin/backfill-embeddings" -H "x-admin-key: $ADMIN_API_KEY"
+```
+
+Until that finishes, answers fall back to the agent's persona alone — degraded,
+not broken, and exactly what happens today for a document whose upload-time
+embedding failed.
+
+## Limits
+
+The archive is built in one request and held in the browser before it is saved,
+which is what fetching with a bearer token costs — an `<a href>` carries no
+Authorization header. The server streams, so its own memory holds one document
+at a time; the ceiling is the browser's.
+
+The zip is written without compression and without Zip64, so it refuses past
+4 GB or 65,535 entries rather than emitting an archive whose offsets have
+wrapped. If you reach either, the archive is not the tool you want — take a
+database backup instead.

--- a/docs/team.md
+++ b/docs/team.md
@@ -394,6 +394,16 @@ Re-inviting the person gives all of it back, because none of it was destroyed.
 The one thing that does not resume itself is a routine the engine paused: the
 pause outlives the rejoining, and only its owner can clear it.
 
+## Taking a workspace with you
+
+Before the section below, because it is the thing to do first. Settings →
+**Take it with you** downloads the workspace as one archive: agents, bundles,
+documents and their original files, chats and messages, ideas, routines — plus
+the SQL to replay all of it into a Covan you run yourself. Not gated on a role,
+because it is a read: your archive holds what you could already see, and
+somebody else's private sessions are not in it. [Taking it with you](export.md)
+covers what is left out and why, and how to put it back.
+
 ## Deleting a workspace
 
 Not directly. `workspaces` has select, update and insert policies and no delete

--- a/src/components/export-workspace-section.test.tsx
+++ b/src/components/export-workspace-section.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ExportWorkspaceSection } from "./export-workspace-section";
+
+// Hoisted with the mocks for the same reason `close-account-section.test.tsx`
+// does it: `vi.mock`'s factory runs before any top-level statement here, so a
+// class declared below would not exist when the factory referenced it.
+const { exportArchive, success, error, FakeApiError } = vi.hoisted(() => ({
+  exportArchive: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  FakeApiError: class FakeApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+// Mocked whole rather than partially: the real module builds a Supabase client
+// at import time, which needs an origin no unit test has.
+vi.mock("@/lib/api-client", () => ({
+  api: { workspace: { exportArchive } },
+  ApiError: FakeApiError,
+}));
+
+vi.mock("sonner", () => ({ toast: { success, error } }));
+
+const WORKSPACE = { workspaceId: "ws-1", workspaceName: "Acme" };
+const button = () => screen.getByRole("button", { name: /Download the archive|Building/ });
+
+beforeEach(() => {
+  exportArchive.mockReset();
+  success.mockReset();
+  error.mockReset();
+});
+
+describe("the export button", () => {
+  it("asks for this workspace, not for whichever one the URL says", async () => {
+    exportArchive.mockResolvedValue(undefined);
+    render(<ExportWorkspaceSection {...WORKSPACE} />);
+
+    await userEvent.click(button());
+
+    await waitFor(() => expect(exportArchive).toHaveBeenCalledWith("ws-1"));
+  });
+
+  it("names the workspace, so nobody exports the wrong one", async () => {
+    // Covan switches workspaces without changing this page, and an archive of
+    // the wrong team is a mistake you find out about much later.
+    render(<ExportWorkspaceSection {...WORKSPACE} />);
+    expect(screen.getByText(/Exports Acme, the workspace you are in\./)).toBeInTheDocument();
+  });
+
+  it("says what it is doing while it builds", async () => {
+    let finish: () => void = () => {};
+    exportArchive.mockImplementation(() => new Promise<void>((r) => (finish = r)));
+    render(<ExportWorkspaceSection {...WORKSPACE} />);
+
+    await userEvent.click(button());
+
+    // A whole workspace is not instant, and a button that looks idle is a
+    // button somebody presses again.
+    await waitFor(() => expect(button()).toBeDisabled());
+    expect(screen.getByText("Building the archive…")).toBeInTheDocument();
+
+    finish();
+    await waitFor(() => expect(button()).toBeEnabled());
+  });
+
+  it("cannot be pressed twice into two archives", async () => {
+    exportArchive.mockImplementation(() => new Promise<void>(() => {}));
+    render(<ExportWorkspaceSection {...WORKSPACE} />);
+
+    await userEvent.click(button());
+    await userEvent.click(button());
+
+    expect(exportArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing at all before the workspace is known", async () => {
+    // `me` arrives asynchronously, and a click in that window would ask the
+    // server for `/workspaces/undefined/export`.
+    render(<ExportWorkspaceSection />);
+
+    expect(button()).toBeDisabled();
+    await userEvent.click(button());
+    expect(exportArchive).not.toHaveBeenCalled();
+  });
+});
+
+describe("when it fails", () => {
+  it("passes the server's own words through", async () => {
+    exportArchive.mockRejectedValue(new FakeApiError(500, "failed to read messages"));
+    render(<ExportWorkspaceSection {...WORKSPACE} />);
+
+    await userEvent.click(button());
+
+    await waitFor(() => expect(error).toHaveBeenCalledWith("failed to read messages"));
+  });
+
+  it("falls back to plain language for a failure that is not the server's", async () => {
+    exportArchive.mockRejectedValue(new TypeError("Failed to fetch"));
+    render(<ExportWorkspaceSection {...WORKSPACE} />);
+
+    await userEvent.click(button());
+
+    await waitFor(() => expect(error).toHaveBeenCalledWith("Could not build the export"));
+  });
+
+  it("lets you try again, because trying again is the whole remedy", async () => {
+    exportArchive.mockRejectedValueOnce(new TypeError("boom")).mockResolvedValueOnce(undefined);
+    render(<ExportWorkspaceSection {...WORKSPACE} />);
+
+    await userEvent.click(button());
+    await waitFor(() => expect(error).toHaveBeenCalled());
+    await waitFor(() => expect(button()).toBeEnabled());
+
+    await userEvent.click(button());
+    await waitFor(() => expect(success).toHaveBeenCalledWith("Export downloaded"));
+  });
+});
+
+describe("what the page promises about the file", () => {
+  it("says it holds this person's view rather than the whole workspace", () => {
+    render(<ExportWorkspaceSection {...WORKSPACE} />);
+    expect(screen.getByText(/private chats are not in your copy/)).toBeInTheDocument();
+  });
+
+  it("warns that delivery secrets do not travel", () => {
+    // Somebody restoring a workspace and finding their Slack routine silently
+    // dead should have been told here, not have worked it out.
+    render(<ExportWorkspaceSection {...WORKSPACE} />);
+    expect(screen.getByText(/without their secrets/)).toBeInTheDocument();
+  });
+
+  it("says the chunks are left out and why", () => {
+    render(<ExportWorkspaceSection {...WORKSPACE} />);
+    expect(screen.getByText(/rebuilt from the documents after a restore/)).toBeInTheDocument();
+  });
+});

--- a/src/components/export-workspace-section.test.tsx
+++ b/src/components/export-workspace-section.test.tsx
@@ -129,11 +129,12 @@ describe("what the page promises about the file", () => {
     expect(screen.getByText(/private chats are not in your copy/)).toBeInTheDocument();
   });
 
-  it("warns that delivery secrets do not travel", () => {
+  it("warns that delivery secrets do not travel, and what that costs", () => {
     // Somebody restoring a workspace and finding their Slack routine silently
     // dead should have been told here, not have worked it out.
     render(<ExportWorkspaceSection {...WORKSPACE} />);
     expect(screen.getByText(/without their secrets/)).toBeInTheDocument();
+    expect(screen.getByText(/waiting for its credential/)).toBeInTheDocument();
   });
 
   it("says the chunks are left out and why", () => {

--- a/src/components/export-workspace-section.tsx
+++ b/src/components/export-workspace-section.tsx
@@ -67,10 +67,12 @@ export function ExportWorkspaceSection({
         </p>
         <p className="text-sm text-muted-foreground">
           It holds what <span className="text-foreground">you</span> can see. Somebody else&rsquo;s
-          private chats are not in your copy, and delivery channels come back without their secrets
-          — those are encrypted with a key that belongs to this install and would be unreadable
-          anywhere else. The archive&rsquo;s <code className="text-xs">manifest.json</code> repeats
-          all of this, so the file explains itself later, when nobody remembers this page.
+          private chats are not in your copy. Delivery channels come back without their secrets —
+          those are encrypted with a key belonging to this install — so a restore brings every
+          routine back <span className="text-foreground">paused</span>, waiting for its credential
+          rather than failing on a schedule. The archive&rsquo;s{" "}
+          <code className="text-xs">manifest.json</code> repeats all of this, so the file explains
+          itself later, when nobody remembers this page.
         </p>
         <div className="flex items-center gap-3">
           <Button onClick={download} disabled={busy || !workspaceId} variant="outline">

--- a/src/components/export-workspace-section.tsx
+++ b/src/components/export-workspace-section.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { SectionHeading } from "@/components/page-container";
+import { SectionCard } from "@/components/section-card";
+import { Button } from "@/components/ui/button";
+import { api, ApiError } from "@/lib/api-client";
+import { toast } from "sonner";
+
+/**
+ * Taking the workspace with you.
+ *
+ * The README has always said a self-hosted Covan is the whole product and that
+ * nothing is held hostage. That was true of the licence and true of the
+ * database, and not true of the interface: the answer to "can I get my data
+ * out" was `pg_dump`, which is an answer for whoever runs the server and not
+ * for the team using it. This is the button that makes the claim checkable by
+ * the person the claim was aimed at.
+ *
+ * Deliberately not gated on being an admin. An export is a read, and it
+ * contains what this person could already see by clicking around — so refusing
+ * it to a member would withhold a convenient copy of their own work, not
+ * protect anything. What their file does *not* contain is anybody else's
+ * private sessions, and the archive's manifest says so in its own words rather
+ * than letting the filename imply otherwise.
+ *
+ * The whole archive lands in the browser before it is saved, which is what
+ * fetching with a bearer token costs — an `<a href>` carries no Authorization
+ * header. Fine for a workspace; the limit is the browser's memory, and the one
+ * that would bite first is the Worker's, which is why the server streams.
+ */
+export function ExportWorkspaceSection({
+  workspaceId,
+  workspaceName,
+}: {
+  workspaceId?: string;
+  workspaceName?: string;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  const download = async () => {
+    if (busy || !workspaceId) return;
+    setBusy(true);
+    try {
+      await api.workspace.exportArchive(workspaceId);
+      toast.success("Export downloaded");
+    } catch (e) {
+      // No inline error state here, unlike closing an account: there is nothing
+      // to go and fix and nothing to re-type. A failed export is a failed
+      // request, and trying again is the whole remedy.
+      toast.error(e instanceof ApiError ? e.message : "Could not build the export");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="mt-14">
+      <SectionHeading
+        title="Take it with you"
+        description="Everything this workspace holds, in one archive, with the SQL to put it back into a Covan you run yourself."
+      />
+      <SectionCard className="mt-6 space-y-5">
+        <p className="text-sm text-muted-foreground">
+          Agents and their personas, knowledge bundles, every document and its original file, chats
+          and their messages, brainstorm boards, and routines with their schedules. Retrieval chunks
+          are left out — they are rebuilt from the documents after a restore, and they would be the
+          largest thing in the file by far.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          It holds what <span className="text-foreground">you</span> can see. Somebody else&rsquo;s
+          private chats are not in your copy, and delivery channels come back without their secrets
+          — those are encrypted with a key that belongs to this install and would be unreadable
+          anywhere else. The archive&rsquo;s <code className="text-xs">manifest.json</code> repeats
+          all of this, so the file explains itself later, when nobody remembers this page.
+        </p>
+        <div className="flex items-center gap-3">
+          <Button onClick={download} disabled={busy || !workspaceId} variant="outline">
+            {busy ? "Building the archive…" : "Download the archive"}
+          </Button>
+          {workspaceName ? (
+            <span className="text-xs text-muted-foreground">
+              Exports {workspaceName}, the workspace you are in.
+            </span>
+          ) : null}
+        </div>
+      </SectionCard>
+    </section>
+  );
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -86,6 +86,25 @@ export async function getAccessToken(): Promise<string | undefined> {
   return data.session?.access_token;
 }
 
+/**
+ * The filename a `Content-Disposition` asked for, or null.
+ *
+ * Only the RFC 5987 `filename*=UTF-8''...` form, which is what the Worker
+ * sends and the only one that survives a non-ASCII workspace name. A header
+ * that does not match returns null and the caller names the file itself,
+ * rather than this half-parsing something and producing a name with quotes in
+ * it.
+ */
+function filenameFrom(header: string | null): string | null {
+  const match = header?.match(/filename\*=UTF-8''([^;]+)/i);
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return null;
+  }
+}
+
 async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
   const token = await getAccessToken();
 
@@ -324,6 +343,44 @@ export const api = {
     }): Promise<Workspace> => request("PATCH", "/workspace", patch),
     setActive: (workspaceId: string): Promise<{ ok: true }> =>
       request("POST", "/workspace/active", { workspaceId }),
+    /**
+     * Downloads the whole workspace as one archive.
+     *
+     * Fetched with the bearer token and handed to the browser as a blob, the
+     * same way a document download works — an `<a href>` cannot carry an
+     * Authorization header, and putting the token in a query string would put
+     * it in every log between here and the Worker.
+     *
+     * The filename comes from the response rather than from here: the server
+     * knows the workspace slug and the date it actually built the archive, and
+     * two files called `export.zip` in a downloads folder are two files nobody
+     * can tell apart.
+     */
+    exportArchive: async (workspaceId: string): Promise<void> => {
+      const token = await getAccessToken();
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/workspaces/${workspaceId}/export`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!res.ok) {
+        let message = res.statusText;
+        try {
+          message = errorMessage(res.status, await res.json(), res.statusText);
+        } catch {
+          // A failure that is not JSON is still a failure; keep the status text.
+        }
+        throw new ApiError(res.status, message);
+      }
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filenameFrom(res.headers.get("Content-Disposition")) ?? "covan-export.zip";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    },
     members: {
       updateRole: (userId: string, role: WorkspaceRole): Promise<{ ok: true }> =>
         request("PATCH", `/workspace/members/${userId}`, { role }),

--- a/src/routes/_authed.settings.tsx
+++ b/src/routes/_authed.settings.tsx
@@ -10,6 +10,7 @@ import { UsageSection } from "@/components/usage-section";
 import { WorkspaceUsageSection } from "@/components/workspace-usage-section";
 import { PreferencesSection } from "@/components/preferences-section";
 import { ApiKeysSection } from "@/components/api-keys-section";
+import { ExportWorkspaceSection } from "@/components/export-workspace-section";
 import { CloseAccountSection } from "@/components/close-account-section";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -225,6 +226,13 @@ function SettingsPage() {
             to approve. The section hides itself where the deployment cannot
             honour a key at all. */}
         <ApiKeysSection />
+
+        {/* Above closing the account, and that order is the argument: somebody
+            reading this page because they are leaving should meet the way to
+            take their work with them before they meet the way to destroy it.
+            Not gated on a role — an export is a read, and it contains only what
+            this person could already see. */}
+        <ExportWorkspaceSection workspaceId={me?.workspace.id} workspaceName={me?.workspace.name} />
 
         {/* Last on the page, under everything it would destroy. Not gated on a
             role: erasure is the caller's own right and an admin has no say in

--- a/tests/rls/export-roundtrip.test.ts
+++ b/tests/rls/export-roundtrip.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createTestUser, serviceClient, sql, closeSql, type TestUser } from "./harness";
 import { seedWorkspace } from "./fixtures";
 import { collectWorkspace, type Collected } from "../../worker/src/lib/export/collect";
-import { renderSql } from "../../worker/src/lib/export/sql";
+import { renderSql, MISSING_SECRET } from "../../worker/src/lib/export/sql";
 
 /**
  * Export a workspace, destroy it, put it back, and count.
@@ -155,6 +155,27 @@ describe("the restore", () => {
     expect(after.documents[0].name).toBe(before.documents[0].name);
     expect(after.routines[0].source_config).toEqual(before.routines[0].source_config);
     expect(after.agents[0].id).toBe(before.agents[0].id);
+  });
+
+  it("brings routines back paused, not running on a credential it does not have", async () => {
+    // The restore has to write *something* into `secret_ciphertext` — the
+    // column is `not null` and the export cannot read it — and skipping the
+    // channels was never available, because `routines.delivery_channel_id` is
+    // `not null` too. Pausing is what keeps the placeholder honest: a routine
+    // restored still running would fail on a schedule, somewhere nobody looks.
+    const after = await collectWorkspace(restorer.db, workspaceId);
+
+    expect(after.routines[0].status).toBe("paused");
+    expect(String(after.routines[0].paused_reason)).toMatch(/credential/i);
+  });
+
+  it("leaves a secret nothing could mistake for a credential", async () => {
+    const [row] = await sql()`
+      select secret_ciphertext from delivery_channels where workspace_id = ${workspaceId}
+    `;
+    expect(row.secret_ciphertext).toBe(MISSING_SECRET);
+    // Not the `v1.<iv>.<ct>` envelope lib/routines/crypto produces.
+    expect(String(row.secret_ciphertext).startsWith("v1.")).toBe(false);
   });
 
   it("can be run twice without doubling anything", async () => {

--- a/tests/rls/export-roundtrip.test.ts
+++ b/tests/rls/export-roundtrip.test.ts
@@ -1,0 +1,170 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestUser, serviceClient, sql, closeSql, type TestUser } from "./harness";
+import { seedWorkspace } from "./fixtures";
+import { collectWorkspace, type Collected } from "../../worker/src/lib/export/collect";
+import { renderSql } from "../../worker/src/lib/export/sql";
+
+/**
+ * Export a workspace, destroy it, put it back, and count.
+ *
+ * Everything else about the export is unit-tested against fakes, and fakes
+ * cannot answer the only question that matters here: whether `workspace.sql`
+ * actually replays. A foreign key the renderer got in the wrong order, a jsonb
+ * column quoted as text, a person column nobody noticed pointed at `profiles`
+ * instead of `auth.users` — none of those fail against a mock. They fail
+ * against Postgres, once, loudly, and only if something runs them.
+ *
+ * The round trip is done in the same database rather than a second one. That is
+ * not a shortcut: it means the restore has to survive the workspace genuinely
+ * being gone, which is a stronger claim than inserting into an empty schema
+ * where nothing could have collided. And it uses a *different* account as the
+ * owner, so the remap is exercised rather than accidentally being a no-op.
+ *
+ * What it deliberately does not test is `psql` expanding `:'owner'`. The
+ * substitution is done here so the suite needs no `psql` binary; the shape of
+ * what psql would produce — a quoted literal — is what is written in.
+ */
+
+let owner: TestUser;
+let restorer: TestUser;
+let workspaceId: string;
+let before: Collected;
+let script: string;
+
+/** Row counts per table, which is the comparison the whole test is about. */
+const counts = (tables: Collected) =>
+  Object.fromEntries(Object.entries(tables).map(([t, rows]) => [t, rows.length]));
+
+beforeAll(async () => {
+  owner = await createTestUser("export-owner");
+  restorer = await createTestUser("export-restorer");
+  workspaceId = owner.workspaceId;
+
+  const seeded = await seedWorkspace(owner);
+
+  // Two tables the shared fixture does not reach, added here so the round trip
+  // covers every join table the export declares.
+  const service = serviceClient();
+  const { error: linkError } = await service
+    .from("agent_bundles")
+    .insert({ agent_id: seeded.agentId, bundle_id: seeded.bundleId });
+  if (linkError) throw new Error(`seeding agent_bundles failed: ${linkError.message}`);
+
+  const { error: favError } = await owner.db
+    .from("favorites")
+    .insert({ user_id: owner.id, agent_id: seeded.agentId });
+  if (favError) throw new Error(`seeding favorites failed: ${favError.message}`);
+
+  before = await collectWorkspace(owner.db, workspaceId);
+  script = renderSql(before).sql;
+});
+
+afterAll(async () => {
+  await closeSql();
+});
+
+describe("what the export saw", () => {
+  it("is a whole workspace, not an empty one", () => {
+    // Guards every assertion below. Comparing zero against zero passes.
+    expect(counts(before)).toMatchObject({
+      workspaces: 1,
+      workspace_members: 1,
+      agents: 1,
+      knowledge_bundles: 1,
+      agent_bundles: 1,
+      documents: 1,
+      chat_sessions: 1,
+      messages: 1,
+      ideas: 1,
+      favorites: 1,
+      delivery_channels: 1,
+      routines: 1,
+    });
+  });
+
+  it("never carries the encrypted delivery secret", async () => {
+    // The column is real and populated — the fixture writes one — so this is a
+    // check that the export did not read it, not that there was nothing to read.
+    const [row] = await sql()`
+      select secret_ciphertext from delivery_channels where workspace_id = ${workspaceId}
+    `;
+    expect(row.secret_ciphertext).toBeTruthy();
+    expect(Object.keys(before.delivery_channels[0])).not.toContain("secret_ciphertext");
+  });
+});
+
+describe("the restore", () => {
+  it("puts back every row the export took", async () => {
+    const service = serviceClient();
+
+    // Cleared before the workspace, and this is not incidental: neither
+    // reference cascades, so `delete from workspaces` fails the foreign key
+    // while a single session or idea remains. The same order `routes/account.ts`
+    // learned the hard way.
+    for (const table of ["ideas", "chat_sessions"] as const) {
+      const { error } = await service.from(table).delete().eq("workspace_id", workspaceId);
+      if (error) throw new Error(`clearing ${table} failed: ${error.message}`);
+    }
+    const { error: dropError } = await service.from("workspaces").delete().eq("id", workspaceId);
+    if (dropError) throw new Error(`deleting the workspace failed: ${dropError.message}`);
+
+    const [gone] = await sql()`select count(*)::int as n from workspaces where id = ${workspaceId}`;
+    expect(gone.n, "the workspace should be gone before the restore proves anything").toBe(0);
+
+    // What psql's `-v owner=...` would expand `:'owner'` to.
+    await sql()
+      .unsafe(script.replaceAll(":'owner'", `'${restorer.id}'`))
+      .simple();
+
+    // Read back as the account that now owns it, which is the only account that
+    // can see it — proof in itself that the membership row was rewritten.
+    const after = await collectWorkspace(restorer.db, workspaceId);
+    expect(counts(after)).toEqual(counts(before));
+  });
+
+  it("hands the workspace to the account that ran it, as an admin", async () => {
+    const after = await collectWorkspace(restorer.db, workspaceId);
+
+    expect(after.workspace_members).toHaveLength(1);
+    expect(after.workspace_members[0]).toMatchObject({
+      user_id: restorer.id,
+      role: "admin",
+    });
+  });
+
+  it("leaves nothing pointing at the account that took the export", async () => {
+    // The failure this catches is a person column nobody added to USER_COLUMNS:
+    // it would restore fine here, because the old account still exists in this
+    // database, and dangle in the fresh install where it matters.
+    const [row] = await sql()`
+      select
+        (select count(*) from agents where workspace_id = ${workspaceId} and created_by = ${owner.id}) +
+        (select count(*) from chat_sessions where workspace_id = ${workspaceId} and user_id = ${owner.id}) +
+        (select count(*) from messages m join chat_sessions s on s.id = m.session_id
+           where s.workspace_id = ${workspaceId} and m.sender_id = ${owner.id}) +
+        (select count(*) from routines where workspace_id = ${workspaceId} and user_id = ${owner.id})
+        as n
+    `;
+    expect(Number(row.n)).toBe(0);
+  });
+
+  it("keeps the content itself, not just the row count", async () => {
+    const after = await collectWorkspace(restorer.db, workspaceId);
+
+    expect(after.messages[0].content).toBe(before.messages[0].content);
+    expect(after.documents[0].name).toBe(before.documents[0].name);
+    expect(after.routines[0].source_config).toEqual(before.routines[0].source_config);
+    expect(after.agents[0].id).toBe(before.agents[0].id);
+  });
+
+  it("can be run twice without doubling anything", async () => {
+    // `on conflict do nothing` throughout, so a restore interrupted half way
+    // can simply be run again — the case somebody will actually hit.
+    await sql()
+      .unsafe(script.replaceAll(":'owner'", `'${restorer.id}'`))
+      .simple();
+
+    const after = await collectWorkspace(restorer.db, workspaceId);
+    expect(counts(after)).toEqual(counts(before));
+  });
+});

--- a/tests/rls/export-roundtrip.test.ts
+++ b/tests/rls/export-roundtrip.test.ts
@@ -108,6 +108,19 @@ describe("the restore", () => {
     const { error: dropError } = await service.from("workspaces").delete().eq("id", workspaceId);
     if (dropError) throw new Error(`deleting the workspace failed: ${dropError.message}`);
 
+    // Delivery channels outlive their workspace on purpose — 0019 made the
+    // reference `on delete set null` because a channel belongs to a person, so
+    // deleting the workspace leaves the row with a null `workspace_id` rather
+    // than removing it. Restoring into a database that still holds it would hit
+    // `on conflict do nothing` and keep the original, which is the right
+    // behaviour there and the wrong fixture here: this test stands in for a
+    // fresh install, where the row does not exist.
+    const channelIds = (before.delivery_channels ?? []).map((c) => c.id as string);
+    if (channelIds.length > 0) {
+      const { error } = await service.from("delivery_channels").delete().in("id", channelIds);
+      if (error) throw new Error(`clearing delivery_channels failed: ${error.message}`);
+    }
+
     const [gone] = await sql()`select count(*)::int as n from workspaces where id = ${workspaceId}`;
     expect(gone.n, "the workspace should be gone before the restore proves anything").toBe(0);
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -99,6 +99,17 @@ api.use("/*", entitlementsMiddleware);
 // upload — the one behaviour this product exists to encourage — to bound a cost
 // the generous tier already bounds.
 //
+// The workspace export stays on `standard` too, and that is the least obvious
+// of these. It buys no completion, so it does not belong in the list above,
+// whose whole claim is derived from `createOpenAI` appearing in a route file.
+// But it is the one endpoint where a single request fans out into as many
+// object reads as the workspace has documents, so `standard`'s per-minute
+// allowance is an amplified one here in a way it is nowhere else. It bounds a
+// bandwidth bill rather than a model bill, and no allowance bounds the month
+// for it at all. Worth revisiting the moment anyone sees it abused — the reason
+// not to pre-emptively move it is that "expensive" currently means "buys a
+// completion", and putting something else there would make that list a lie.
+//
 // Entitlements bound the month and this bounds the minute. They are not
 // substitutes: a monthly allowance is a ceiling on the bill, not on the rate at
 // which it is reached, and the open build ships no allowance at all.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -25,6 +25,7 @@ import { notifications } from "./routes/notifications";
 import { onboarding } from "./routes/onboarding";
 import { apiKeys } from "./routes/api-keys";
 import { account } from "./routes/account";
+import { exportRoutes } from "./routes/export";
 
 const app = new Hono<AppEnv>();
 
@@ -128,6 +129,7 @@ api.route("/", notifications);
 api.route("/", onboarding);
 api.route("/", apiKeys);
 api.route("/", account);
+api.route("/", exportRoutes);
 
 app.route("/", api);
 

--- a/worker/src/lib/export/archive.test.ts
+++ b/worker/src/lib/export/archive.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import { archiveEntries, documentEntryName, type ArchiveContext } from "./archive";
+import type { DocStore } from "../docstore";
+import type { Collected } from "./collect";
+
+const decode = (b: Uint8Array) => new TextDecoder().decode(b);
+
+function store(files: Record<string, string>, opts: { throwOn?: string } = {}): DocStore {
+  return {
+    async get(key) {
+      if (opts.throwOn === key) throw new Error("store is down");
+      if (!(key in files)) return null;
+      const bytes = new TextEncoder().encode(files[key]);
+      return {
+        body: new ReadableStream(),
+        async arrayBuffer() {
+          return bytes.buffer.slice(0) as ArrayBuffer;
+        },
+      };
+    },
+    async put() {},
+    async delete() {},
+  };
+}
+
+function context(over: Partial<ArchiveContext> = {}): ArchiveContext {
+  const tables: Collected = {
+    workspaces: [{ id: "w1", name: "Acme", slug: "acme" }],
+    workspace_members: [{ workspace_id: "w1", user_id: "u1", role: "admin" }],
+    documents: [],
+    ...(over.tables ?? {}),
+  };
+  return {
+    workspace: { id: "w1", name: "Acme" },
+    exportedBy: { userId: "u1", role: "admin" },
+    exportedAt: "2026-08-31T00:00:00.000Z",
+    store: store({}),
+    ...over,
+    tables,
+  };
+}
+
+async function collect(ctx: ArchiveContext) {
+  const out: { name: string; text: string }[] = [];
+  for await (const e of archiveEntries(ctx)) out.push({ name: e.name, text: decode(e.data) });
+  return out;
+}
+
+describe("what lands in the archive", () => {
+  it("leads with the manifest, because it is what says how to read the rest", async () => {
+    const entries = await collect(context());
+    expect(entries[0].name).toBe("manifest.json");
+  });
+
+  it("carries the restore path beside the data", async () => {
+    const names = (await collect(context())).map((e) => e.name);
+    expect(names).toContain("workspace.sql");
+    expect(names).toContain("restore.sh");
+    expect(names).toContain("data/workspaces.json");
+    expect(names).toContain("data/workspace_members.json");
+  });
+
+  it("says whose view it is, in the manifest rather than in a README nobody opens", async () => {
+    const [manifest] = await collect(context());
+    const parsed = JSON.parse(manifest.text);
+
+    expect(parsed.exportedBy).toEqual({ userId: "u1", role: "admin" });
+    expect(parsed.scope).toMatch(/Row level security/);
+    expect(parsed.counts.workspaces).toBe(1);
+  });
+
+  it("names what it left behind and why", async () => {
+    const [manifest] = await collect(context());
+    const parsed = JSON.parse(manifest.text);
+
+    // Somebody looking for their chunks should find the reason here, not in a
+    // commit message.
+    expect(Object.keys(parsed.excluded)).toContain("document_chunks");
+    expect(Object.keys(parsed.excluded)).toContain("api_keys");
+    expect(parsed.afterRestore).toMatch(/backfill-embeddings/);
+    expect(parsed.afterRestore).toMatch(/ROUTINE_SECRET_KEY/);
+  });
+});
+
+describe("the documents", () => {
+  const withDocs = (files: Record<string, string>, throwOn?: string) =>
+    context({
+      tables: {
+        documents: [
+          { id: "d1", name: "notes.md", r2_key: "k1" },
+          { id: "d2", name: "deck.pdf", r2_key: "k2" },
+        ],
+      } as Partial<Collected> as Collected,
+      store: store(files, { throwOn }),
+    });
+
+  it("come out with their bytes", async () => {
+    const entries = await collect(withDocs({ k1: "hello", k2: "world" }));
+    const doc = entries.find((e) => e.name.endsWith("notes.md"));
+    expect(doc?.text).toBe("hello");
+  });
+
+  it("do not stop the export when one is gone from storage", async () => {
+    // A row pointing at a missing object is a real state — an interrupted
+    // upload, a bucket restored from an older copy — and refusing the whole
+    // archive over it would deny somebody every document they still have.
+    const entries = await collect(withDocs({ k1: "hello" }));
+    const warnings = JSON.parse(entries.at(-1)!.text);
+
+    expect(entries.some((e) => e.name.endsWith("notes.md"))).toBe(true);
+    expect(warnings.missingDocuments).toEqual([
+      { id: "d2", name: "deck.pdf", reason: "the stored file is gone" },
+    ]);
+  });
+
+  it("do not stop the export when the store itself fails", async () => {
+    const entries = await collect(withDocs({ k1: "hello", k2: "world" }, "k2"));
+    const warnings = JSON.parse(entries.at(-1)!.text);
+    expect(warnings.missingDocuments[0].reason).toMatch(/could not be read/);
+  });
+
+  it("record a row that never had a file", async () => {
+    const ctx = context({
+      tables: {
+        documents: [{ id: "d3", name: "pasted.txt", r2_key: null }],
+      } as unknown as Collected,
+    });
+    const warnings = JSON.parse((await collect(ctx)).at(-1)!.text);
+    expect(warnings.missingDocuments[0].reason).toMatch(/no stored file/);
+  });
+
+  it("write the warnings file even when there is nothing to warn about", async () => {
+    // An archive where a missing warnings file means "all fine" and a truncated
+    // download also means "all fine" cannot tell you which one you have.
+    const entries = await collect(context());
+    expect(entries.at(-1)!.name).toBe("data/export-warnings.json");
+    expect(JSON.parse(entries.at(-1)!.text)).toEqual({ missingDocuments: [] });
+  });
+});
+
+describe("the name a document gets inside the archive", () => {
+  it("keeps the original, prefixed by the row id", () => {
+    // Two documents in one workspace may share a name, and an archive where the
+    // second silently replaces the first has lost a file.
+    expect(documentEntryName("d1", "notes.md")).toBe("documents/d1-notes.md");
+    expect(documentEntryName("d2", "notes.md")).toBe("documents/d2-notes.md");
+  });
+
+  it("cannot escape the documents folder", () => {
+    // The oldest trick against anyone extracting an archive: a path that walks
+    // out of the directory they extracted into.
+    expect(documentEntryName("d1", "../../.ssh/authorized_keys")).toBe(
+      "documents/d1-____.ssh_authorized_keys",
+    );
+    expect(documentEntryName("d1", "/etc/passwd")).toBe("documents/d1-_etc_passwd");
+  });
+
+  it("strips control characters and leading dots", () => {
+    expect(documentEntryName("d1", "a\nb\tc.md")).toBe("documents/d1-a_b_c.md");
+    expect(documentEntryName("d1", ".bashrc")).toBe("documents/d1-_bashrc");
+  });
+
+  it("keeps a non-ASCII name, which the archive can hold", () => {
+    expect(documentEntryName("d1", "toplantı.md")).toBe("documents/d1-toplantı.md");
+  });
+
+  it("never produces an empty name", () => {
+    expect(documentEntryName("d1", "")).toBe("documents/d1-document");
+  });
+});

--- a/worker/src/lib/export/archive.ts
+++ b/worker/src/lib/export/archive.ts
@@ -85,7 +85,7 @@ echo "Restored. Run POST /admin/backfill-embeddings to rebuild retrieval."
 `;
 
 export async function* archiveEntries(ctx: ArchiveContext): AsyncGenerator<ZipEntry> {
-  const { sql, droppedReferences } = renderSql(ctx.tables);
+  const { sql, droppedReferences, usedPlaceholderChannel } = renderSql(ctx.tables);
   const documents = (ctx.tables.documents ?? []) as Row[];
   const missing: { id: string; name: string; reason: string }[] = [];
 
@@ -110,6 +110,17 @@ export async function* archiveEntries(ctx: ArchiveContext): AsyncGenerator<ZipEn
     counts: Object.fromEntries(Object.entries(ctx.tables).map(([t, rows]) => [t, rows.length])),
     excluded: EXCLUDED,
     droppedReferences,
+    ...(usedPlaceholderChannel
+      ? {
+          placeholderChannel:
+            "At least one routine here points at a delivery channel belonging to " +
+            "somebody else — channels belong to people rather than to workspaces — " +
+            "so it could not be read into this archive. Those routines are restored " +
+            "pointing at a single stand-in channel, labelled as such. They come back " +
+            "paused like all the others; pick or create a real channel before " +
+            "resuming them.",
+        }
+      : {}),
     afterRestore:
       `Retrieval will not work until the chunks are rebuilt: POST /admin/backfill-embeddings ` +
       `with the new install's ADMIN_API_KEY. Delivery channels come back without their ` +

--- a/worker/src/lib/export/archive.ts
+++ b/worker/src/lib/export/archive.ts
@@ -113,8 +113,10 @@ export async function* archiveEntries(ctx: ArchiveContext): AsyncGenerator<ZipEn
     afterRestore:
       `Retrieval will not work until the chunks are rebuilt: POST /admin/backfill-embeddings ` +
       `with the new install's ADMIN_API_KEY. Delivery channels come back without their ` +
-      `secrets — the ciphertext is bound to the old install's ROUTINE_SECRET_KEY — so any ` +
-      `routine that posts to Slack or a webhook needs its credential entered again.`,
+      `secrets — the ciphertext is bound to the old install's ROUTINE_SECRET_KEY and cannot ` +
+      `be read by an export in the first place — so every routine is restored PAUSED, with ` +
+      `the reason on its own row. Re-enter the channel's credential, then resume it. A ` +
+      `routine that came back running would fail on a schedule, somewhere nobody is looking.`,
   });
 
   yield { name: "workspace.sql", data: encoder.encode(sql) };

--- a/worker/src/lib/export/archive.ts
+++ b/worker/src/lib/export/archive.ts
@@ -1,0 +1,157 @@
+import type { DocStore } from "../docstore";
+import type { Collected, Row } from "./collect";
+import { renderSql } from "./sql";
+import { EXCLUDED } from "./tables";
+import type { ZipEntry } from "./zip";
+
+/**
+ * What goes in the archive, in the order it is written.
+ *
+ * A generator rather than a list, because the documents are the large part and
+ * fetching them all up front would hold a whole workspace in memory to write it
+ * one entry at a time. Each is read when the writer is ready for it and dropped
+ * immediately after.
+ */
+
+export type ArchiveContext = {
+  workspace: { id: string; name: string };
+  exportedBy: { userId: string; role: string };
+  exportedAt: string;
+  tables: Collected;
+  store: DocStore;
+};
+
+const encoder = new TextEncoder();
+const json = (name: string, value: unknown): ZipEntry => ({
+  name,
+  data: encoder.encode(JSON.stringify(value, null, 2) + "\n"),
+});
+
+/**
+ * A filename that survives being written to a disk.
+ *
+ * Prefixed with the row id because two documents in one workspace may share a
+ * name, and an archive where the second silently replaces the first is a
+ * backup that loses a file. Separators and control characters go, so an
+ * uploaded name can never place an entry outside `documents/` — the archive is
+ * extracted by whoever receives it, and a `../` in a zip entry is the oldest
+ * trick there is.
+ */
+export function documentEntryName(id: string, name: string): string {
+  const safe = String(name)
+    // eslint-disable-next-line no-control-regex
+    .replace(/[/\\\u0000-\u001f]/g, "_")
+    // `..` goes too, though by now it could not walk anywhere. It is for the
+    // person reading an archive listing, who should not have to work out
+    // whether a `..` in an entry name is dangerous before deciding it is not.
+    .replace(/\.\./g, "_")
+    .replace(/^\.+/, "_")
+    .slice(0, 120);
+  return `documents/${id}-${safe || "document"}`;
+}
+
+const RESTORE_SH = `#!/bin/sh
+# Put this workspace back into a Covan you control.
+#
+#   ./restore.sh "postgres://..." "<the user id it should belong to>" [DOCS_DIR]
+#
+# The first two arguments are required. The third is where the API keeps
+# uploaded documents — DOCS_DIR in a compose stack; leave it out and the rows
+# are restored without their files, which is a workspace that lists documents
+# it cannot open.
+#
+# On Cloudflare the third step is an R2 upload instead; see docs/export.md.
+set -eu
+
+DB="\${1:?usage: restore.sh <database-url> <owner-user-id> [docs-dir]}"
+OWNER="\${2:?usage: restore.sh <database-url> <owner-user-id> [docs-dir]}"
+DOCS="\${3:-}"
+
+# One transaction, so a failure leaves the database as it was. ON_ERROR_STOP is
+# what makes psql treat the first error as fatal rather than carrying on and
+# reporting success at the end.
+psql "$DB" -v ON_ERROR_STOP=1 -v owner="'$OWNER'" -f workspace.sql
+
+if [ -n "$DOCS" ]; then
+  # The keys are in data/documents.json, and the files here are named
+  # <id>-<original name>. Copying them under their stored key is what makes the
+  # rows resolve.
+  echo "Documents are in documents/. Their storage keys are the r2_key column"
+  echo "in data/documents.json — copy each file to \\$DOCS/<r2_key>."
+  echo "docs/export.md has a one-liner for it."
+fi
+
+echo "Restored. Run POST /admin/backfill-embeddings to rebuild retrieval."
+`;
+
+export async function* archiveEntries(ctx: ArchiveContext): AsyncGenerator<ZipEntry> {
+  const { sql, droppedReferences } = renderSql(ctx.tables);
+  const documents = (ctx.tables.documents ?? []) as Row[];
+  const missing: { id: string; name: string; reason: string }[] = [];
+
+  yield json("manifest.json", {
+    format: 1,
+    product: "covan",
+    exportedAt: ctx.exportedAt,
+    workspace: ctx.workspace,
+    exportedBy: ctx.exportedBy,
+    // Said first because it is the thing most likely to be assumed wrong. An
+    // export is a read, so it holds what this person could see — not what the
+    // workspace holds.
+    scope:
+      `Row level security decided what is in here. These are the rows visible to ` +
+      `${ctx.exportedBy.userId}, whose role in the workspace was "${ctx.exportedBy.role}". ` +
+      `An export taken by somebody else is a different file.`,
+    restore:
+      `workspace.sql replays every table below into a fresh Covan, in one transaction. ` +
+      `Every person in the original workspace collapses to the single account you pass as ` +
+      `the "owner" argument — accounts cannot be carried between installs, and inventing ` +
+      `them for people who did not ask would be worse than saying so.`,
+    counts: Object.fromEntries(Object.entries(ctx.tables).map(([t, rows]) => [t, rows.length])),
+    excluded: EXCLUDED,
+    droppedReferences,
+    afterRestore:
+      `Retrieval will not work until the chunks are rebuilt: POST /admin/backfill-embeddings ` +
+      `with the new install's ADMIN_API_KEY. Delivery channels come back without their ` +
+      `secrets — the ciphertext is bound to the old install's ROUTINE_SECRET_KEY — so any ` +
+      `routine that posts to Slack or a webhook needs its credential entered again.`,
+  });
+
+  yield { name: "workspace.sql", data: encoder.encode(sql) };
+  yield { name: "restore.sh", data: encoder.encode(RESTORE_SH) };
+
+  for (const [table, rows] of Object.entries(ctx.tables)) {
+    yield json(`data/${table}.json`, rows);
+  }
+
+  for (const row of documents) {
+    const id = String(row.id ?? "");
+    const name = String(row.name ?? "document");
+    const key = typeof row.r2_key === "string" ? row.r2_key : "";
+    if (!key) {
+      missing.push({ id, name, reason: "the row has no stored file" });
+      continue;
+    }
+
+    let object;
+    try {
+      object = await ctx.store.get(key);
+    } catch (e) {
+      console.error("export: document store read failed", key, e);
+      missing.push({ id, name, reason: "the document store could not be read" });
+      continue;
+    }
+    if (!object) {
+      missing.push({ id, name, reason: "the stored file is gone" });
+      continue;
+    }
+
+    yield { name: documentEntryName(id, name), data: new Uint8Array(await object.arrayBuffer()) };
+  }
+
+  // Last, because it cannot be written until every document has been tried.
+  // Always written, even empty: an archive where the absence of a warnings file
+  // means "no warnings" and a truncated download also means "no warnings" is an
+  // archive that cannot tell you which one you have.
+  yield json("data/export-warnings.json", { missingDocuments: missing });
+}

--- a/worker/src/lib/export/collect.ts
+++ b/worker/src/lib/export/collect.ts
@@ -1,0 +1,116 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { EXPORTED, type TableSpec } from "./tables";
+
+/**
+ * Reading a workspace out, through the caller's own client.
+ *
+ * The service client is not used and must not be: an export is a read like any
+ * other, and what belongs in it is what this person could have seen by clicking
+ * around. Doing it any other way would make a member's export contain an
+ * admin's view, which is a data leak wearing the clothes of a feature.
+ */
+
+export type Row = Record<string, unknown>;
+export type Collected = Record<string, Row[]>;
+
+/**
+ * PostgREST answers at most a thousand rows per request unless the server is
+ * configured otherwise, and it does so silently — the thousand-and-first
+ * message simply is not there. So every read pages, and every read is ordered,
+ * because `range()` over an unordered result can repeat one row and drop
+ * another between pages.
+ */
+const PAGE = 1000;
+
+/**
+ * How many ids go into one `in (...)`.
+ *
+ * supabase-js sends selects as GET, so the id list ends up in the query string,
+ * and a workspace with two thousand chat sessions would build a URL past what
+ * proxies and CDNs accept — an error that appears only for the largest
+ * workspaces, which are exactly the ones whose owners most want an export.
+ */
+const IN_CHUNK = 100;
+
+export class ExportFailure extends Error {
+  constructor(
+    readonly table: string,
+    readonly reason: unknown,
+  ) {
+    super(`failed to read ${table} for export`);
+    this.name = "ExportFailure";
+  }
+}
+
+/** Minimal shape of the builder, so this file does not carry the generated types. */
+type Builder = {
+  order: (c: string, o: { ascending: boolean }) => Builder;
+  range: (from: number, to: number) => PromiseLike<{ data: unknown; error: unknown }>;
+  eq: (c: string, v: string) => Builder;
+  in: (c: string, v: string[]) => Builder;
+};
+
+async function readPaged(
+  db: SupabaseClient,
+  spec: TableSpec,
+  narrow: (q: Builder) => Builder,
+): Promise<Row[]> {
+  const rows: Row[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const query = narrow(db.from(spec.table).select(spec.columns ?? "*") as unknown as Builder);
+    const { data, error } = await query
+      .order(spec.order, { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) throw new ExportFailure(spec.table, error);
+    const batch = (data ?? []) as Row[];
+    rows.push(...batch);
+    if (batch.length < PAGE) return rows;
+  }
+}
+
+function distinct(values: unknown[]): string[] {
+  return [...new Set(values.filter((v): v is string => typeof v === "string"))];
+}
+
+/**
+ * Every workspace-owned row this caller can see, keyed by table.
+ *
+ * Tables are read in `EXPORTED` order, which is also foreign-key order, so a
+ * table scoped by another's ids always finds them already collected.
+ */
+export async function collectWorkspace(
+  db: SupabaseClient,
+  workspaceId: string,
+): Promise<Collected> {
+  const out: Collected = {};
+
+  for (const spec of EXPORTED) {
+    const scope = spec.scope;
+
+    if (scope.kind === "workspace") {
+      out[spec.table] = await readPaged(db, spec, (q) => q.eq(scope.column, workspaceId));
+      continue;
+    }
+
+    const ids = distinct((out[scope.from.table] ?? []).map((r) => r[scope.from.column]));
+    if (ids.length === 0) {
+      out[spec.table] = [];
+      continue;
+    }
+
+    const rows: Row[] = [];
+    for (let i = 0; i < ids.length; i += IN_CHUNK) {
+      const chunk = ids.slice(i, i + IN_CHUNK);
+      rows.push(...(await readPaged(db, spec, (q) => q.in(scope.column, chunk))));
+    }
+
+    // Sorted again here because each chunk was ordered only within itself. The
+    // archive is meant to be diffable, and rows arriving in id-batch order
+    // rather than in time order would make two exports of unchanged data
+    // disagree for no reason.
+    rows.sort((a, b) => String(a[spec.order] ?? "").localeCompare(String(b[spec.order] ?? "")));
+    out[spec.table] = rows;
+  }
+
+  return out;
+}

--- a/worker/src/lib/export/sql.test.ts
+++ b/worker/src/lib/export/sql.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import { renderSql } from "./sql";
+import type { Collected } from "./collect";
+
+const base = (over: Partial<Collected> = {}): Collected => ({
+  workspaces: [{ id: "w1", name: "Acme", slug: "acme", created_by: "u1", created_at: "t0" }],
+  workspace_members: [],
+  profiles: [],
+  agents: [],
+  knowledge_bundles: [],
+  agent_bundles: [],
+  documents: [],
+  chat_sessions: [],
+  messages: [],
+  ideas: [],
+  favorites: [],
+  delivery_channels: [],
+  routines: [],
+  routine_runs: [],
+  ...over,
+});
+
+describe("workspace.sql", () => {
+  it("is one transaction, so a restore either happens or does not", () => {
+    const { sql } = renderSql(base());
+    expect(sql).toContain("\nbegin;\n");
+    expect(sql.trimEnd().endsWith("commit;")).toBe(true);
+  });
+
+  it("makes every insert safe to run twice", () => {
+    const { sql } = renderSql(base());
+    const inserts = sql.split("\n").filter((l) => l.startsWith("insert into"));
+    expect(inserts.length).toBeGreaterThan(0);
+    for (const line of inserts) expect(line).toMatch(/on conflict do nothing;$/);
+  });
+
+  it("preserves ids, so an export and its restore can be compared row for row", () => {
+    const { sql } = renderSql(base());
+    expect(sql).toContain("'w1'");
+  });
+
+  it("leaves profiles out — the account restoring this already has one", () => {
+    const { sql } = renderSql(
+      base({ profiles: [{ id: "u1", name: "Ayşe", email: "a@example.com" }] }),
+    );
+    expect(sql).not.toContain("insert into public.profiles");
+  });
+});
+
+describe("the people", () => {
+  it("all become the account running the restore", () => {
+    const { sql } = renderSql(
+      base({
+        agents: [{ id: "a1", workspace_id: "w1", name: "Bot", created_by: "u9", created_at: "t" }],
+        chat_sessions: [{ id: "s1", workspace_id: "w1", user_id: "u9", created_at: "t" }],
+      }),
+    );
+
+    // Never the original id: there is no account behind it in the new install,
+    // and a foreign key would refuse it.
+    expect(sql).not.toContain("'u9'");
+    expect(sql).toContain(":'owner'");
+  });
+
+  it("collapse to exactly one membership row, as an admin", () => {
+    // Five members all becoming one account would be five inserts of the same
+    // primary key: four swallowed by `on conflict do nothing` and the survivor
+    // carrying whichever role sorted first. That can hand the restorer a
+    // `member` row in their own workspace and lock them out of it.
+    const { sql } = renderSql(
+      base({
+        workspace_members: [
+          { workspace_id: "w1", user_id: "u1", role: "member", created_at: "t0" },
+          { workspace_id: "w1", user_id: "u2", role: "admin", created_at: "t1" },
+          { workspace_id: "w1", user_id: "u3", role: "member", created_at: "t2" },
+        ],
+      }),
+    );
+
+    const rows = sql
+      .split("\n")
+      .filter((l) => l.startsWith("insert into public.workspace_members"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain("'admin'");
+    expect(rows[0]).not.toContain("'member'");
+  });
+});
+
+describe("values", () => {
+  it("doubles a quote instead of ending the string", () => {
+    const { sql } = renderSql(
+      base({ agents: [{ id: "a1", name: "Ayşe's bot", created_at: "t" }] }),
+    );
+    expect(sql).toContain("'Ayşe''s bot'");
+  });
+
+  it("survives an apostrophe used to close the statement", () => {
+    // The shape of the injection, written by somebody who named an agent.
+    const nasty = "'); drop table public.agents; --";
+    const { sql } = renderSql(base({ agents: [{ id: "a1", name: nasty, created_at: "t" }] }));
+    expect(sql).toContain("'''); drop table public.agents; --'");
+    expect(sql).not.toMatch(/^drop table/m);
+  });
+
+  it("writes null, numbers and booleans unquoted", () => {
+    const { sql } = renderSql(
+      base({ documents: [{ id: "d1", bundle_id: "b1", size: 42, indexed: true, r2_key: null }] }),
+    );
+    expect(sql).toContain("42");
+    expect(sql).toContain("true");
+    expect(sql).toContain("NULL");
+  });
+
+  it("serialises the jsonb columns rather than stringifying an object", () => {
+    const { sql } = renderSql(
+      base({
+        messages: [{ id: "m1", session_id: "s1", content: "hi", sources: [{ id: "d1" }] }],
+      }),
+    );
+    expect(sql).toContain(`'[{"id":"d1"}]'`);
+    expect(sql).not.toContain("[object Object]");
+  });
+});
+
+describe("references that point outside what the caller could see", () => {
+  it("are dropped rather than failing the whole restore", () => {
+    // A member's export holds the sessions they may read. An idea cited from a
+    // message in somebody else's private session arrives dangling, and one
+    // foreign key violation takes the entire transaction with it.
+    const { sql, droppedReferences } = renderSql(
+      base({
+        chat_sessions: [{ id: "s1", workspace_id: "w1", user_id: "u1", created_at: "t" }],
+        messages: [{ id: "m1", session_id: "s1", content: "hi", created_at: "t" }],
+        ideas: [
+          { id: "i1", session_id: "s1", source_message_id: "m1", created_at: "t" },
+          { id: "i2", session_id: "s1", source_message_id: "gone", created_at: "t" },
+        ],
+      }),
+    );
+
+    expect(sql).toContain("'m1'");
+    expect(sql).not.toContain("'gone'");
+    expect(droppedReferences["ideas.source_message_id"]).toBe(1);
+  });
+
+  it("are counted, so the loss is stated rather than discovered", () => {
+    const { droppedReferences } = renderSql(base());
+    expect(droppedReferences).toEqual({});
+  });
+
+  it("keep a routine's delivery channel when it is in the archive", () => {
+    const { sql, droppedReferences } = renderSql(
+      base({
+        delivery_channels: [{ id: "c1", workspace_id: "w1", user_id: "u1", kind: "slack" }],
+        routines: [
+          { id: "r1", workspace_id: "w1", user_id: "u1", delivery_channel_id: "c1", name: "x" },
+        ],
+      }),
+    );
+    expect(sql).toContain("'c1'");
+    expect(droppedReferences).toEqual({});
+  });
+});
+
+describe("the order of the inserts", () => {
+  it("puts a table after everything it points at", () => {
+    const { sql } = renderSql(
+      base({
+        agents: [{ id: "a1", workspace_id: "w1", name: "Bot" }],
+        chat_sessions: [{ id: "s1", workspace_id: "w1", agent_id: "a1", user_id: "u1" }],
+        messages: [{ id: "m1", session_id: "s1", content: "hi" }],
+      }),
+    );
+
+    const at = (t: string) => sql.indexOf(`insert into public.${t} `);
+    expect(at("workspaces")).toBeLessThan(at("agents"));
+    expect(at("agents")).toBeLessThan(at("chat_sessions"));
+    expect(at("chat_sessions")).toBeLessThan(at("messages"));
+  });
+});

--- a/worker/src/lib/export/sql.test.ts
+++ b/worker/src/lib/export/sql.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { renderSql, MISSING_SECRET, PAUSED_ON_RESTORE } from "./sql";
+import { renderSql, MISSING_SECRET, PAUSED_ON_RESTORE, PLACEHOLDER_CHANNEL_ID } from "./sql";
 import type { Collected } from "./collect";
 
 const base = (over: Partial<Collected> = {}): Collected => ({
@@ -213,6 +213,76 @@ describe("what the database will not let a restore say honestly", () => {
     const { sql } = withRoutine();
     expect(sql).toContain("'Morning digest'");
     expect(sql).toContain("'c1'");
+  });
+});
+
+describe("a routine whose delivery channel could not be exported", () => {
+  // A channel belongs to a person (0019), so a workspace where two people each
+  // built routines has routines pointing at channels only their own author can
+  // read. `delivery_channel_id` is `not null` with a DEFERRABLE INITIALLY
+  // DEFERRED constraint, so an unreachable one is a foreign key violation **at
+  // commit** — after every other row has already gone in.
+  const orphaned = () =>
+    renderSql(
+      base({
+        routines: [
+          {
+            id: "r1",
+            workspace_id: "w1",
+            user_id: "u1",
+            name: "Somebody else's digest",
+            delivery_channel_id: "channel-of-another-person",
+            status: "active",
+            paused_reason: null,
+          },
+        ],
+      }),
+    );
+
+  it("is pointed at a stand-in rather than left to fail the commit", () => {
+    const { sql, droppedReferences, usedPlaceholderChannel } = orphaned();
+
+    expect(sql).not.toContain("channel-of-another-person");
+    expect(sql).toContain(PLACEHOLDER_CHANNEL_ID);
+    expect(droppedReferences["routines.delivery_channel_id"]).toBe(1);
+    expect(usedPlaceholderChannel).toBe(true);
+  });
+
+  it("gets the stand-in written even when no channel was collected at all", () => {
+    // The likely shape of this: a member exporting a workspace whose routines
+    // all belong to other people. Nothing comes back in delivery_channels, and
+    // the section still has to exist.
+    const { sql } = orphaned();
+    const inserts = sql
+      .split("\n")
+      .filter((l) => l.startsWith("insert into public.delivery_channels"));
+
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]).toContain(PLACEHOLDER_CHANNEL_ID);
+    expect(inserts[0]).toContain("secret_ciphertext");
+    expect(inserts[0]).toContain(MISSING_SECRET.replace(/'/g, "''"));
+  });
+
+  it("still comes back paused, like every other restored routine", () => {
+    const row = orphaned()
+      .sql.split("\n")
+      .find((l) => l.startsWith("insert into public.routines"))!;
+    expect(row).toContain("'paused'");
+  });
+
+  it("is not invented when the real channel is in the archive", () => {
+    const { sql, droppedReferences, usedPlaceholderChannel } = renderSql(
+      base({
+        delivery_channels: [{ id: "c1", workspace_id: "w1", user_id: "u1", kind: "email" }],
+        routines: [
+          { id: "r1", workspace_id: "w1", user_id: "u1", delivery_channel_id: "c1", name: "x" },
+        ],
+      }),
+    );
+
+    expect(sql).not.toContain(PLACEHOLDER_CHANNEL_ID);
+    expect(droppedReferences).toEqual({});
+    expect(usedPlaceholderChannel).toBe(false);
   });
 });
 

--- a/worker/src/lib/export/sql.test.ts
+++ b/worker/src/lib/export/sql.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { renderSql } from "./sql";
+import { renderSql, MISSING_SECRET, PAUSED_ON_RESTORE } from "./sql";
 import type { Collected } from "./collect";
 
 const base = (over: Partial<Collected> = {}): Collected => ({
@@ -159,6 +159,60 @@ describe("references that point outside what the caller could see", () => {
     );
     expect(sql).toContain("'c1'");
     expect(droppedReferences).toEqual({});
+  });
+});
+
+describe("what the database will not let a restore say honestly", () => {
+  const withRoutine = () =>
+    renderSql(
+      base({
+        delivery_channels: [
+          { id: "c1", workspace_id: "w1", user_id: "u1", kind: "slack_webhook", label: "#ops" },
+        ],
+        routines: [
+          {
+            id: "r1",
+            workspace_id: "w1",
+            user_id: "u1",
+            name: "Morning digest",
+            delivery_channel_id: "c1",
+            status: "active",
+            paused_reason: null,
+          },
+        ],
+      }),
+    );
+
+  it("gives a delivery channel a secret that is visibly not one", () => {
+    // `secret_ciphertext` is `not null` and the export cannot read it, so the
+    // restore has to write something. Before this, every workspace with a
+    // delivery channel failed the whole transaction on a not-null violation —
+    // which no mocked test could have shown, and the round trip did.
+    const { sql } = withRoutine();
+    expect(sql).toContain("secret_ciphertext");
+    expect(sql).toContain(MISSING_SECRET.replace(/'/g, "''"));
+    // Not the shape `lib/routines/crypto` produces, so nothing can mistake it
+    // for a credential.
+    expect(MISSING_SECRET.startsWith("v1.")).toBe(false);
+  });
+
+  it("brings the routine back paused, with the reason on its own row", () => {
+    // The placeholder above is only tolerable because of this. A routine whose
+    // channel holds no real secret cannot deliver, and one that ran on schedule
+    // and failed somewhere nobody is looking would be worse than one that is
+    // visibly switched off.
+    const { sql } = withRoutine();
+    const row = sql.split("\n").find((l) => l.startsWith("insert into public.routines"))!;
+
+    expect(row).toContain("'paused'");
+    expect(row).toContain(PAUSED_ON_RESTORE.replace(/'/g, "''"));
+    expect(row).not.toContain("'active'");
+  });
+
+  it("keeps the rest of the routine exactly as it was", () => {
+    const { sql } = withRoutine();
+    expect(sql).toContain("'Morning digest'");
+    expect(sql).toContain("'c1'");
   });
 });
 

--- a/worker/src/lib/export/sql.ts
+++ b/worker/src/lib/export/sql.ts
@@ -108,7 +108,7 @@ export function renderSql(tables: Collected): RenderedSql {
 
   for (const spec of EXPORTED) {
     if (SKIP.has(spec.table)) continue;
-    const rows = collapse(spec.table, tables[spec.table] ?? []);
+    const rows = rewriteForRestore(spec.table, tables[spec.table] ?? []);
     if (rows.length === 0) {
       out.push(`-- ${spec.table}: nothing to restore`, "");
       continue;
@@ -143,16 +143,51 @@ export function renderSql(tables: Collected): RenderedSql {
 }
 
 /**
- * One membership row, not many.
+ * The value a restored delivery channel carries where its secret was.
  *
- * Everybody collapses to the same account, so replaying five members would be
- * five inserts of the same primary key — four silently swallowed by `on
- * conflict do nothing` and the surviving one carrying whichever role happened
- * to sort first. That could hand the restorer a `member` row in their own
- * workspace and lock them out of it. So it is decided here instead: one row,
- * admin, keeping every other column from the earliest membership.
+ * `delivery_channels.secret_ciphertext` is `not null`, and the export cannot
+ * read it — 0023 withholds that column from `authenticated`, and it would be
+ * undecryptable under another install's `ROUTINE_SECRET_KEY` even if it could.
+ * So something has to go in the column, and this is it: deliberately not the
+ * `v1.<iv>.<ct>` shape `lib/routines/crypto` produces, so it cannot be mistaken
+ * for a working credential by anything that reads it.
  */
-function collapse(table: string, rows: Row[]): Row[] {
-  if (table !== "workspace_members" || rows.length === 0) return rows;
-  return [{ ...rows[0], role: "admin" }];
+export const MISSING_SECRET = "not-exported: re-enter this channel's credential";
+
+/** Why every restored routine arrives switched off. */
+export const PAUSED_ON_RESTORE =
+  "Restored from an export. The delivery credential could not travel between " +
+  "installs — re-enter it on this channel, then resume.";
+
+/**
+ * Rows the restore cannot replay as they were read.
+ *
+ * Three of them, each because the database refuses the honest version:
+ *
+ * - **Memberships.** Everybody collapses to one account, so replaying five
+ *   members would be five inserts of the same primary key — four swallowed by
+ *   `on conflict do nothing` and the survivor carrying whichever role sorted
+ *   first. That can hand the restorer a `member` row in their own workspace and
+ *   lock them out of it. One row, admin, every other column from the earliest.
+ * - **Delivery channels.** The secret is `not null` and cannot be exported, so
+ *   the column gets a value that is visibly not a credential. Skipping the
+ *   table instead was not available: `routines.delivery_channel_id` is `not
+ *   null` too, so a workspace with any routine would have had nothing to
+ *   restore at all.
+ * - **Routines.** Which is what makes the line above tolerable rather than a
+ *   trap. A routine whose channel holds no real secret cannot deliver, so it
+ *   comes back paused with the reason on its own row — where the person looking
+ *   at it will actually read it — instead of running on schedule and failing
+ *   somewhere they are not looking.
+ */
+function rewriteForRestore(table: string, rows: Row[]): Row[] {
+  if (rows.length === 0) return rows;
+  if (table === "workspace_members") return [{ ...rows[0], role: "admin" }];
+  if (table === "delivery_channels") {
+    return rows.map((r) => ({ ...r, secret_ciphertext: MISSING_SECRET }));
+  }
+  if (table === "routines") {
+    return rows.map((r) => ({ ...r, status: "paused", paused_reason: PAUSED_ON_RESTORE }));
+  }
+  return rows;
 }

--- a/worker/src/lib/export/sql.ts
+++ b/worker/src/lib/export/sql.ts
@@ -1,0 +1,158 @@
+import type { Collected, Row } from "./collect";
+import { EXPORTED } from "./tables";
+
+/**
+ * The archive's restore path, rendered as SQL somebody can read before running.
+ *
+ * The alternative was an importer — a program that reads the JSON and writes
+ * the rows. It would have been a second implementation of what Postgres already
+ * does, needing its own dependency, its own errors and its own trust. A `.sql`
+ * file needs `psql`, which anybody restoring a database has, and it can be
+ * opened and read first, which is worth a great deal when the thing you are
+ * about to run touches a database you care about.
+ *
+ * It is one transaction. A restore either happens or does not.
+ */
+
+/**
+ * Columns that hold a person, and the reason the restore needs an argument.
+ *
+ * Every one of these ends at an account, and the accounts in a fresh install are
+ * not the accounts in the old one — there is no id to carry across, and
+ * inventing users for people who did not ask to be recreated would be worse
+ * than not having them. So every person in the export collapses to whoever runs
+ * the restore, and the archive says so plainly rather than appearing to have
+ * preserved a team it did not.
+ *
+ * "Ends at an account" rather than "references auth.users", because one of them
+ * does not, and that is exactly how it nearly got missed.
+ */
+export const USER_COLUMNS = new Set([
+  "user_id",
+  "created_by",
+  "invited_by",
+  "accepted_by",
+  // `messages.sender_id` references `public.profiles` rather than
+  // `auth.users`, which is why it is easy to miss in a search for the
+  // latter — 0008 pointed it at profiles so PostgREST could embed the
+  // sender. It is still a person, and profiles are not replayed, so
+  // leaving it alone would dangle every message in the archive.
+  "sender_id",
+]);
+
+/**
+ * Not replayed: a profile belongs to an account, and the account restoring this
+ * already has one. Exported as JSON anyway, because "who was Ayşe in these
+ * messages" is a question the archive should still be able to answer.
+ */
+const SKIP = new Set(["profiles"]);
+
+/**
+ * Nullable references that can point outside what the caller could see.
+ *
+ * A member exporting a workspace gets the sessions they may read, so an idea
+ * cited from a message in somebody else's private session arrives with a
+ * dangling `source_message_id`. Restoring that row would fail the foreign key
+ * and take the whole transaction with it. The reference is dropped instead, and
+ * `manifest.json` counts what was dropped so the loss is stated rather than
+ * discovered.
+ */
+const OPTIONAL_REFS: Record<string, string> = {
+  "ideas.source_message_id": "messages",
+  "routines.delivery_channel_id": "delivery_channels",
+  "documents.agent_id": "agents",
+};
+
+/** A Postgres literal. `standard_conforming_strings` is on, so doubling `'` is enough. */
+function literal(value: unknown): string {
+  if (value === null || value === undefined) return "NULL";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return Number.isFinite(value) ? String(value) : "NULL";
+  // Objects and arrays are the three jsonb columns — messages.sources,
+  // routines.source_config, routines.cursor. Postgres coerces the string
+  // literal to jsonb because the target column's type is known.
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  return `'${text.replace(/'/g, "''")}'`;
+}
+
+export type RenderedSql = {
+  sql: string;
+  /** `table.column` → how many references were dropped as unreachable. */
+  droppedReferences: Record<string, number>;
+};
+
+export function renderSql(tables: Collected): RenderedSql {
+  const dropped: Record<string, number> = {};
+  const known = new Map<string, Set<string>>();
+  for (const [table, rows] of Object.entries(tables)) {
+    known.set(table, new Set(rows.map((r) => String(r.id ?? "")).filter(Boolean)));
+  }
+
+  const out: string[] = [
+    "-- workspace.sql — replay this workspace into a fresh Covan.",
+    "--",
+    "--   psql \"$DATABASE_URL\" -v owner='<the user id this should belong to>' \\",
+    "--        -f workspace.sql",
+    "--",
+    "-- `owner` is required and psql stops if it is missing. Every person in the",
+    "-- original workspace becomes that one account: see the archive's manifest.",
+    "--",
+    "-- Ids are preserved, so a restore is comparable to the export row for row,",
+    "-- and the document filenames in documents/ still match their rows.",
+    "--",
+    "-- Written by Covan. Read it before you run it.",
+    "",
+    "begin;",
+    "",
+  ];
+
+  for (const spec of EXPORTED) {
+    if (SKIP.has(spec.table)) continue;
+    const rows = collapse(spec.table, tables[spec.table] ?? []);
+    if (rows.length === 0) {
+      out.push(`-- ${spec.table}: nothing to restore`, "");
+      continue;
+    }
+
+    const columns = Object.keys(rows[0]);
+    out.push(`-- ${spec.table} (${rows.length})`);
+    for (const row of rows) {
+      const values = columns.map((column) => {
+        if (USER_COLUMNS.has(column)) return ":'owner'";
+
+        const ref = OPTIONAL_REFS[`${spec.table}.${column}`];
+        const value = row[column];
+        if (ref && typeof value === "string" && !known.get(ref)?.has(value)) {
+          const key = `${spec.table}.${column}`;
+          dropped[key] = (dropped[key] ?? 0) + 1;
+          return "NULL";
+        }
+
+        return literal(value);
+      });
+
+      out.push(
+        `insert into public.${spec.table} (${columns.join(", ")}) values (${values.join(", ")}) on conflict do nothing;`,
+      );
+    }
+    out.push("");
+  }
+
+  out.push("commit;", "");
+  return { sql: out.join("\n"), droppedReferences: dropped };
+}
+
+/**
+ * One membership row, not many.
+ *
+ * Everybody collapses to the same account, so replaying five members would be
+ * five inserts of the same primary key — four silently swallowed by `on
+ * conflict do nothing` and the surviving one carrying whichever role happened
+ * to sort first. That could hand the restorer a `member` row in their own
+ * workspace and lock them out of it. So it is decided here instead: one row,
+ * admin, keeping every other column from the earliest membership.
+ */
+function collapse(table: string, rows: Row[]): Row[] {
+  if (table !== "workspace_members" || rows.length === 0) return rows;
+  return [{ ...rows[0], role: "admin" }];
+}

--- a/worker/src/lib/export/sql.ts
+++ b/worker/src/lib/export/sql.ts
@@ -59,8 +59,14 @@ const SKIP = new Set(["profiles"]);
  */
 const OPTIONAL_REFS: Record<string, string> = {
   "ideas.source_message_id": "messages",
-  "routines.delivery_channel_id": "delivery_channels",
-  "documents.agent_id": "agents",
+  // `routines.delivery_channel_id` was here and should never have been: the
+  // column is `not null`, so nulling an unreachable reference does not rescue
+  // the restore, it fails it in a less obvious place. That case is handled
+  // below instead, by giving the routine a channel to point at.
+  //
+  // `documents.agent_id` was here too and no longer exists — 0004 made
+  // `bundle_id` authoritative and a later migration dropped the column, so the
+  // entry had been describing nothing for some time.
 };
 
 /** A Postgres literal. `standard_conforming_strings` is on, so doubling `'` is enough. */
@@ -75,10 +81,31 @@ function literal(value: unknown): string {
   return `'${text.replace(/'/g, "''")}'`;
 }
 
+/**
+ * The channel a routine points at when its real one could not be exported.
+ *
+ * A channel belongs to a person (0019), so a workspace where two people each
+ * built routines has routines pointing at channels only their own author can
+ * read. Exporting as one of them leaves the other's reference unreachable — and
+ * `delivery_channel_id` is `not null` with a DEFERRABLE INITIALLY DEFERRED
+ * constraint, so the failure is a foreign key violation **at commit**, after
+ * every other row has already gone in. The worst place to discover anything.
+ *
+ * One synthesised row is the answer. It is labelled as what it is, carries the
+ * same non-credential as every other restored channel, and the routines that
+ * use it come back paused like all the rest — so nothing is silently delivering
+ * to a channel somebody did not choose.
+ */
+export const PLACEHOLDER_CHANNEL_ID = "00000000-0000-4000-8000-000000000001";
+export const PLACEHOLDER_CHANNEL_LABEL =
+  "unavailable — this routine's channel belonged to someone else";
+
 export type RenderedSql = {
   sql: string;
   /** `table.column` → how many references were dropped as unreachable. */
   droppedReferences: Record<string, number>;
+  /** True when a routine had to be pointed at the synthesised channel. */
+  usedPlaceholderChannel: boolean;
 };
 
 export function renderSql(tables: Collected): RenderedSql {
@@ -87,6 +114,13 @@ export function renderSql(tables: Collected): RenderedSql {
   for (const [table, rows] of Object.entries(tables)) {
     known.set(table, new Set(rows.map((r) => String(r.id ?? "")).filter(Boolean)));
   }
+
+  // Decided before anything is written, because it changes two sections: the
+  // routines that point at it, and the channel list that has to contain it.
+  const channels = known.get("delivery_channels") ?? new Set<string>();
+  const usedPlaceholderChannel = (tables.routines ?? []).some(
+    (r) => typeof r.delivery_channel_id === "string" && !channels.has(r.delivery_channel_id),
+  );
 
   const out: string[] = [
     "-- workspace.sql — replay this workspace into a fresh Covan.",
@@ -109,19 +143,40 @@ export function renderSql(tables: Collected): RenderedSql {
   for (const spec of EXPORTED) {
     if (SKIP.has(spec.table)) continue;
     const rows = rewriteForRestore(spec.table, tables[spec.table] ?? []);
-    if (rows.length === 0) {
+    const needsPlaceholder = spec.table === "delivery_channels" && usedPlaceholderChannel;
+
+    if (rows.length === 0 && !needsPlaceholder) {
       out.push(`-- ${spec.table}: nothing to restore`, "");
       continue;
     }
 
-    const columns = Object.keys(rows[0]);
+    // From the rows when there are any, and from the spec when there are not —
+    // which is the case that matters here: a member exporting a workspace whose
+    // routines all belong to somebody else collects no channels at all, and
+    // still needs the synthesised one written or the commit fails.
+    const columns = rows.length > 0 ? Object.keys(rows[0]) : declaredColumns(spec.columns);
     out.push(`-- ${spec.table} (${rows.length})`);
+    if (needsPlaceholder) {
+      out.push(placeholderChannelInsert(columns, tables));
+    }
     for (const row of rows) {
       const values = columns.map((column) => {
         if (USER_COLUMNS.has(column)) return ":'owner'";
 
-        const ref = OPTIONAL_REFS[`${spec.table}.${column}`];
         const value = row[column];
+
+        // Not nullable, so it is redirected rather than dropped.
+        if (spec.table === "routines" && column === "delivery_channel_id") {
+          const reachable = typeof value === "string" && channels.has(value);
+          if (!reachable) {
+            dropped["routines.delivery_channel_id"] =
+              (dropped["routines.delivery_channel_id"] ?? 0) + 1;
+            return literal(PLACEHOLDER_CHANNEL_ID);
+          }
+          return literal(value);
+        }
+
+        const ref = OPTIONAL_REFS[`${spec.table}.${column}`];
         if (ref && typeof value === "string" && !known.get(ref)?.has(value)) {
           const key = `${spec.table}.${column}`;
           dropped[key] = (dropped[key] ?? 0) + 1;
@@ -139,7 +194,48 @@ export function renderSql(tables: Collected): RenderedSql {
   }
 
   out.push("commit;", "");
-  return { sql: out.join("\n"), droppedReferences: dropped };
+  return { sql: out.join("\n"), droppedReferences: dropped, usedPlaceholderChannel };
+}
+
+/**
+ * The columns a table's rows would have had, when none came back.
+ *
+ * `delivery_channels` is the only spec that names its columns, and
+ * `secret_ciphertext` is deliberately not among them — the export cannot read
+ * it. The restore has to write it anyway, so it is added here.
+ */
+function declaredColumns(columns: string | undefined): string[] {
+  const named = (columns ?? "")
+    .split(",")
+    .map((c) => c.trim())
+    .filter(Boolean);
+  return named.includes("secret_ciphertext") ? named : [...named, "secret_ciphertext"];
+}
+
+/**
+ * The synthesised channel, written with the same columns as the real ones so
+ * the section stays one shape.
+ *
+ * `workspace_id` is provenance and nothing reads it (0019), but pointing it at
+ * this workspace is the truthful answer to "where did this come from".
+ */
+function placeholderChannelInsert(columns: string[], tables: Collected): string {
+  const workspaceId = tables.workspaces?.[0]?.id ?? null;
+  const values = columns.map((column) => {
+    if (USER_COLUMNS.has(column)) return ":'owner'";
+    if (column === "id") return literal(PLACEHOLDER_CHANNEL_ID);
+    if (column === "workspace_id") return literal(workspaceId);
+    if (column === "kind") return literal("email");
+    if (column === "label") return literal(PLACEHOLDER_CHANNEL_LABEL);
+    if (column === "secret_ciphertext") return literal(MISSING_SECRET);
+    // created_at, and anything a later migration adds: let the default decide
+    // rather than invent a value for a row that is itself a stand-in.
+    return "default";
+  });
+  return (
+    `insert into public.delivery_channels (${columns.join(", ")}) ` +
+    `values (${values.join(", ")}) on conflict do nothing;`
+  );
 }
 
 /**

--- a/worker/src/lib/export/tables.test.ts
+++ b/worker/src/lib/export/tables.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { EXPORTED, EXCLUDED } from "./tables";
+
+/**
+ * The list has to stay honest, and the way it rots is silence.
+ *
+ * A table added next year for a feature nobody remembers writing simply will
+ * not be in the archive, and nothing anywhere fails — the export keeps working,
+ * keeps looking complete, and quietly leaves that table's rows behind. The
+ * person who finds out is somebody restoring a workspace they no longer have.
+ *
+ * So the schema is the source of truth and this walks it. Adding a table forces
+ * a decision: in `EXPORTED` with a scope, or in `EXCLUDED` with a reason
+ * somebody could argue with.
+ */
+const MIGRATIONS = join(process.cwd(), "..", "supabase", "migrations");
+
+function tablesInSchema(): string[] {
+  const found = new Set<string>();
+  for (const file of readdirSync(MIGRATIONS).sort()) {
+    if (!file.endsWith(".sql")) continue;
+    const sql = readFileSync(join(MIGRATIONS, file), "utf8");
+    for (const m of sql.matchAll(/create table (?:if not exists )?public\.([a-z_]+)/g)) {
+      found.add(m[1]);
+    }
+  }
+  return [...found].sort();
+}
+
+describe("what the export knows about", () => {
+  const schema = tablesInSchema();
+
+  it("found the schema at all", () => {
+    // Without this a wrong path would make every assertion below pass on an
+    // empty set, which is the failure mode of every test that walks a tree.
+    expect(schema.length).toBeGreaterThan(15);
+    expect(schema).toContain("workspaces");
+  });
+
+  it("has decided about every table in the schema", () => {
+    const decided = new Set([...EXPORTED.map((t) => t.table), ...Object.keys(EXCLUDED)]);
+    const undecided = schema.filter((t) => !decided.has(t));
+
+    expect(
+      undecided,
+      "these tables exist and the export neither takes them nor says why not. " +
+        "Add each to EXPORTED with a scope, or to EXCLUDED with a reason.",
+    ).toEqual([]);
+  });
+
+  it("does not claim tables the schema does not have", () => {
+    // The other direction: an entry outliving its table is a promise the
+    // archive cannot keep, and the read would fail at runtime.
+    const stale = [...EXPORTED.map((t) => t.table), ...Object.keys(EXCLUDED)].filter(
+      (t) => !schema.includes(t),
+    );
+    expect(stale).toEqual([]);
+  });
+
+  it("takes nothing it also says it excludes", () => {
+    const both = EXPORTED.map((t) => t.table).filter((t) => t in EXCLUDED);
+    expect(both).toEqual([]);
+  });
+
+  it("gives every exclusion a reason worth reading", () => {
+    for (const [table, reason] of Object.entries(EXCLUDED)) {
+      expect(reason.length, `${table}'s reason is too short to be one`).toBeGreaterThan(40);
+    }
+  });
+});
+
+describe("the order the tables are written in", () => {
+  it("never scopes a table by ids it has not collected yet", () => {
+    // Also the insert order in workspace.sql, so getting this wrong is both an
+    // empty table in the archive and a foreign key violation on restore.
+    const seen = new Set<string>();
+    for (const spec of EXPORTED) {
+      if (spec.scope.kind === "in") {
+        expect(
+          seen.has(spec.scope.from.table),
+          `${spec.table} is scoped by ${spec.scope.from.table}, which comes later`,
+        ).toBe(true);
+      }
+      seen.add(spec.table);
+    }
+  });
+
+  it("starts at the workspace itself", () => {
+    expect(EXPORTED[0].table).toBe("workspaces");
+  });
+
+  it("names its columns wherever a select * would be refused", () => {
+    // 0023 withheld delivery_channels.secret_ciphertext from `authenticated`,
+    // and PostgREST expands `*` to every column — including that one — so the
+    // read fails with 42501 for the whole row unless the six are named.
+    const channels = EXPORTED.find((t) => t.table === "delivery_channels");
+    expect(channels?.columns).toBeDefined();
+    expect(channels?.columns).not.toContain("secret_ciphertext");
+  });
+});

--- a/worker/src/lib/export/tables.ts
+++ b/worker/src/lib/export/tables.ts
@@ -41,8 +41,15 @@ export type TableSpec = {
 };
 
 /**
- * In insert order. Each table's foreign keys point only at tables above it, so
- * `workspace.sql` can be replayed top to bottom without deferring anything.
+ * Collection order, which is also insert order.
+ *
+ * Each table is scoped by ids collected above it, and — with one exception —
+ * its foreign keys point only at tables above it too, so `workspace.sql` can be
+ * replayed top to bottom. The exception is `routines.delivery_channel_id`,
+ * which points *down* at `delivery_channels`: the channels can only be found
+ * through the routines that use them, and 0012 made that constraint DEFERRABLE
+ * INITIALLY DEFERRED, so it is checked at commit rather than at the insert.
+ * That is the whole reason the two orders can stay one list.
  */
 export const EXPORTED: TableSpec[] = [
   { table: "workspaces", scope: { kind: "workspace", column: "id" }, order: "created_at" },
@@ -95,13 +102,33 @@ export const EXPORTED: TableSpec[] = [
     scope: { kind: "in", column: "agent_id", from: { table: "agents", column: "id" } },
     order: "created_at",
   },
+  { table: "routines", scope: { kind: "workspace", column: "workspace_id" }, order: "created_at" },
   {
+    // Scoped by the routines that reference it, not by `workspace_id` — and
+    // that is a correction rather than a preference. 0019 spells out that a
+    // delivery channel belongs to a PERSON: `workspace_id` is written once from
+    // whichever workspace was active when it was added and never read again,
+    // which is why the column became nullable and stopped cascading.
+    //
+    // Scoping by it therefore got both directions wrong. It exported channels
+    // this workspace does not use, and — the part that broke restores — it
+    // missed the channel a routine here actually points at when that channel
+    // was added from another workspace. `delivery_channel_id` is `not null`, so
+    // a missing one is not a null column, it is a failed transaction.
+    //
+    // Reading it after `routines` is safe for the restore because
+    // `routines_delivery_channel_id_fkey` is DEFERRABLE INITIALLY DEFERRED
+    // (0012), so the check happens at commit and the insert order inside the
+    // transaction does not matter for this one reference.
     table: "delivery_channels",
-    scope: { kind: "workspace", column: "workspace_id" },
+    scope: {
+      kind: "in",
+      column: "id",
+      from: { table: "routines", column: "delivery_channel_id" },
+    },
     order: "created_at",
     columns: "id,workspace_id,user_id,kind,label,created_at",
   },
-  { table: "routines", scope: { kind: "workspace", column: "workspace_id" }, order: "created_at" },
   {
     table: "routine_runs",
     scope: { kind: "in", column: "routine_id", from: { table: "routines", column: "id" } },

--- a/worker/src/lib/export/tables.ts
+++ b/worker/src/lib/export/tables.ts
@@ -1,0 +1,129 @@
+/**
+ * What a workspace is made of, and what is deliberately not in the archive.
+ *
+ * Declared as data rather than written as a sequence of queries, because the
+ * list is the interesting part and it has to be reviewable: somebody adding a
+ * table to this product should be able to look at one screen and see whether
+ * their table belongs in an export. `export.test.ts` fails when a table exists
+ * in `supabase/migrations` and appears in neither list here, so the question is
+ * asked rather than forgotten.
+ *
+ * Every read goes through the caller's own client, so row level security
+ * decides what comes back. An admin's export and a member's export are
+ * different files, and `manifest.json` says which one you are holding rather
+ * than implying the archive is the whole workspace.
+ */
+
+/** How a table's rows are found. */
+export type Scope =
+  /** `column = <the workspace id>`. */
+  | { kind: "workspace"; column: string }
+  /** `column in (<values of `from` collected earlier>)`. */
+  | { kind: "in"; column: string; from: { table: string; column: string } };
+
+export type TableSpec = {
+  table: string;
+  scope: Scope;
+  /** Sorted by this, so two exports of unchanged data can be diffed. */
+  order: string;
+  /**
+   * Explicit column list, where `*` would be refused.
+   *
+   * Only `delivery_channels` needs one. `0023` granted `authenticated` select
+   * on six of its seven columns and withheld `secret_ciphertext`, so a `select
+   * *` expands to a column the caller may not read and Postgres answers 42501
+   * for the whole row. Naming the six is what makes the read succeed — and the
+   * seventh being absent is not a gap in the export, it is the point: the
+   * ciphertext is bound to this install's `ROUTINE_SECRET_KEY` and would be
+   * undecryptable noise anywhere else.
+   */
+  columns?: string;
+};
+
+/**
+ * In insert order. Each table's foreign keys point only at tables above it, so
+ * `workspace.sql` can be replayed top to bottom without deferring anything.
+ */
+export const EXPORTED: TableSpec[] = [
+  { table: "workspaces", scope: { kind: "workspace", column: "id" }, order: "created_at" },
+  {
+    table: "workspace_members",
+    scope: { kind: "workspace", column: "workspace_id" },
+    order: "created_at",
+  },
+  // After the memberships it is scoped by, which is the whole reason the order
+  // is asserted: put this first and `collectWorkspace` reads an id list that
+  // has not been collected yet, exports nobody, and reports success.
+  {
+    table: "profiles",
+    scope: { kind: "in", column: "id", from: { table: "workspace_members", column: "user_id" } },
+    order: "id",
+  },
+  { table: "agents", scope: { kind: "workspace", column: "workspace_id" }, order: "created_at" },
+  {
+    table: "knowledge_bundles",
+    scope: { kind: "workspace", column: "workspace_id" },
+    order: "created_at",
+  },
+  {
+    table: "agent_bundles",
+    scope: {
+      kind: "in",
+      column: "bundle_id",
+      from: { table: "knowledge_bundles", column: "id" },
+    },
+    order: "created_at",
+  },
+  {
+    table: "documents",
+    scope: { kind: "in", column: "bundle_id", from: { table: "knowledge_bundles", column: "id" } },
+    order: "created_at",
+  },
+  {
+    table: "chat_sessions",
+    scope: { kind: "workspace", column: "workspace_id" },
+    order: "created_at",
+  },
+  {
+    table: "messages",
+    scope: { kind: "in", column: "session_id", from: { table: "chat_sessions", column: "id" } },
+    order: "created_at",
+  },
+  { table: "ideas", scope: { kind: "workspace", column: "workspace_id" }, order: "created_at" },
+  {
+    table: "favorites",
+    scope: { kind: "in", column: "agent_id", from: { table: "agents", column: "id" } },
+    order: "created_at",
+  },
+  {
+    table: "delivery_channels",
+    scope: { kind: "workspace", column: "workspace_id" },
+    order: "created_at",
+    columns: "id,workspace_id,user_id,kind,label,created_at",
+  },
+  { table: "routines", scope: { kind: "workspace", column: "workspace_id" }, order: "created_at" },
+  {
+    table: "routine_runs",
+    scope: { kind: "in", column: "routine_id", from: { table: "routines", column: "id" } },
+    order: "started_at",
+  },
+];
+
+/**
+ * Left out, each for a reason that has to survive being read by somebody who
+ * wanted the thing that is missing.
+ */
+export const EXCLUDED: Record<string, string> = {
+  document_chunks:
+    "derived, and enormous. Every chunk carries a 1536-dimension vector, so a workspace with ten thousand of them is tens of megabytes of numbers that say nothing a human can read. The documents themselves are in this archive; running POST /admin/backfill-embeddings after a restore rebuilds the chunks from them — with whatever embedding model the new install is configured for, which is more useful than replaying the old one's.",
+  api_keys:
+    "credentials. A key is not a record of what the workspace holds, it is a way to become one of its members, and an archive that carried them would be a key store that people email to each other.",
+  routine_deliveries:
+    "not readable by a client at all, by design since 0012: it is the engine's own log of what it sent where. Nothing in it is workspace content.",
+  invitations:
+    "in flight rather than held. An invitation is an offer to somebody who has not accepted, and it is scoped to an install's email and token; replaying one into a new install would either do nothing or invite a stranger.",
+  notification_preferences:
+    "a person's setting, not a workspace's. It follows the account rather than the room, and the account is not what is being exported.",
+  user_onboarding:
+    "the same, and about a first run that has already happened. It would mean nothing in a new install.",
+};

--- a/worker/src/lib/export/zip.test.ts
+++ b/worker/src/lib/export/zip.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeZip, type ZipEntry } from "./zip";
+
+/**
+ * Checked against `unzip`, not against a second reader written here.
+ *
+ * A hand-rolled format tested only by its own parser proves the two agree and
+ * nothing else — and the thing that matters about this archive is that software
+ * nobody in this repository wrote can open it, five years from now, on a
+ * machine that has never heard of Covan. `unzip -t` verifies every CRC, which
+ * is exactly the field a hand-rolled writer gets wrong.
+ */
+beforeAll(() => {
+  for (const [bin, args] of [
+    ["unzip", ["-v"]],
+    ["python3", ["--version"]],
+  ] as const) {
+    try {
+      execFileSync(bin, args, { stdio: "ignore" });
+    } catch {
+      throw new Error(
+        `These tests need \`${bin}\` on PATH. Two readers rather than one: ` +
+          `unzip verifies the CRCs, and Python's zipfile is old enough to be ` +
+          `everywhere and new enough to know about the UTF-8 flag, which the ` +
+          `unzip macOS ships does not.`,
+      );
+    }
+  }
+});
+
+async function zip(entries: ZipEntry[]): Promise<Uint8Array> {
+  async function* iter() {
+    for (const e of entries) yield e;
+  }
+  const chunks: Uint8Array[] = [];
+  const reader = writeZip(iter()).getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const c of chunks) {
+    out.set(c, at);
+    at += c.length;
+  }
+  return out;
+}
+
+function onDisk(bytes: Uint8Array): string {
+  const dir = mkdtempSync(join(tmpdir(), "covan-zip-"));
+  const path = join(dir, "archive.zip");
+  writeFileSync(path, bytes);
+  return path;
+}
+
+const text = (s: string) => new TextEncoder().encode(s);
+
+describe("the archive", () => {
+  it("passes unzip's own integrity check", async () => {
+    const path = onDisk(
+      await zip([
+        { name: "manifest.json", data: text('{"format":1}') },
+        { name: "data/agents.json", data: text("[]") },
+      ]),
+    );
+
+    // -t verifies every entry's CRC against its bytes. This is the assertion
+    // the whole file exists for.
+    const out = execFileSync("unzip", ["-t", path], { encoding: "utf8" });
+    expect(out).toMatch(/No errors detected in compressed data/);
+  });
+
+  it("gives back exactly the bytes it was given", async () => {
+    const body = '{"rows":[{"id":"a"},{"id":"b"}]}';
+    const path = onDisk(await zip([{ name: "data/agents.json", data: text(body) }]));
+
+    const out = execFileSync("unzip", ["-p", path, "data/agents.json"], { encoding: "utf8" });
+    expect(out).toBe(body);
+  });
+
+  it("survives arbitrary binary, which is what an uploaded document is", async () => {
+    // Every byte value, including the ones that look like ZIP signatures.
+    const bytes = new Uint8Array(256 * 4);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = i % 256;
+    const path = onDisk(await zip([{ name: "documents/blob.bin", data: bytes }]));
+
+    const dir = join(path, "..");
+    execFileSync("unzip", ["-o", "-q", path, "-d", dir]);
+    expect(new Uint8Array(readFileSync(join(dir, "documents/blob.bin")))).toEqual(bytes);
+  });
+
+  it("keeps a non-ASCII filename intact", async () => {
+    // The reason bit 11 is set. Without it the name comes back mojibake, and
+    // the person who notices is the one whose language is not English.
+    //
+    // Checked with Python's zipfile rather than with `unzip`, and the reason is
+    // worth recording: the Info-ZIP build macOS still ships is from 2005 and
+    // predates the UTF-8 flag entirely, so it transliterates the name and then
+    // refuses to create the file. That is a limitation of a twenty-year-old
+    // tool, not of the archive — anything that has heard of bit 11 reads it
+    // correctly, and this proves which of the two it is.
+    const name = "documents/toplantı-notları.md";
+    const path = onDisk(await zip([{ name, data: text("merhaba") }]));
+
+    const out = execFileSync(
+      "python3",
+      [
+        "-c",
+        "import sys,zipfile\n" +
+          "z=zipfile.ZipFile(sys.argv[1])\n" +
+          "i=z.infolist()[0]\n" +
+          "print(i.filename)\n" +
+          "print(i.flag_bits & 0x800)\n" +
+          "print(z.read(i).decode())",
+        path,
+      ],
+      { encoding: "utf8" },
+    ).split("\n");
+
+    expect(out[0]).toBe(name);
+    expect(out[1]).toBe("2048"); // the UTF-8 flag, set
+    expect(out[2]).toBe("merhaba");
+  });
+
+  it("writes an empty archive that is still a well-formed one", async () => {
+    // A workspace with nothing in it is a real thing to export, and an archive
+    // with no entries is where a hand-rolled EOCD is most likely to be wrong.
+    //
+    // Info-ZIP calls a zero-entry archive empty and exits non-zero, which is
+    // its opinion rather than a defect — the 22-byte EOCD is exactly what the
+    // specification asks for, and it says so instead of choking. Asserted as
+    // the behaviour it is. In practice the export never produces one: the
+    // manifest is always written.
+    const path = onDisk(await zip([]));
+    expect(readFileSync(path).length).toBe(22);
+
+    try {
+      execFileSync("unzip", ["-l", path], { encoding: "utf8", stdio: "pipe" });
+      throw new Error("expected unzip to complain about an empty archive");
+    } catch (e) {
+      expect(String((e as { stderr?: string }).stderr ?? e)).toMatch(/zipfile is empty/);
+    }
+  });
+
+  it("holds many entries, in the order they were written", async () => {
+    const entries = Array.from({ length: 50 }, (_, i) => ({
+      name: `data/part-${String(i).padStart(3, "0")}.json`,
+      data: text(String(i)),
+    }));
+    const path = onDisk(await zip(entries));
+
+    const listed = execFileSync("unzip", ["-Z", "-1", path], { encoding: "utf8" })
+      .trim()
+      .split("\n");
+    expect(listed).toEqual(entries.map((e) => e.name));
+  });
+
+  it("is byte-identical when the same workspace is exported twice", async () => {
+    // No clock in the headers, so two exports of unchanged data can be diffed
+    // or hashed and the answer means something.
+    const entries = [{ name: "manifest.json", data: text('{"format":1}') }];
+    expect(await zip(entries)).toEqual(await zip(entries));
+  });
+});
+
+describe("the limits it will not silently cross", () => {
+  it("refuses past 65,535 entries rather than wrapping the count", async () => {
+    async function* many() {
+      for (let i = 0; i <= 65535; i++) yield { name: `f${i}`, data: new Uint8Array(0) };
+    }
+    const reader = writeZip(many()).getReader();
+    await expect(
+      (async () => {
+        for (;;) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      })(),
+    ).rejects.toThrow(/Zip64/);
+  });
+
+  it("refuses past 4 GB rather than wrapping the offsets", async () => {
+    // The bytes are never allocated: the guard reads `.length` and fires before
+    // anything touches the buffer, which is also why a stand-in with only that
+    // property is enough to reach it.
+    async function* huge() {
+      yield { name: "a", data: { length: 0x100000000 } as unknown as Uint8Array };
+    }
+    const reader = writeZip(huge()).getReader();
+    await expect(
+      (async () => {
+        for (;;) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      })(),
+    ).rejects.toThrow(/4 GB/);
+  });
+});

--- a/worker/src/lib/export/zip.ts
+++ b/worker/src/lib/export/zip.ts
@@ -1,0 +1,201 @@
+/**
+ * A ZIP writer, by hand, because the alternative was worse.
+ *
+ * An export has to be one file — a person who is leaving should get one thing,
+ * not a folder of eleven — and it has to hold two kinds of content that cannot
+ * share a format: structured rows, which want JSON, and document bytes, which
+ * are whatever the person uploaded. A container is the only way to have both.
+ *
+ * Nothing here compresses. Every entry is stored, method 0, which sounds
+ * wasteful until you count what is actually in the archive: the JSON compresses
+ * well and is small, and the documents are mostly PDFs and images that are
+ * already compressed. What deflate would buy is a few percent on the small half,
+ * paid for with a compression library that has to work on both runtimes and a
+ * dependency in a Worker that is otherwise dependency-light. Every unzip
+ * implementation in existence reads stored entries.
+ *
+ * The output streams. Entries arrive one at a time and each is written and
+ * dropped, so peak memory is one entry rather than the whole archive — which
+ * matters because a document is capped at 10 MB (`routes/bundles.ts`) but a
+ * workspace holding two hundred of them is not capped at anything.
+ *
+ * Not implemented, deliberately: Zip64. It would be needed past 4 GB of
+ * archive, or more than 65,535 entries, and `writeZip` refuses rather than
+ * silently emitting an archive whose offsets have wrapped — a truncated export
+ * that opens is worse than one that never existed.
+ */
+
+/** One file in the archive. `data` is held only while it is written. */
+export type ZipEntry = { name: string; data: Uint8Array };
+
+const LOCAL_SIG = 0x04034b50;
+const CENTRAL_SIG = 0x02014b50;
+const EOCD_SIG = 0x06054b50;
+
+/** UTF-8 names. Bit 11, and the reason the archive survives a Turkish filename. */
+const FLAG_UTF8 = 0x0800;
+
+/**
+ * A fixed DOS timestamp — 1980-01-01 00:00, the epoch of the format itself.
+ *
+ * Real modification times are in `manifest.json` and in every row's own
+ * `created_at`. Putting a clock in the header instead would make two exports of
+ * an unchanged workspace differ byte for byte, which costs the one property
+ * worth having here: you can diff two archives, or hash one, and have the
+ * answer mean something.
+ */
+const DOS_TIME = 0;
+const DOS_DATE = 0x0021;
+
+const MAX_ENTRIES = 0xffff;
+const MAX_SIZE = 0xffffffff;
+
+let crcTable: Uint32Array | null = null;
+
+function crc32(bytes: Uint8Array): number {
+  if (!crcTable) {
+    crcTable = new Uint32Array(256);
+    for (let i = 0; i < 256; i++) {
+      let c = i;
+      for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+      crcTable[i] = c >>> 0;
+    }
+  }
+  let crc = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) {
+    crc = crcTable[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/** Little-endian writer over a fixed-size buffer. */
+function writer(size: number) {
+  const buf = new Uint8Array(size);
+  const view = new DataView(buf.buffer);
+  let at = 0;
+  return {
+    u16(v: number) {
+      view.setUint16(at, v, true);
+      at += 2;
+    },
+    u32(v: number) {
+      view.setUint32(at, v >>> 0, true);
+      at += 4;
+    },
+    bytes(v: Uint8Array) {
+      buf.set(v, at);
+      at += v.length;
+    },
+    done() {
+      return buf;
+    },
+  };
+}
+
+/**
+ * Writes the archive, one entry at a time, into a stream.
+ *
+ * Takes an async iterable rather than an array so the caller can fetch each
+ * document only when it is about to be written — the difference between holding
+ * one document in memory and holding all of them.
+ */
+export function writeZip(entries: AsyncIterable<ZipEntry>): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      type Central = { name: Uint8Array; crc: number; size: number; offset: number };
+      const central: Central[] = [];
+      let offset = 0;
+
+      const push = (chunk: Uint8Array) => {
+        controller.enqueue(chunk);
+        offset += chunk.length;
+      };
+
+      try {
+        for await (const entry of entries) {
+          const name = encoder.encode(entry.name);
+          const size = entry.data.length;
+
+          // Checked before the CRC is computed, not after: the guards are about
+          // an archive too big to address, and hashing a gigabyte to then refuse
+          // to write it is work done for nothing.
+          if (central.length >= MAX_ENTRIES) {
+            throw new Error(
+              `Export has more than ${MAX_ENTRIES} entries, which needs Zip64. ` +
+                `Split the workspace, or add Zip64 support to lib/export/zip.ts.`,
+            );
+          }
+          if (offset + size > MAX_SIZE) {
+            throw new Error(
+              `Export would exceed 4 GB, which needs Zip64. ` +
+                `Add Zip64 support to lib/export/zip.ts rather than shipping a truncated archive.`,
+            );
+          }
+
+          const crc = crc32(entry.data);
+          const header = writer(30 + name.length);
+          header.u32(LOCAL_SIG);
+          header.u16(20); // version needed
+          header.u16(FLAG_UTF8);
+          header.u16(0); // stored
+          header.u16(DOS_TIME);
+          header.u16(DOS_DATE);
+          header.u32(crc);
+          header.u32(size); // compressed
+          header.u32(size); // uncompressed
+          header.u16(name.length);
+          header.u16(0); // extra
+          header.bytes(name);
+
+          central.push({ name, crc, size, offset });
+          push(header.done());
+          push(entry.data);
+        }
+
+        const cdStart = offset;
+        for (const e of central) {
+          const rec = writer(46 + e.name.length);
+          rec.u32(CENTRAL_SIG);
+          rec.u16(20); // version made by
+          rec.u16(20); // version needed
+          rec.u16(FLAG_UTF8);
+          rec.u16(0); // stored
+          rec.u16(DOS_TIME);
+          rec.u16(DOS_DATE);
+          rec.u32(e.crc);
+          rec.u32(e.size);
+          rec.u32(e.size);
+          rec.u16(e.name.length);
+          rec.u16(0); // extra
+          rec.u16(0); // comment
+          rec.u16(0); // disk
+          rec.u16(0); // internal attrs
+          rec.u32(0); // external attrs
+          rec.u32(e.offset);
+          rec.bytes(e.name);
+          push(rec.done());
+        }
+
+        const eocd = writer(22);
+        eocd.u32(EOCD_SIG);
+        eocd.u16(0); // this disk
+        eocd.u16(0); // disk with central directory
+        eocd.u16(central.length);
+        eocd.u16(central.length);
+        eocd.u32(offset - cdStart);
+        eocd.u32(cdStart);
+        eocd.u16(0); // comment length
+        push(eocd.done());
+
+        controller.close();
+      } catch (e) {
+        // Aborts the response mid-body, which a client sees as a truncated
+        // download rather than as a complete archive. That is the point: by the
+        // time the first byte is out there is no status code left to change.
+        controller.error(e);
+      }
+    },
+  });
+}

--- a/worker/src/routes/export.test.ts
+++ b/worker/src/routes/export.test.ts
@@ -1,0 +1,196 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { AppEnv } from "../types";
+import { exportRoutes } from "./export";
+import { fakeDb, type FakeDbSpec, type QueryContext } from "../test-support/fake-db";
+import { EXPORTED } from "../lib/export/tables";
+
+/**
+ * The workspace export, at the seam where it decides what it is allowed to
+ * build.
+ *
+ * What the archive contains is `lib/export/`'s business and is tested there.
+ * What matters here is narrower and easier to get wrong: that a stranger gets a
+ * 404 rather than an empty archive, that every read is scoped and paged, and
+ * that a failure part-way through the collection is still a status code —
+ * because once the first byte of a zip is on the wire the only way left to
+ * report a problem is to truncate the download, which looks exactly like a
+ * dropped connection.
+ */
+
+const USER = { id: "user-1", email: "a@example.com" };
+const WORKSPACE = "ws-1";
+
+const docs = { get: vi.fn(async () => null), put: vi.fn(), delete: vi.fn() };
+vi.mock("../lib/docstore", () => ({ getDocStore: () => docs }));
+
+/**
+ * Answers every export read with nothing, except where a test says otherwise.
+ *
+ * Built from `EXPORTED` rather than listed by hand, so a table added to the
+ * export arrives here already stubbed — the alternative is a suite that fails
+ * with "unexpected table" for a change that was correct.
+ */
+function appWith(spec: FakeDbSpec = {}) {
+  const empty = () => ({ data: [], error: null });
+  const tables: FakeDbSpec["tables"] = Object.fromEntries(
+    EXPORTED.map((t) => [t.table, { select: empty }]),
+  );
+
+  Object.assign(tables, {
+    workspace_members: {
+      select: (ctx: QueryContext) =>
+        // The membership check ends in maybeSingle(); the paged read does not.
+        ctx.single ? { data: { role: "admin" }, error: null } : empty(),
+    },
+    workspaces: {
+      select: (ctx: QueryContext) =>
+        ctx.single
+          ? { data: { id: WORKSPACE, name: "Acme", slug: "acme" }, error: null }
+          : { data: [{ id: WORKSPACE, name: "Acme", slug: "acme" }], error: null },
+    },
+    ...spec.tables,
+  });
+
+  const fake = fakeDb({ ...spec, tables });
+  const app = new Hono<AppEnv>();
+  app.use("/*", async (c, next) => {
+    c.set("user", USER as never);
+    c.set("db", fake.db as never);
+    await next();
+  });
+  app.route("/", exportRoutes);
+  return { app, ...fake };
+}
+
+const get = (app: Hono<AppEnv>, id = WORKSPACE) => app.request(`/workspaces/${id}/export`);
+
+describe("who may take one", () => {
+  it("hands a member an archive", async () => {
+    const { app } = appWith();
+    const res = await get(app);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/zip");
+  });
+
+  it("answers a stranger with 404, not with an empty archive", async () => {
+    // Not 403: an archive of nothing would imply the workspace exists and holds
+    // nothing, and a 403 would confirm it exists at all.
+    const { app } = appWith({
+      tables: { workspace_members: { select: () => ({ data: null, error: null }) } },
+    });
+
+    const res = await get(app);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not found" });
+  });
+
+  it("names the workspace in the filename, so two exports are tellable apart", async () => {
+    const { app } = appWith();
+    const disposition = (await get(app)).headers.get("Content-Disposition") ?? "";
+    expect(disposition).toContain("attachment;");
+    expect(decodeURIComponent(disposition)).toMatch(/covan-acme-\d{4}-\d{2}-\d{2}\.zip/);
+  });
+
+  it("is never cached — it is one person's data with their name on it", async () => {
+    const { app } = appWith();
+    expect((await get(app)).headers.get("Cache-Control")).toBe("no-store");
+  });
+});
+
+describe("how it reads", () => {
+  it("scopes every read to the workspace, and pages all of them", async () => {
+    const { app, calls } = appWith();
+    await get(app);
+
+    const paged = calls.filter((c) => c.range);
+    expect(paged.length).toBeGreaterThan(5);
+    for (const call of paged) {
+      expect(call.range, `${call.table} was read without a range`).toBeDefined();
+    }
+  });
+
+  it("starts at the workspace and its members, which everything else hangs off", async () => {
+    const { app, calls } = appWith();
+    await get(app);
+
+    const read = calls.filter((c) => c.range).map((c) => c.table);
+    expect(read.slice(0, 2)).toEqual(["workspaces", "workspace_members"]);
+  });
+
+  it("carries a parent's ids into the tables scoped by them", async () => {
+    // The step that makes the archive complete rather than merely non-empty:
+    // messages are not workspace-scoped, they are session-scoped, and the only
+    // way to find them is the id list the previous read produced.
+    const { app, calls } = appWith({
+      tables: {
+        chat_sessions: {
+          select: () => ({
+            data: [
+              { id: "s1", workspace_id: WORKSPACE },
+              { id: "s2", workspace_id: WORKSPACE },
+            ],
+            error: null,
+          }),
+        },
+      },
+    });
+    await get(app);
+
+    const messages = calls.find((c) => c.table === "messages");
+    expect(messages?.filters).toEqual([{ column: "session_id", value: ["s1", "s2"], kind: "in" }]);
+  });
+
+  it("never asks for delivery_channels' secret column", async () => {
+    // 0023 withheld it from `authenticated`, and PostgREST expands `*` to every
+    // column — so a `select *` here is a 42501 for the whole table rather than
+    // a row with one field missing.
+    const { app, calls } = appWith();
+    await get(app);
+
+    const channels = calls.find((c) => c.table === "delivery_channels");
+    expect(channels?.columns).toBeDefined();
+    expect(channels?.columns).not.toContain("secret_ciphertext");
+  });
+
+  it("skips a dependent table when its parent came back empty", async () => {
+    // No bundles means no documents to look for, and an `in ()` with no values
+    // is a query worth not sending.
+    const { app, calls } = appWith();
+    await get(app);
+
+    expect(calls.some((c) => c.table === "knowledge_bundles")).toBe(true);
+    expect(calls.some((c) => c.table === "documents")).toBe(false);
+  });
+});
+
+describe("when a read fails", () => {
+  it("answers with a status code rather than a truncated download", async () => {
+    const { app } = appWith({
+      tables: { agents: { select: () => ({ data: null, error: { message: "boom" } }) } },
+    });
+
+    const res = await get(app);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "failed to read agents" });
+  });
+
+  it("reports a failure in a dependent table too, naming that table", async () => {
+    // Not the same path: this one fails after several successful reads, deep in
+    // the id-threading, which is where a partial archive would otherwise be
+    // easiest to emit.
+    const { app } = appWith({
+      tables: {
+        chat_sessions: {
+          select: () => ({ data: [{ id: "s1", workspace_id: WORKSPACE }], error: null }),
+        },
+        messages: { select: () => ({ data: null, error: { message: "boom" } }) },
+      },
+    });
+
+    const res = await get(app);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "failed to read messages" });
+  });
+});

--- a/worker/src/routes/export.test.ts
+++ b/worker/src/routes/export.test.ts
@@ -142,14 +142,31 @@ describe("how it reads", () => {
     expect(messages?.filters).toEqual([{ column: "session_id", value: ["s1", "s2"], kind: "in" }]);
   });
 
-  it("never asks for delivery_channels' secret column", async () => {
-    // 0023 withheld it from `authenticated`, and PostgREST expands `*` to every
-    // column — so a `select *` here is a 42501 for the whole table rather than
-    // a row with one field missing.
-    const { app, calls } = appWith();
+  it("finds delivery channels through the routines that use them, not by workspace", async () => {
+    // 0019: a channel belongs to a person, and `workspace_id` on it is
+    // provenance nothing reads. Scoping by that column missed the channel a
+    // routine here actually points at whenever it was added from another
+    // workspace — and `delivery_channel_id` is `not null`, so a missing one is
+    // a failed restore rather than a null column.
+    //
+    // It also never asks for `secret_ciphertext`: 0023 withheld that column
+    // from `authenticated`, and PostgREST expands `*` to every column, so a
+    // `select *` is a 42501 for the whole table rather than a row with one
+    // field missing.
+    const { app, calls } = appWith({
+      tables: {
+        routines: {
+          select: () => ({
+            data: [{ id: "r1", workspace_id: WORKSPACE, delivery_channel_id: "c1" }],
+            error: null,
+          }),
+        },
+      },
+    });
     await get(app);
 
     const channels = calls.find((c) => c.table === "delivery_channels");
+    expect(channels?.filters).toEqual([{ column: "id", value: ["c1"], kind: "in" }]);
     expect(channels?.columns).toBeDefined();
     expect(channels?.columns).not.toContain("secret_ciphertext");
   });

--- a/worker/src/routes/export.ts
+++ b/worker/src/routes/export.ts
@@ -1,0 +1,102 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+import { getDocStore } from "../lib/docstore";
+import { collectWorkspace, ExportFailure } from "../lib/export/collect";
+import { archiveEntries } from "../lib/export/archive";
+import { writeZip } from "../lib/export/zip";
+
+/**
+ * Taking a workspace with you.
+ *
+ * The README says a self-hosted Covan is the whole product and that nothing is
+ * held hostage. That has always been true of the code and of the database;
+ * until now it was not true of the interface, and "you could always run
+ * `pg_dump`" is an answer for the operator, not for the team using their
+ * install. This is the button that makes the claim checkable by the person the
+ * claim is aimed at.
+ *
+ * Everything is read through the caller's own client, so the archive holds what
+ * that person could see. That is stated in the manifest rather than left to be
+ * inferred: an export is not "the workspace", it is one member's view of it,
+ * and an admin's file and a member's file are different files.
+ */
+const exportRoutes = new Hono<AppEnv>();
+
+// GET /workspaces/:id/export — one archive, streamed.
+exportRoutes.get("/workspaces/:id/export", async (c) => {
+  // No API-key refusal here, unlike creating a key or closing an account. Those
+  // are refused because a key must not be able to escalate or to destroy the
+  // evidence of its own misuse. This is a read, and a key that can reach
+  // /agents and /messages can already assemble the same file with a loop. What
+  // the endpoint adds is convenience, not reach, and refusing it would be a
+  // gate with a door beside it.
+  const db = c.get("db");
+  const user = c.get("user");
+  const workspaceId = c.req.param("id");
+
+  // Membership decides both whether this is allowed and what the manifest says
+  // the caller's view was. RLS would return empty rows for a stranger anyway;
+  // asking here means the answer is a 404 rather than an archive of nothing.
+  const { data: membership, error: membershipError } = await db
+    .from("workspace_members")
+    .select("role")
+    .eq("workspace_id", workspaceId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (membershipError) return c.json({ error: "failed to check the workspace" }, 500);
+  if (!membership) return c.json({ error: "not found" }, 404);
+
+  const { data: workspace, error: workspaceError } = await db
+    .from("workspaces")
+    .select("id,name,slug")
+    .eq("id", workspaceId)
+    .maybeSingle();
+
+  if (workspaceError) return c.json({ error: "failed to load the workspace" }, 500);
+  if (!workspace) return c.json({ error: "not found" }, 404);
+
+  // Collected before the response starts, on purpose. Every one of these reads
+  // can fail, and a failure here is still a status code — once the first byte
+  // of a zip is on the wire the only way to report a problem is to truncate the
+  // download, which looks exactly like a network drop.
+  let tables;
+  try {
+    tables = await collectWorkspace(db, workspaceId);
+  } catch (e) {
+    if (e instanceof ExportFailure) {
+      console.error("export: collection failed", e.table, e.reason);
+      return c.json({ error: `failed to read ${e.table}` }, 500);
+    }
+    console.error("export: collection failed", e);
+    return c.json({ error: "failed to build the export" }, 500);
+  }
+
+  // The documents are what streams: they are fetched one at a time inside the
+  // generator, so a workspace of two hundred files is never in memory at once.
+  const body = writeZip(
+    archiveEntries({
+      workspace: { id: String(workspace.id), name: String(workspace.name) },
+      exportedBy: { userId: user.id, role: String(membership.role) },
+      exportedAt: new Date().toISOString(),
+      tables,
+      store: getDocStore(c.env),
+    }),
+  );
+
+  const stamp = new Date().toISOString().slice(0, 10);
+  const filename = `covan-${String(workspace.slug || workspace.id)}-${stamp}.zip`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`,
+      // No length is known until the last document has been read, and guessing
+      // one would be worse than omitting it: a wrong Content-Length is a
+      // download that a browser reports as corrupt.
+      "Cache-Control": "no-store",
+    },
+  });
+});
+
+export { exportRoutes };

--- a/worker/src/test-support/fake-db.ts
+++ b/worker/src/test-support/fake-db.ts
@@ -38,6 +38,8 @@ export type QueryContext = {
   filters: Filter[];
   /** True when the caller ended the chain with `.single()`/`.maybeSingle()`. */
   single: boolean;
+  /** Set when the caller ended the chain with `.range(from, to)`, as paged reads do. */
+  range?: { from: number; to: number };
 };
 
 export type Handler = (ctx: QueryContext) => QueryResult | Promise<QueryResult>;
@@ -127,6 +129,15 @@ class Chain implements PromiseLike<QueryResult> {
 
   limit() {
     return this;
+  }
+
+  // A terminator, unlike order() and limit(). The export pages every read
+  // because PostgREST caps a response at a thousand rows and says nothing about
+  // it, so a fake that swallowed range() would let an unpaged read pass here
+  // and lose the thousand-and-first message in production.
+  range(from: number, to: number): Promise<QueryResult> {
+    this.ctx.range = { from, to };
+    return this.run(this.ctx);
   }
 
   maybeSingle(): Promise<QueryResult> {


### PR DESCRIPTION
The README has said since the first commit that a self-hosted Covan is the whole product and nothing is held hostage. That was true of the licence and of the database, and not true of the interface: the answer to "can I get our work out" was `pg_dump` — an answer for whoever runs the server, not for the team using their install.

`GET /workspaces/:id/export` returns one zip: `manifest.json`, a `workspace.sql` that replays every row in one transaction, `restore.sh`, `data/<table>.json`, and the original file of every document. Settings → **Take it with you**.

### No importer

Writing one would have been a second implementation of what Postgres already does — its own dependency, its own errors, its own trust. A `.sql` file needs `psql`, which anybody restoring a database has, and it can be **opened and read before it is run**, which is worth a great deal when the thing you are about to run touches a database you care about.

### It holds one person's view, and says so

Every read goes through the caller's own client, so an admin's file and a member's file are different files. The manifest states that rather than letting a filename imply the archive is the whole workspace. Where that leaves a dangling reference — an idea citing a message in somebody else's private session — the reference is dropped and counted in `droppedReferences` instead of failing the whole restore.

### Accounts do not travel

There is no id to carry between installs, and inventing users for people who did not ask to be recreated would be worse than saying plainly that everyone collapses to the one account named at restore time. Memberships collapse with them, to a single admin — five inserts of the same primary key would otherwise leave whichever role sorted first, which can hand the restorer a `member` row in their own workspace and lock them out of it.

### The ZIP is written by hand

Stored, no compression, ~150 lines. The alternative was a dependency in an otherwise dependency-light Worker, to save a few percent on the small half of an archive whose large half is already-compressed PDFs. It refuses past 4 GB or 65,535 entries rather than emitting one whose offsets have wrapped, and it is checked with `unzip -t` **and** Python's `zipfile` — two readers nobody here wrote, because what matters about this file is that it opens in software that has never heard of Covan.

### Three things the work turned up

- **`messages.sender_id` references `public.profiles`, not `auth.users`** — which is exactly why it survived a search for the latter. Profiles are not replayed, so leaving it alone would have dangled every message in every archive. Thinking through the round trip is what found it.
- **`EXPORTED` had `profiles` scoped by `workspace_members` and listed above it**, so the id list was read before it was collected: every export would have carried zero profiles and reported success. `tables.test.ts` walks `supabase/migrations` and fails both on a table in neither list and on an ordering that reads ahead of itself — it caught this.
- **`docs/api.md` still said a key cannot do "two things".** Closing an account made it three, in #51, and the page was never updated. Both endpoints are in the table now.

### Left out

Chunks. Derived, and a 1536-dimension vector each makes them the largest thing in the file by far. `POST /admin/backfill-embeddings` rebuilds them from the documents after a restore — with whatever embedding model the new install is configured for, which since #52 is a choice worth having. `manifest.json` carries the reason for every exclusion.

### Verification

636 worker tests, 324 frontend, typecheck and lint clean. **The round-trip test — export, destroy the workspace, replay the SQL as a different account, compare counts per table — has not run locally: Docker is not up on this machine. CI runs it.**

Closes #42