### PR TITLE
Let a conversation go with the room it was had in

### DIFF
--- a/supabase/migrations/0035_a_conversation_goes_with_the_room.sql
+++ b/supabase/migrations/0035_a_conversation_goes_with_the_room.sql
@@ -1,0 +1,57 @@
+-- 0035_a_conversation_goes_with_the_room.sql
+--
+-- `delete from workspaces` failed on any workspace anybody had ever used, and
+-- three separate places carried the same paragraph explaining how to get past
+-- it.
+--
+-- Every foreign key pointing at `workspaces` cascades — `agents`, `api_keys`,
+-- `document_chunks`, `invitations`, `knowledge_bundles`, `routines`,
+-- `workspace_members` — except three. Two of those three are decisions, and
+-- both are written down: `delivery_channels.workspace_id` is `set null`
+-- because a channel belongs to a PERSON rather than to a room (0019), and
+-- `profiles.active_workspace_id` is `set null` because the state that leaves
+-- behind is the one a fresh account is already in.
+--
+-- The other two were never decided. `chat_sessions.workspace_id` arrived in
+-- 0008 and `ideas.workspace_id` in 0011, both after the original schema, both
+-- written as a plain `references public.workspaces (id)` with no delete rule.
+-- Nobody chose NO ACTION for them; NO ACTION is what you get when you do not
+-- say. And because the failure only shows up when a workspace is deleted —
+-- which nothing in the product did until account closure — the accident had
+-- years to look like the schema.
+--
+-- What it cost is the giveaway. Not a bug anybody hit, but the same paragraph
+-- copied into three places: `worker/src/routes/account.ts` clearing both
+-- tables before deleting each empty workspace, `tests/rls/export-roundtrip.
+-- test.ts` doing the same to make room for a restore, and `docs/team.md`
+-- documenting it as the operator's procedure. Three copies of one rule is how
+-- a rule goes stale.
+--
+-- Cascade rather than `set null`, because unlike a delivery channel neither
+-- row means anything without its workspace. A session is already reachable
+-- only through an agent and agents cascade; an idea belongs to a session. The
+-- column was refusing a relationship the rest of the schema already had.
+--
+-- `chat_sessions.workspace_id` stays nullable and `ideas.workspace_id` stays
+-- `not null`; this changes what happens on delete and nothing else.
+--
+-- **For whoever removes the three workarounds:** they are safe either way, but
+-- not in any order. Clearing the two tables first still does exactly what it
+-- did — the rows go, and then the workspace goes. What changes is that the
+-- delete now succeeds without them. Since migrations reach this schema's
+-- production by hand, apply this file there BEFORE merging the removal, or the
+-- route runs against a database that still refuses.
+
+alter table public.chat_sessions
+  drop constraint if exists chat_sessions_workspace_id_fkey;
+
+alter table public.chat_sessions
+  add constraint chat_sessions_workspace_id_fkey
+  foreign key (workspace_id) references public.workspaces (id) on delete cascade;
+
+alter table public.ideas
+  drop constraint if exists ideas_workspace_id_fkey;
+
+alter table public.ideas
+  add constraint ideas_workspace_id_fkey
+  foreign key (workspace_id) references public.workspaces (id) on delete cascade;

--- a/tests/rls/deletion.test.ts
+++ b/tests/rls/deletion.test.ts
@@ -69,6 +69,32 @@ describe("deleting a workspace", () => {
     expect(Number(users)).toBe(1);
   });
 
+  it("takes the conversation and the idea that used to hold it open", async () => {
+    // The two deletes the test above still performs are the subject of this
+    // one. Before 0035, `chat_sessions.workspace_id` and `ideas.workspace_id`
+    // were plain references with no delete rule, so NO ACTION refused the
+    // workspace while a single row named it — and four places carried the same
+    // procedure for getting past that: the test above, `routes/account.ts`,
+    // `export-roundtrip.test.ts`, and `docs/team.md`.
+    //
+    // So: a workspace with a conversation and an idea still in it, deleted
+    // with nothing cleared first. This is the assertion the workarounds exist
+    // in place of, which is why it is worth having before they go.
+    const gwen = await createTestUser("gwen");
+    const seeded = await seedWorkspace(gwen);
+    const db = sql();
+
+    await db`delete from public.workspaces where id = ${gwen.workspaceId}`;
+
+    const [{ count: sessions }] = await db<{ count: string }[]>`
+      select count(*) from public.chat_sessions where id = ${seeded.sessionId}`;
+    expect(Number(sessions)).toBe(0);
+
+    const [{ count: ideas }] = await db<{ count: string }[]>`
+      select count(*) from public.ideas where id = ${seeded.ideaId}`;
+    expect(Number(ideas)).toBe(0);
+  });
+
   it("still refuses to leave a surviving workspace without an admin", async () => {
     // The guard, doing its job. Bob is the only admin of his own workspace, and
     // that workspace is not going anywhere.


### PR DESCRIPTION
Refs #55. The migration and the proof; the workaround removal is deliberately not in here — see below.

## What was wrong

`chat_sessions.workspace_id` and `ideas.workspace_id` were the only two references to `workspaces` with no delete rule. Every other one cascades, and the two exceptions that are not cascades are decisions with reasons written down — `delivery_channels.workspace_id` is `set null` because a channel belongs to a person (`0019`), `profiles.active_workspace_id` because the state it leaves is the one a fresh account is in.

These two were never decided. Both columns arrived after the original schema (`0008`, `0011`) written as a plain `references public.workspaces (id)`, and NO ACTION is what you get when you do not say. Because nothing in the product deleted a workspace until account closure, the accident had years to look like the schema.

## What it actually cost

Not a bug anybody hit — the same paragraph copied into **four** places. The issue counted three and said it was worth doing "before a fourth place needs the same paragraph"; the fourth was already there, at the top of `tests/rls/deletion.test.ts`.

- `worker/src/routes/account.ts` — clears both tables before deleting each empty workspace
- `tests/rls/export-roundtrip.test.ts` — same, to make room for a restore
- `docs/team.md` — documents it as the operator's procedure
- `tests/rls/deletion.test.ts` — same, in the first test

## The proof

Measured against the docker stack **before** applying, which is the point of adding the test in the same commit:

```
PostgresError: update or delete on table "workspaces" violates foreign key
constraint "chat_sessions_workspace_id_fkey" on table "chat_sessions"
```

After applying: both constraints report `c`, and all 95 RLS tests pass.

## Why the workarounds are still here

They are safe either way but not in any order. Clearing the two tables first still does exactly what it did; what changes is that the delete now succeeds without it. Migrations reach the hosted database **by hand**, so removing the clears before this file is applied there would leave `DELETE /account` running against a schema that still refuses. Apply first, then a second PR takes all four out and simplifies the `docs/team.md` paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)