### PR TITLE
Delete the paragraph six places were carrying

### DIFF
--- a/docs/team.md
+++ b/docs/team.md
@@ -420,15 +420,15 @@ still in is never touched, and being the last _admin_ of one refuses the whole
 deletion until the role is handed over. What it removes is a room with nobody
 left to enter it.
 
-Two of the references to a workspace do not cascade. `chat_sessions.workspace_id`
-and `ideas.workspace_id` were both added after the original schema and are plain
-references, so the tested procedure clears those two tables for the workspace
-first and then deletes the workspace row. Account closure follows the same
-procedure for the same reason — a workspace with a single conversation in it
-cannot be deleted until that row is gone, which is every workspace anybody has
-actually used. A third,
-`profiles.active_workspace_id`, sets itself to null, which is the same state a
-fresh account is in and resolves to the person's oldest remaining membership.
+Deleting the workspace row is the whole procedure. It was not until `0035`:
+`chat_sessions.workspace_id` and `ideas.workspace_id` were added after the
+original schema as plain references with no delete rule, so the delete failed on
+a foreign key while a single conversation remained — which was every workspace
+anybody had actually used — and the operator, the route and two tests each
+carried their own copy of "clear those two tables first". Both cascade now.
+One reference still does not: `profiles.active_workspace_id` sets itself to
+null, which is the same state a fresh account is in and resolves to the person's
+oldest remaining membership.
 
 What goes with it is everything that hangs off it, directly or through something
 that does: memberships, agents, and through the agents every session, message and

