### PR TITLE
Put an age on a citation, and store the id that makes one possible

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -204,11 +204,31 @@ failing.
 
 ### Sources
 
-The document names that grounded a reply are written onto the message when it is
-saved, deduplicated and kept in relevance order, and shown as chips beneath the
-answer. Because they are stored rather than recomputed, they survive a reload and
-they are what actually went into that specific turn — not a fresh search run
-against whatever the bundles hold today.
+The documents that grounded a reply are written onto the message when it is
+saved — by id and by name, deduplicated and kept in relevance order — and shown
+as chips beneath the answer. Because they are stored rather than recomputed,
+they survive a reload and they are what actually went into that specific turn,
+not a fresh search run against whatever the bundles hold today.
+
+Each chip also carries the document's age, and warns past ninety days. That is
+there because retrieval working correctly is the whole problem: a process
+document written in January is still the best match for a January question in
+September, and the agent will quote it with the same confidence it quotes
+anything. The chip made the answer checkable and said which file; it could not
+say that the file is nine months old. An onboarding document written once and
+wrong a quarter later is exactly what teams upload first and exactly what nobody
+remembers to revisit.
+
+The age is the upload date, and for a document that is the whole of freshness:
+nothing updates one in place. A re-upload creates a new document, and
+**Reindex** re-embeds the same stored text. So there is no "last edited" to
+want — the January file is the January file.
+
+A chip with no date is not a fault. Replies written before ids were stored cite
+by name alone, and a name cannot be resolved back to a document without
+guessing; the same is true of a document that has since been deleted. Both keep
+their citation and say nothing about age, which is the honest half of the
+answer.
 
 Read them as what was in scope, not as what the model saw, because the two are
 not the same list. The names are collected from every match — and on the fallback

--- a/src/components/source-chip.test.tsx
+++ b/src/components/source-chip.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SourceChip } from "./source-chip";
+import { STALE_AFTER_DAYS } from "@/lib/relative-time";
+
+const daysAgo = (n: number) => Date.now() - n * 86_400_000;
+const chip = () => screen.getByTitle(/./);
+
+describe("a citation with a date", () => {
+  it("says how old the document is, not only which one it was", () => {
+    // The whole complaint: retrieval is working as designed when a January
+    // process document is the best match for a January question in September.
+    // Nothing else in the interface was in a position to mention the nine
+    // months.
+    render(<SourceChip source={{ id: "d1", name: "onboarding.md" }} uploadedAt={daysAgo(12)} />);
+
+    expect(screen.getByText("onboarding.md")).toBeInTheDocument();
+    expect(screen.getByText("12 days ago")).toBeInTheDocument();
+  });
+
+  it("puts both in the tooltip, where a truncated name is readable again", () => {
+    render(
+      <SourceChip source={{ id: "d1", name: "a-very-long-name.md" }} uploadedAt={daysAgo(3)} />,
+    );
+    expect(chip()).toHaveAttribute("title", "a-very-long-name.md — uploaded 3 days ago");
+  });
+});
+
+describe("a citation old enough to be worth checking", () => {
+  it("warns past the threshold", () => {
+    render(<SourceChip source={{ id: "d1", name: "process.md" }} uploadedAt={daysAgo(200)} />);
+
+    expect(screen.getByText("6 months ago")).toBeInTheDocument();
+    expect(chip().className).toContain("amber");
+  });
+
+  it("does not warn a day early", () => {
+    render(
+      <SourceChip
+        source={{ id: "d1", name: "process.md" }}
+        uploadedAt={daysAgo(STALE_AFTER_DAYS - 1)}
+      />,
+    );
+    expect(chip().className).not.toContain("amber");
+  });
+
+  it("says it in words as well as in colour", () => {
+    // Colour alone reaches neither a screen reader nor somebody who cannot tell
+    // amber from grey, and a warning nobody perceives is not a warning.
+    render(<SourceChip source={{ id: "d1", name: "process.md" }} uploadedAt={daysAgo(200)} />);
+    expect(screen.getByText(/older than 90 days; check it is still current/)).toBeInTheDocument();
+  });
+});
+
+describe("a citation with no date to give", () => {
+  it("still renders, for a reply written before ids were stored", () => {
+    // The column held bare names then, and a name cannot be resolved back to a
+    // document without guessing. The citation survives; the age does not.
+    render(<SourceChip source={{ id: null, name: "old-answer.md" }} />);
+
+    expect(screen.getByText("old-answer.md")).toBeInTheDocument();
+    expect(chip()).toHaveAttribute("title", "old-answer.md");
+    expect(screen.queryByText(/ago/)).not.toBeInTheDocument();
+  });
+
+  it("stays quiet for a document that has since been deleted", () => {
+    // It has an id, but nothing on this screen knows the id any more.
+    render(<SourceChip source={{ id: "gone", name: "deleted.md" }} />);
+
+    expect(screen.getByText("deleted.md")).toBeInTheDocument();
+    expect(chip().className).not.toContain("amber");
+  });
+
+  it("never guesses an age from a missing date", () => {
+    // The failure worth naming: `uploadedAt` defaulting to 0 would render epoch
+    // 1970 as "55 years ago" and paint every old citation as a warning.
+    render(<SourceChip source={{ id: null, name: "x.md" }} />);
+    expect(screen.queryByText(/years ago/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/source-chip.tsx
+++ b/src/components/source-chip.tsx
@@ -1,0 +1,64 @@
+import { FileText, TriangleAlert } from "lucide-react";
+import { documentAge, STALE_AFTER_DAYS } from "@/lib/relative-time";
+import { cn } from "@/lib/utils";
+
+/**
+ * One document under an answer, with its age.
+ *
+ * The chip has always made an answer checkable — that is what a citation is for
+ * — but it said which file and not how old it is, and those are different
+ * questions. Retrieval is working as designed when a process document written
+ * in January comes back as the best match for a January question in September:
+ * it *is* the best match. Nothing else in the interface was in a position to
+ * mention that the answer is nine months old.
+ *
+ * The date is when the document was uploaded, and for a document that is the
+ * whole of freshness — nothing updates one in place, so a file uploaded in
+ * January is exactly the January file today.
+ *
+ * A chip with no date is not a bug. Replies written before ids were stored cite
+ * by name alone, and a name cannot be resolved back to a document without
+ * guessing; so can a document that has since been deleted. Both keep their
+ * citation and say nothing about age, which is the honest half.
+ */
+export function SourceChip({
+  source,
+  uploadedAt,
+}: {
+  source: { id: string | null; name: string };
+  uploadedAt?: number;
+}) {
+  const age = uploadedAt === undefined ? null : documentAge(uploadedAt);
+
+  return (
+    <span
+      title={age ? `${source.name} — uploaded ${age.label}` : source.name}
+      className={cn(
+        "inline-flex max-w-[260px] items-center gap-1.5 rounded-md border px-2 py-1 text-[11px]",
+        age?.stale
+          ? "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+          : "border-hairline bg-popover text-muted-foreground",
+      )}
+    >
+      {age?.stale ? (
+        <TriangleAlert className="h-3 w-3 shrink-0" aria-hidden />
+      ) : (
+        <FileText className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden />
+      )}
+      <span className="truncate">{source.name}</span>
+      {age && (
+        <span className={cn("shrink-0", age.stale ? "font-medium" : "opacity-70")}>
+          {age.label}
+        </span>
+      )}
+      {age?.stale && (
+        // Said in words as well as in colour. The whole point is a reader
+        // noticing, and colour alone reaches neither a screen reader nor
+        // somebody who cannot tell amber from grey.
+        <span className="sr-only">
+          — older than {STALE_AFTER_DAYS} days; check it is still current
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/lib/agents-store.tsx
+++ b/src/lib/agents-store.tsx
@@ -12,7 +12,15 @@ export type Agent = {
   model: string;
   persona: string;
   mode: "normal" | "brainstorm";
-  documents: { id: string; name: string; size: number; chunkCount: number; indexed: boolean }[];
+  documents: {
+    id: string;
+    name: string;
+    size: number;
+    /** When it was uploaded, which for a document is the whole of its freshness. */
+    createdAt: number;
+    chunkCount: number;
+    indexed: boolean;
+  }[];
   bundleIds: string[];
   createdAt: number;
 };
@@ -22,9 +30,16 @@ export type Message = {
   role: "user" | "assistant";
   content: string;
   createdAt: number;
-  // Names of the documents that grounded an assistant reply (real RAG
-  // citations). Absent/empty when the reply used no retrieved knowledge.
-  sources?: string[];
+  /**
+   * The documents that grounded an assistant reply — real citations, absent or
+   * empty when the reply used no retrieved knowledge.
+   *
+   * `id` is null on every reply written before ids were stored: the column held
+   * bare names then, and a name cannot be resolved back to a document without
+   * guessing. Those citations still render, they just cannot say how old the
+   * document was.
+   */
+  sources?: { id: string | null; name: string }[];
   // In a shared session, the human author of a user message. Absent for
   // assistant messages and for one's own optimistic messages before refetch.
   sender?: { id: string; name: string | null; avatarUrl: string | null };

--- a/src/lib/relative-time.test.ts
+++ b/src/lib/relative-time.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatRelative } from "./relative-time";
+import { formatRelative, documentAge, STALE_AFTER_DAYS } from "./relative-time";
 
 const NOW = Date.UTC(2026, 7, 16, 12, 0, 0);
 
@@ -17,5 +17,40 @@ describe("formatRelative", () => {
   it("collapses anything under a minute rather than counting seconds at the user", () => {
     expect(formatRelative(NOW + 5_000, NOW)).toBe("now");
     expect(formatRelative(NOW - 5_000, NOW)).toBe("now");
+  });
+});
+
+describe("documentAge", () => {
+  const NOW = Date.parse("2026-09-01T12:00:00Z");
+  const daysAgo = (n: number) => NOW - n * 86_400_000;
+
+  it("says today for anything inside a day", () => {
+    expect(documentAge(NOW, NOW).label).toBe("today");
+    expect(documentAge(NOW - 3_600_000, NOW).label).toBe("today");
+  });
+
+  it("counts days, then months, then years", () => {
+    expect(documentAge(daysAgo(12), NOW).label).toBe("12 days ago");
+    expect(documentAge(daysAgo(95), NOW).label).toBe("3 months ago");
+    expect(documentAge(daysAgo(400), NOW).label).toBe("1 year ago");
+  });
+
+  it("rounds down, so it never claims more age than there is", () => {
+    // Overstating raises a false alarm; understating hides a real staleness.
+    // Between the two, the number is the one that must not exaggerate — the
+    // threshold below is what is allowed to be strict.
+    expect(documentAge(daysAgo(59), NOW).label).toBe("1 month ago");
+    expect(documentAge(daysAgo(364), NOW).label).toBe("12 months ago");
+  });
+
+  it("turns stale at ninety days, not before", () => {
+    expect(documentAge(daysAgo(89), NOW).stale).toBe(false);
+    expect(documentAge(daysAgo(STALE_AFTER_DAYS), NOW).stale).toBe(true);
+  });
+
+  it("treats a future date as today rather than as negative age", () => {
+    // Clock skew between a browser and Postgres is real, and "in 2 hours ago"
+    // is not a thing to render.
+    expect(documentAge(NOW + 7_200_000, NOW)).toEqual({ label: "today", stale: false });
   });
 });

--- a/src/lib/relative-time.ts
+++ b/src/lib/relative-time.ts
@@ -19,3 +19,44 @@ export function formatRelative(epochMs: number, now: number = Date.now()): strin
   if (abs < DAY) return rtf.format(Math.round(diff / HOUR), "hour");
   return rtf.format(Math.round(diff / DAY), "day");
 }
+
+/**
+ * How old a document is allowed to get before the interface says so.
+ *
+ * Ninety days because that is the interval the failure actually turns on: an
+ * onboarding document written once and wrong three months later is the thing
+ * teams upload first and nobody remembers to revisit. Longer and the warning
+ * arrives after the damage; much shorter and every chip in a working workspace
+ * is a warning, which is the same as none.
+ */
+export const STALE_AFTER_DAYS = 90;
+
+export type DocumentAge = {
+  /** "today", "12 days ago", "7 months ago". */
+  label: string;
+  stale: boolean;
+};
+
+/**
+ * The age of an uploaded document, in the coarsest unit that is still true.
+ *
+ * Separate from `formatRelative` above, which stops at days because it serves a
+ * routine's next run — "in 3 days" is what you want there and "247 days ago" is
+ * not what you want here. Months and years are how people hold the age of a
+ * document.
+ *
+ * Rounded **down**, always. Overstating an age raises a false alarm; understating
+ * one hides a real staleness, and between the two the second is the failure this
+ * exists to prevent — so the number never claims more age than there is, and the
+ * threshold is crossed only once it genuinely has been.
+ */
+export function documentAge(uploadedAt: number, now: number = Date.now()): DocumentAge {
+  const days = Math.floor(Math.max(0, now - uploadedAt) / DAY);
+  const stale = days >= STALE_AFTER_DAYS;
+
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "always" });
+  if (days < 1) return { label: "today", stale };
+  if (days < 30) return { label: rtf.format(-days, "day"), stale };
+  if (days < 365) return { label: rtf.format(-Math.floor(days / 30), "month"), stale };
+  return { label: rtf.format(-Math.floor(days / 365), "year"), stale };
+}

--- a/src/routes/_authed.agents.$agentId.chat.tsx
+++ b/src/routes/_authed.agents.$agentId.chat.tsx
@@ -31,6 +31,7 @@ import { appendDictation, useDictation } from "@/lib/use-dictation";
 import { useChatUploads } from "@/lib/use-chat-uploads";
 import { useQuota, quotaSentence } from "@/lib/quota";
 import { startersFor } from "@/lib/chat-starters";
+import { SourceChip } from "@/components/source-chip";
 
 export const Route = createFileRoute("/_authed/agents/$agentId/chat")({
   component: ChatTab,
@@ -59,6 +60,15 @@ function ChatTab() {
   // Named after a real file once one is indexed, so the first tap on a fresh
   // agent returns an answer with a citation on it rather than a general one.
   const starters = useMemo(() => startersFor(agent.documents), [agent.documents]);
+
+  // Citations carry a document id; the age lives on the agent's document list,
+  // which this screen already has. Resolved by id rather than by name on
+  // purpose — two documents can share a name, and a chip that dated an answer
+  // from the wrong file would be worse than one that says nothing.
+  const uploadedAt = useMemo(
+    () => new Map(agent.documents.map((d) => [d.id, d.createdAt])),
+    [agent.documents],
+  );
 
   // Only the hosted service meters anything; self-hosted installs answer with
   // `limit: null` and nothing below renders. Refetched by the invalidation that
@@ -707,15 +717,12 @@ function ChatTab() {
                       {sources.length > 0 && (
                         <div className="mt-3 flex flex-wrap items-center gap-1.5">
                           <span className="text-xs text-muted-foreground">Sources</span>
-                          {sources.map((name) => (
-                            <span
-                              key={name}
-                              title={name}
-                              className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-hairline bg-popover px-2 py-1 text-[11px] text-muted-foreground"
-                            >
-                              <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />
-                              <span className="truncate">{name}</span>
-                            </span>
+                          {sources.map((source, i) => (
+                            <SourceChip
+                              key={source.id ?? `${source.name}:${i}`}
+                              source={source}
+                              uploadedAt={source.id ? uploadedAt.get(source.id) : undefined}
+                            />
                           ))}
                         </div>
                       )}

--- a/worker/src/lib/dto.test.ts
+++ b/worker/src/lib/dto.test.ts
@@ -3,40 +3,94 @@ import { mapDocument, mapMessage, mapAgent, mapChatSession, mapIdea, mapRoutine 
 
 describe("mapDocument", () => {
   it("marks a document indexed when it has embedded chunks", () => {
-    const d = mapDocument({ id: "d1", name: "a.md", size: 20, document_chunks: [{ count: 3 }] });
+    const d = mapDocument({
+      id: "d1",
+      name: "a.md",
+      size: 20,
+      created_at: "2026-01-05T00:00:00Z",
+      document_chunks: [{ count: 3 }],
+    });
     expect(d).toMatchObject({ id: "d1", name: "a.md", size: 20, chunkCount: 3, indexed: true });
   });
 
   it("marks a document not indexed when it has zero chunks", () => {
     expect(
-      mapDocument({ id: "d2", name: "b.md", size: 5, document_chunks: [{ count: 0 }] }),
+      mapDocument({
+        id: "d2",
+        name: "b.md",
+        size: 5,
+        created_at: "2026-01-05T00:00:00Z",
+        document_chunks: [{ count: 0 }],
+      }),
     ).toMatchObject({ chunkCount: 0, indexed: false });
-    expect(mapDocument({ id: "d3", name: "c.md", size: 5, document_chunks: [] })).toMatchObject({
+    expect(
+      mapDocument({
+        id: "d3",
+        name: "c.md",
+        size: 5,
+        created_at: "2026-01-05T00:00:00Z",
+        document_chunks: [],
+      }),
+    ).toMatchObject({
       chunkCount: 0,
       indexed: false,
     });
-    expect(mapDocument({ id: "d4", name: "d.md", size: 5 })).toMatchObject({
+    expect(
+      mapDocument({ id: "d4", name: "d.md", size: 5, created_at: "2026-01-05T00:00:00Z" }),
+    ).toMatchObject({
       chunkCount: 0,
       indexed: false,
     });
   });
 
   it("defaults a null size to 0", () => {
-    expect(mapDocument({ id: "d5", name: "e.md", size: null }).size).toBe(0);
+    expect(
+      mapDocument({ id: "d5", name: "e.md", size: null, created_at: "2026-01-05T00:00:00Z" }).size,
+    ).toBe(0);
   });
 });
 
 describe("mapMessage", () => {
   const base = { id: "m1", role: "assistant", content: "hi", created_at: "2026-01-01T00:00:00Z" };
 
-  it("surfaces a string[] sources array", () => {
-    expect(mapMessage({ ...base, sources: ["a.md", "b.md"] }).sources).toEqual(["a.md", "b.md"]);
+  it("reads the ids stored with a source", () => {
+    expect(
+      mapMessage({
+        ...base,
+        sources: [
+          { id: "d1", name: "a.md" },
+          { id: "d2", name: "b.md" },
+        ],
+      }).sources,
+    ).toEqual([
+      { id: "d1", name: "a.md" },
+      { id: "d2", name: "b.md" },
+    ]);
   });
 
-  it("drops non-string entries and yields undefined when absent", () => {
-    expect(mapMessage({ ...base, sources: ["a.md", 3, null] }).sources).toEqual(["a.md"]);
+  it("still reads the bare names written before ids were stored", () => {
+    // The column is jsonb and holds both shapes forever: every reply given
+    // before `routes/chat.ts` started keeping `document_id` is a list of
+    // strings. Those answers keep their citations and simply cannot say how old
+    // the document was — which beats guessing by matching on a name.
+    expect(mapMessage({ ...base, sources: ["a.md", "b.md"] }).sources).toEqual([
+      { id: null, name: "a.md" },
+      { id: null, name: "b.md" },
+    ]);
+  });
+
+  it("drops entries that are neither, and yields undefined when absent", () => {
+    expect(mapMessage({ ...base, sources: ["a.md", 3, null, {}, { id: "d" }] }).sources).toEqual([
+      { id: null, name: "a.md" },
+    ]);
     expect(mapMessage({ ...base }).sources).toBeUndefined();
     expect(mapMessage({ ...base, sources: "nope" }).sources).toBeUndefined();
+  });
+
+  it("keeps a name whose id is not a string, rather than losing the citation", () => {
+    expect(mapMessage({ ...base, sources: [{ id: 7, name: "a.md" }] }).sources).toEqual([
+      { id: null, name: "a.md" },
+    ]);
   });
 });
 
@@ -53,21 +107,38 @@ describe("mapAgent", () => {
         {
           bundle_id: "b1",
           knowledge_bundles: {
-            documents: [{ id: "d1", name: "x.md", size: 10, document_chunks: [{ count: 2 }] }],
+            documents: [
+              {
+                id: "d1",
+                name: "x.md",
+                size: 10,
+                created_at: "2026-01-05T00:00:00Z",
+                document_chunks: [{ count: 2 }],
+              },
+            ],
           },
         },
         {
           bundle_id: "b2",
           knowledge_bundles: {
-            documents: [{ id: "d2", name: "y.md", size: null, document_chunks: [] }],
+            documents: [
+              {
+                id: "d2",
+                name: "y.md",
+                size: null,
+                created_at: "2026-01-05T00:00:00Z",
+                document_chunks: [],
+              },
+            ],
           },
         },
       ],
     });
     expect(agent.bundleIds).toEqual(["b1", "b2"]);
+    const uploaded = Date.parse("2026-01-05T00:00:00Z");
     expect(agent.documents).toEqual([
-      { id: "d1", name: "x.md", size: 10, chunkCount: 2, indexed: true },
-      { id: "d2", name: "y.md", size: 0, chunkCount: 0, indexed: false },
+      { id: "d1", name: "x.md", size: 10, createdAt: uploaded, chunkCount: 2, indexed: true },
+      { id: "d2", name: "y.md", size: 0, createdAt: uploaded, chunkCount: 0, indexed: false },
     ]);
   });
 

--- a/worker/src/lib/dto.ts
+++ b/worker/src/lib/dto.ts
@@ -7,6 +7,16 @@ export type DocumentDTO = {
   id: string;
   name: string;
   size: number;
+  /**
+   * When it was uploaded — and, for a document, the whole of what "how fresh is
+   * this" can mean. Nothing updates a document in place: a re-upload creates a
+   * new row, and `POST /documents/:id/reindex` re-embeds the same stored text.
+   * So there is no `updated_at` to want, and this date is not a proxy for
+   * freshness, it is freshness. An onboarding file uploaded in January is
+   * exactly the January file in September, which is why the chat screen puts
+   * this under an answer.
+   */
+  createdAt: number;
   // How many embedded chunks back this document. `indexed` is false when the
   // count is 0 — the document exists but isn't retrievable yet (embedding
   // pending or failed), which the UI surfaces with a reindex action.
@@ -26,12 +36,26 @@ export type AgentDTO = {
   createdAt: number;
 };
 
+/**
+ * One document that grounded an answer.
+ *
+ * `id` is null for every reply written before the id was stored. The column
+ * held bare display names until then — which is not a link: two documents can
+ * share a name, a rename detaches the history, and a delete leaves a string
+ * pointing at nothing. `match_chunks` has returned `document_id` since 0005 and
+ * `routes/chat.ts` was throwing it away.
+ *
+ * Old rows keep working and simply cannot say how old their sources are, which
+ * is the honest answer rather than a guess made by matching on a name.
+ */
+export type SourceDTO = { id: string | null; name: string };
+
 export type MessageDTO = {
   id: string;
   role: "user" | "assistant";
   content: string;
   createdAt: number;
-  sources?: string[];
+  sources?: SourceDTO[];
   sender?: { id: string; name: string | null; avatarUrl: string | null };
 };
 
@@ -128,6 +152,10 @@ export function mapDocument(row: {
   id: string;
   name: string;
   size: number | null;
+  // Required, not optional: every caller has to fetch it, and a `?? 0` fallback
+  // would render a missing date as 1970 — "55 years ago" under an answer, which
+  // is worse than the bare filename this replaces.
+  created_at: string;
   document_chunks?: Array<{ count: number }> | null;
 }): DocumentDTO {
   const chunkCount = row.document_chunks?.[0]?.count ?? 0;
@@ -135,6 +163,7 @@ export function mapDocument(row: {
     id: row.id,
     name: row.name,
     size: row.size ?? 0,
+    createdAt: toEpochMs(row.created_at),
     chunkCount,
     indexed: chunkCount > 0,
   };
@@ -155,6 +184,7 @@ export function mapAgent(row: {
         id: string;
         name: string;
         size: number | null;
+        created_at: string;
         document_chunks?: Array<{ count: number }> | null;
       }> | null;
     } | null;
@@ -182,6 +212,23 @@ function firstEmbedded<T>(value: unknown): T | null {
   return null;
 }
 
+/**
+ * Reads either shape out of `messages.sources`, which is jsonb and therefore
+ * holds both: bare strings from before ids were stored, `{id, name}` since.
+ */
+function mapSource(value: unknown): SourceDTO | null {
+  if (typeof value === "string") return value ? { id: null, name: value } : null;
+  if (value && typeof value === "object") {
+    const row = value as { id?: unknown; name?: unknown };
+    if (typeof row.name === "string" && row.name) {
+      return { id: typeof row.id === "string" ? row.id : null, name: row.name };
+    }
+  }
+  return null;
+}
+
+const isSource = (s: SourceDTO | null): s is SourceDTO => s !== null;
+
 export function mapMessage(row: {
   id: string;
   role: string;
@@ -199,9 +246,7 @@ export function mapMessage(row: {
     role: row.role === "assistant" ? "assistant" : "user",
     content: row.content,
     createdAt: toEpochMs(row.created_at),
-    sources: Array.isArray(row.sources)
-      ? row.sources.filter((s): s is string => typeof s === "string")
-      : undefined,
+    sources: Array.isArray(row.sources) ? row.sources.map(mapSource).filter(isSource) : undefined,
     sender: sender ? { id: sender.id, name: sender.name, avatarUrl: sender.avatar_url } : undefined,
   };
 }

--- a/worker/src/routes/agents.ts
+++ b/worker/src/routes/agents.ts
@@ -7,7 +7,7 @@ import { getActiveWorkspaceId } from "../lib/workspace";
 const agents = new Hono<AppEnv>();
 
 const AGENT_SELECT =
-  "*, agent_bundles(bundle_id, knowledge_bundles(documents(id,name,size,document_chunks(count))))";
+  "*, agent_bundles(bundle_id, knowledge_bundles(documents(id,name,size,created_at,document_chunks(count))))";
 
 const createAgentSchema = z.object({
   name: z.string().min(1),

--- a/worker/src/routes/bundles.ts
+++ b/worker/src/routes/bundles.ts
@@ -207,7 +207,7 @@ bundles.post("/bundles/:id/documents/upload", async (c) => {
   const { data: doc, error } = await db
     .from("documents")
     .insert({ bundle_id: bundleId, name: file.name, size: file.size, r2_key: r2Key, content })
-    .select("id,name,size")
+    .select("id,name,size,created_at")
     .single();
   if (error || !doc) {
     try {

--- a/worker/src/routes/chat.ts
+++ b/worker/src/routes/chat.ts
@@ -103,7 +103,23 @@ chat.post("/chat/stream", async (c) => {
 
   // Documents that actually grounded this reply, deduped in relevance order.
   // Persisted with the assistant message so the UI can show real citations.
-  const sourceNames: string[] = [];
+  /**
+   * The documents that grounded this reply, by id as well as by name.
+   *
+   * Names alone were what the column held until now, and a name is not a link:
+   * two documents can share one, a rename detaches every answer that cited it,
+   * and a delete leaves a string pointing at nothing. `match_chunks` has
+   * returned `document_id` since 0005 and this route was discarding it — so the
+   * chat screen could say which file an answer came from and never how old it
+   * was. Keyed by id here so a document retrieved through two chunks is cited
+   * once.
+   */
+  const sources = new Map<string, { id: string | null; name: string }>();
+  const addSource = (id: string | null, name: string) => {
+    if (!name) return;
+    const key = id ?? `name:${name}`;
+    if (!sources.has(key)) sources.set(key, { id, name });
+  };
   // Retrieved knowledge for this turn. Kept OUT of the persona/system prefix and
   // the persisted history so that prefix stays byte-identical across turns and
   // OpenAI's automatic prompt cache can discount the bulk of the input.
@@ -161,16 +177,16 @@ chat.post("/chat/stream", async (c) => {
         if (matchError) {
           console.error("match_chunks failed", matchError);
         } else if (matches && matches.length > 0) {
-          const typed = matches as Array<{ document_name: string; content: string }>;
+          const typed = matches as Array<{
+            document_id: string;
+            document_name: string;
+            content: string;
+          }>;
           ragBlock = buildContextBlock(
             typed.map((m) => ({ documentName: m.document_name, content: m.content })),
           );
           if (ragBlock) {
-            for (const m of typed) {
-              if (m.document_name && !sourceNames.includes(m.document_name)) {
-                sourceNames.push(m.document_name);
-              }
-            }
+            for (const m of typed) addSource(m.document_id ?? null, m.document_name);
           }
         }
       }
@@ -187,12 +203,12 @@ chat.post("/chat/stream", async (c) => {
   if (!ragBlock && hasKnowledge) {
     const { data: docRows, error: docError } = await db
       .from("documents")
-      .select("name,content")
+      .select("id,name,content")
       .in("bundle_id", bundleIds)
       .order("created_at", { ascending: false });
     const withContent = docError
       ? []
-      : ((docRows ?? []) as Array<{ name: string; content: string | null }>).filter(
+      : ((docRows ?? []) as Array<{ id: string; name: string; content: string | null }>).filter(
           (d) => d.content && d.content.trim().length > 0,
         );
     if (withContent.length > 0) {
@@ -200,9 +216,7 @@ chat.post("/chat/stream", async (c) => {
         withContent.map((d) => ({ documentName: d.name, content: d.content as string })),
       );
       if (ragBlock) {
-        for (const d of withContent) {
-          if (!sourceNames.includes(d.name)) sourceNames.push(d.name);
-        }
+        for (const d of withContent) addSource(d.id ?? null, d.name);
       }
     }
   }
@@ -297,7 +311,7 @@ chat.post("/chat/stream", async (c) => {
             role: "assistant",
             content: text,
             sender_id: null,
-            sources: sourceNames.length > 0 ? sourceNames : null,
+            sources: sources.size > 0 ? [...sources.values()] : null,
             prompt_tokens: opts.promptTokens,
             completion_tokens: opts.completionTokens,
             cached_tokens: opts.cachedTokens,

--- a/worker/src/routes/documents.ts
+++ b/worker/src/routes/documents.ts
@@ -83,7 +83,7 @@ documents.patch("/documents/:id", async (c) => {
 
   const { data: doc, error: docErr } = await db
     .from("documents")
-    .select("id,name,size,bundle_id,knowledge_bundles(workspace_id)")
+    .select("id,name,size,created_at,bundle_id,knowledge_bundles(workspace_id)")
     .eq("id", id)
     .maybeSingle();
   if (docErr) return c.json({ error: "failed to load document" }, 500);
@@ -140,7 +140,7 @@ documents.patch("/documents/:id", async (c) => {
     .from("documents")
     .update({ bundle_id: bundleId })
     .eq("id", id)
-    .select("id,name,size,document_chunks(count)")
+    .select("id,name,size,created_at,document_chunks(count)")
     .single();
   if (upErr || !updated) {
     // Put the passages back where the document still is.
@@ -204,7 +204,7 @@ documents.post("/documents/:id/reindex", async (c) => {
 
   const { data: doc, error } = await db
     .from("documents")
-    .select("id,name,size,bundle_id,r2_key,content,knowledge_bundles(workspace_id)")
+    .select("id,name,size,created_at,bundle_id,r2_key,content,knowledge_bundles(workspace_id)")
     .eq("id", id)
     .maybeSingle();
   if (error) return c.json({ error: "failed to load document" }, 500);


### PR DESCRIPTION
Retrieval working exactly as designed is the failure. A process document written in January is still the best match for a January question in September, so the agent quotes it with the confidence it quotes anything and puts a source chip underneath. The chip made the answer checkable and said *which* file — never how old it is.

Chips now carry the document's age and warn past ninety days.

### Two of #43's premises did not hold

**`documents` has no `updated_at`.** Only `created_at` — and there is no way to update a document in place either: a re-upload creates a new row, and Reindex re-embeds the same stored text. So there is no "last edited" to add, and the upload date is not a proxy for freshness, it **is** freshness. The January file is the January file.

**`messages.sources` stored names, not ids.** `match_chunks` has returned `document_id` since 0005 and `routes/chat.ts` was discarding it. A display name is not a link — two documents can share one, a rename detaches every answer that cited it, a delete leaves a string pointing at nothing — so there was nothing to resolve an age from, and "the link is already stored" was not true.

The column is jsonb, so both shapes live there now and `mapMessage` reads either. Replies written before today keep their citations and simply cannot say how old their sources were, which beats guessing by matching on a name.

### Details worth the review

- `documentAge` sits beside `formatRelative` rather than replacing it: "in 3 days" is right for a routine's next run, "247 days ago" is not right for a document. It rounds **down**, always — the number never claims more age than there is, and the threshold is crossed only once it genuinely has been.
- Ninety days because that is the interval the failure turns on. Longer and the warning arrives after the damage; much shorter and every chip in a working workspace is a warning, which is the same as none.
- The warning is said in words as well as colour. Colour alone reaches neither a screen reader nor somebody who cannot tell amber from grey.
- `mapDocument` now **requires** `created_at` rather than defaulting it. A `?? 0` would render a missing date as 1970 — "55 years ago" under an answer, worse than the bare filename this replaces — and requiring it makes tsc name every select that has to fetch it.

### Half of #43, deliberately

The second half — a list of documents ordered by how many answers they ground against how long they have gone unrefreshed — **waits on this one**, because the ids it would count do not exist until this ships. Building both today would produce a screen that is empty on day one and misleading for weeks. Filed as the remainder of #43 rather than closed.

337 frontend tests, 645 worker, typecheck and lint clean.

Part of #43