--- a/tests/rls/deletion.test.ts
+++ b/tests/rls/deletion.test.ts
@@ -49,10 +49,12 @@ describe("deleting a workspace", () => {
     const seeded = await seedWorkspace(alice);
     const db = sql();
 
-    // chat_sessions.workspace_id and ideas.workspace_id are NO ACTION, so they
-    // still go first — that is a separate arrangement from the one 0016 fixed.
-    await db`delete from public.ideas where workspace_id = ${alice.workspaceId}`;
-    await db`delete from public.chat_sessions where workspace_id = ${alice.workspaceId}`;
+    // One statement, and until 0035 it could not be. `chat_sessions.
+    // workspace_id` and `ideas.workspace_id` were plain references with no
+    // delete rule, so NO ACTION refused the workspace while a single row named
+    // it — and this test used to clear both tables first, as three other places
+    // did. The seeded workspace has a conversation and an idea in it, which is
+    // what makes deleting it in one line an assertion rather than a shortcut.
     await db`delete from public.workspaces where id = ${alice.workspaceId}`;
 
     const [{ count: workspaces }] = await db<{ count: string }[]>`
@@ -64,28 +66,9 @@ describe("deleting a workspace", () => {
       select count(*) from public.agents where id = ${seeded.agentId}`;
     expect(Number(agents)).toBe(0);
 
-    const [{ count: users }] = await db<{ count: string }[]>`
-      select count(*) from auth.users where id = ${alice.id}`;
-    expect(Number(users)).toBe(1);
-  });
-
-  it("takes the conversation and the idea that used to hold it open", async () => {
-    // The two deletes the test above still performs are the subject of this
-    // one. Before 0035, `chat_sessions.workspace_id` and `ideas.workspace_id`
-    // were plain references with no delete rule, so NO ACTION refused the
-    // workspace while a single row named it — and four places carried the same
-    // procedure for getting past that: the test above, `routes/account.ts`,
-    // `export-roundtrip.test.ts`, and `docs/team.md`.
-    //
-    // So: a workspace with a conversation and an idea still in it, deleted
-    // with nothing cleared first. This is the assertion the workarounds exist
-    // in place of, which is why it is worth having before they go.
-    const gwen = await createTestUser("gwen");
-    const seeded = await seedWorkspace(gwen);
-    const db = sql();
-
-    await db`delete from public.workspaces where id = ${gwen.workspaceId}`;
-
+    // The two that used to hold it open, named individually: a count over the
+    // whole table would pass just as well if the cascade stopped working and
+    // the fixture had never inserted them.
     const [{ count: sessions }] = await db<{ count: string }[]>`
       select count(*) from public.chat_sessions where id = ${seeded.sessionId}`;
     expect(Number(sessions)).toBe(0);
@@ -93,6 +76,10 @@ describe("deleting a workspace", () => {
     const [{ count: ideas }] = await db<{ count: string }[]>`
       select count(*) from public.ideas where id = ${seeded.ideaId}`;
     expect(Number(ideas)).toBe(0);
+
+    const [{ count: users }] = await db<{ count: string }[]>`
+      select count(*) from auth.users where id = ${alice.id}`;
+    expect(Number(users)).toBe(1);
   });
 
   it("still refuses to leave a surviving workspace without an admin", async () => {
@@ -266,8 +253,6 @@ describe("deleting a person", () => {
     const dave = await createTestUser("dave");
     const seeded = await seedWorkspace(dave);
 
-    await db`delete from public.ideas where workspace_id = ${dave.workspaceId}`;
-    await db`delete from public.chat_sessions where workspace_id = ${dave.workspaceId}`;
     await db`delete from public.workspaces where created_by = ${dave.id}`;
     await db`delete from auth.users where id = ${dave.id}`;
 
@@ -312,20 +297,19 @@ describe("deleting a person", () => {
     // the ordering below has become decoration and the comment above is wrong.
     await expect(db`delete from auth.users where id = ${erin.id}`).rejects.toThrow(/last admin/);
 
-    // The two references that do not cascade, cleared first — the same order
-    // the route uses, and the reason it has to. This is what the test caught:
-    // without it `delete from workspaces` fails on
-    // `chat_sessions_workspace_id_fkey` for every workspace anybody has used.
-    await db`delete from public.ideas where workspace_id = ${erin.workspaceId}`;
-    await db`delete from public.chat_sessions where workspace_id = ${erin.workspaceId}`;
+    // The workspace first and then the person, which is the order the route
+    // uses and the only one the last-admin trigger permits. Until 0035 there
+    // were two more deletes above this pair, clearing `ideas` and
+    // `chat_sessions` by hand, because `delete from workspaces` failed on
+    // `chat_sessions_workspace_id_fkey` for every workspace anybody had used.
     await db`delete from public.workspaces where id = ${erin.workspaceId}`;
     await db`delete from auth.users where id = ${erin.id}`;
 
-    // `chat_sessions` is not asserted here — it was deleted by name two lines
-    // up, so its absence would prove nothing. The test above it covers the
-    // cascade case.
+    // `chat_sessions` joins the list now that nothing deletes it by name: its
+    // absence proves the cascade rather than the line above it.
     for (const [table, id] of [
       ["api_keys", key.id],
+      ["chat_sessions", seeded.sessionId],
       ["profiles", erin.id],
     ] as const) {
       const [{ count }] = await db<{ count: string }[]>`

--- a/tests/rls/export-roundtrip.test.ts
+++ b/tests/rls/export-roundtrip.test.ts
@@ -97,14 +97,11 @@ describe("the restore", () => {
   it("puts back every row the export took", async () => {
     const service = serviceClient();
 
-    // Cleared before the workspace, and this is not incidental: neither
-    // reference cascades, so `delete from workspaces` fails the foreign key
-    // while a single session or idea remains. The same order `routes/account.ts`
-    // learned the hard way.
-    for (const table of ["ideas", "chat_sessions"] as const) {
-      const { error } = await service.from(table).delete().eq("workspace_id", workspaceId);
-      if (error) throw new Error(`clearing ${table} failed: ${error.message}`);
-    }
+    // One delete, and it takes the conversations and the ideas with it. Until
+    // 0035 it took three, because neither reference cascaded and this one
+    // failed the foreign key while a single session or idea remained — the
+    // same order `routes/account.ts` learned the hard way and has now also
+    // forgotten.
     const { error: dropError } = await service.from("workspaces").delete().eq("id", workspaceId);
     if (dropError) throw new Error(`deleting the workspace failed: ${dropError.message}`);
 

--- a/tests/rls/harness.ts
+++ b/tests/rls/harness.ts
@@ -184,9 +184,11 @@ export async function createTestUser(label: string): Promise<TestUser> {
  * under them; deleting a user then cascades what was only ever theirs, and
  * nulls their name on anything left standing in someone else's workspace.
  *
- * `chat_sessions.workspace_id` and `ideas.workspace_id` are NO ACTION and so
- * still have to be cleared by hand first — that is a different arrangement from
- * the one 0016 dealt with, and unrelated to who is being deleted.
+ * Until 0035 this also had to clear `chat_sessions` and `ideas` by workspace
+ * first, because neither reference cascaded. Both do now, and the only session
+ * delete left is the one scoped by person: a private session in somebody
+ * else's workspace belongs to the user, not to the room, so nothing above
+ * reaches it.
  *
  * This used to need `session_replication_role = replica` to get past
  * `trg_prevent_last_admin`, which refused to remove a workspace's last admin
@@ -202,10 +204,6 @@ export async function destroyTestUsers() {
   const users = db.array(ids);
 
   await db.begin(async (tx) => {
-    const workspaces = tx`select id from public.workspaces where created_by = any(${users}::uuid[])`;
-
-    await tx`delete from public.ideas where workspace_id in (${workspaces})`;
-    await tx`delete from public.chat_sessions where workspace_id in (${workspaces})`;
     await tx`delete from public.chat_sessions where user_id = any(${users}::uuid[])`;
     await tx`delete from public.workspaces where created_by = any(${users}::uuid[])`;
     await tx`delete from auth.users where id = any(${users}::uuid[])`;

--- a/worker/src/routes/account.test.ts
+++ b/worker/src/routes/account.test.ts
@@ -231,7 +231,7 @@ describe("DELETE /account", () => {
     expect(deleteUser).not.toHaveBeenCalled();
   });
 
-  it("clears what does not cascade, then the workspace, then the user", async () => {
+  it("deletes the workspace before the user", async () => {
     const order: string[] = [];
     serviceFrom.mockImplementation(
       serviceTables({ onDelete: (table, id) => order.push(`${table}:${id}`) }),
@@ -248,15 +248,21 @@ describe("DELETE /account", () => {
 
     expect(status).toBe(200);
     expect(body).toEqual({ ok: true });
-    // Three orderings in one list, and each is load-bearing. `ideas` and
-    // `chat_sessions` reference a workspace without cascading, so the workspace
-    // delete fails on a foreign key until they are cleared — CI found that, not
-    // this file. The workspace goes before the user because the last-admin
-    // trigger refuses the membership row while its workspace still stands.
-    expect(order).toEqual(["ideas:solo", "chat_sessions:solo", "workspaces:solo", "user"]);
+    // One ordering left, and it is the one this file can actually see: the
+    // workspace goes before the user, because the last-admin trigger refuses
+    // the membership row while its workspace still stands.
+    //
+    // This list used to open with `ideas:solo` and `chat_sessions:solo`,
+    // because neither reference cascaded and the workspace delete failed on a
+    // foreign key until they were cleared. **CI found that, not this file** —
+    // these mocks answer whatever they are told to and cannot see a
+    // constraint. 0035 made both cascade; the guarantee now lives in
+    // `tests/rls/deletion.test.ts`, against a real database, which is the only
+    // place it could ever have lived.
+    expect(order).toEqual(["workspaces:solo", "user"]);
   });
 
-  it("leaves the account alone when a workspace cannot be cleared or deleted", async () => {
+  it("leaves the account alone when a workspace cannot be deleted", async () => {
     serviceFrom.mockImplementation(serviceTables({ deleteError: { message: "nope" } }));
     const app = appWith({
       members: [{ workspace_id: "solo", user_id: USER.id, role: "admin" }],

--- a/worker/src/routes/account.ts
+++ b/worker/src/routes/account.ts
@@ -201,28 +201,15 @@ account.delete("/account", async (c) => {
   // because a failure part-way through should leave the rest of the account
   // intact and the caller told, rather than half a person in the database.
   for (const id of deletable) {
-    // Two references to a workspace do not cascade, and this is the procedure
-    // `docs/team.md` documents for an operator deleting one by hand.
-    // `chat_sessions.workspace_id` and `ideas.workspace_id` were both added
-    // after the original schema as plain references, so a workspace with a
-    // single conversation in it cannot be deleted until they are cleared —
-    // which is every workspace anybody has used. Scoped by workspace rather
-    // than by user on purpose: a session belonging to somebody who was removed
-    // from this workspace still carries its `workspace_id` and would hold the
-    // delete open just the same.
+    // One statement per workspace, and it was three until 0035. `chat_sessions.
+    // workspace_id` and `ideas.workspace_id` were plain references with no
+    // delete rule, so this loop cleared both tables first — as the operator
+    // procedure in `docs/team.md` and two RLS tests separately did. 0035 makes
+    // both cascade and all four copies of that paragraph are gone with it.
     //
-    // Better fixed as a migration that makes both cascade, which would also
-    // simplify the operator procedure. Done here instead because the route has
-    // to work against a database that has not had that migration applied, and
-    // migrations reach production by hand.
-    for (const table of ["ideas", "chat_sessions"] as const) {
-      const { error } = await admin.from(table).delete().eq("workspace_id", id);
-      if (error) {
-        console.error(`account deletion: failed to clear ${table}`, id, error);
-        return c.json({ error: "failed to close your account" }, 500);
-      }
-    }
-
+    // A failure here still leaves the rest of the account intact rather than
+    // half a person in the database, which is why the loop is one workspace at
+    // a time rather than one `in (…)` delete.
     const { error } = await admin.from("workspaces").delete().eq("id", id);
     if (error) {
       console.error("account deletion: failed to delete empty workspace", id, error);


### PR DESCRIPTION
Closes #55. The second half of #58 — `0035` is now applied to the hosted database (verified: both constraints report `c`, row counts unmoved, ledger recorded), so the hand-clearing can go.

## Six, not three

The issue found three copies and said it was worth doing "before a fourth place needs the same paragraph". There were already six:

| Where | What it did |
| --- | --- |
| `worker/src/routes/account.ts` | cleared both tables before each empty workspace |
| `tests/rls/export-roundtrip.test.ts` | same, to make room for a restore |
| `docs/team.md` | documented it as the operator procedure |
| `tests/rls/deletion.test.ts` | three separate times |
| `tests/rls/harness.ts` | `destroyTestUsers`, for every test in the suite |

The spread is the argument rather than the count. Nothing linked them, so each was discovered and written independently — and a seventh would have been too.

## Two assertions got stronger

**`deletion.test.ts` stopped deleting `chat_sessions` by name before checking it was gone.** The old comment was honest about it — "its absence would prove nothing" — so the row was simply not asserted. Now nothing deletes it explicitly and the count is a real assertion about the cascade.

**The account route's unit test lost its `ideas → chat_sessions → workspaces → user` ordering.** Worth being explicit about why that is not a loss: the first two were never observable there. The mocks answer whatever they are told and cannot see a foreign key — which is exactly why CI found the missing cascade and 552 passing unit tests did not. What the test still asserts is the part it can see: the workspace goes before the user, because the last-admin trigger refuses the membership row while its workspace stands. The rest lives in `tests/rls/`, against a real database.

94 RLS tests, 645 worker, 337 frontend, typecheck and format clean. Net −28 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)