### PR TITLE
Resume the first run where it stopped, not where it started

### DIFF
--- a/src/lib/onboarding-flow.test.ts
+++ b/src/lib/onboarding-flow.test.ts
@@ -106,6 +106,34 @@ describe("resolveStep", () => {
     // would strand the flow on a card the user already declined.
     expect(resolveStep(undefined, ctx())).toBe("workspace");
   });
+
+  it("resumes after the agent step once an agent exists", () => {
+    // Walked in a browser and this is what it did: a reload with no `?step=`
+    // went back to naming the workspace even though the agent was already
+    // created, and clicking forward through a step with no idempotency made a
+    // SECOND agent. `hasAgent` is the one part of setup that leaves a row
+    // behind, so it is the only thing a cold return can key on.
+    expect(resolveStep(undefined, ctx({ hasAgent: true }))).toBe("knowledge");
+  });
+
+  it("resumes the same way when this flow has no invite step at all", () => {
+    // No knowledge step is not a case: it exists exactly when an agent does.
+    // This is the shape where the step AFTER it is missing instead.
+    const solo = { ...ANSWERED, teamSize: "solo" };
+    expect(resolveStep(undefined, ctx({ hasAgent: true, answers: solo }))).toBe("knowledge");
+  });
+
+  it("refuses to show the agent step again once one exists", () => {
+    // Not only the cold return: the back button asks for `?step=agent` by
+    // name. Every other step can be re-shown harmlessly — this is the only one
+    // that creates something, so it is the only one a request cannot reopen.
+    expect(resolveStep("agent", ctx({ hasAgent: true }))).toBe("knowledge");
+  });
+
+  it("still honours a request for a step that creates nothing", () => {
+    expect(resolveStep("workspace", ctx({ hasAgent: true }))).toBe("workspace");
+    expect(resolveStep("invite", ctx({ hasAgent: true }))).toBe("invite");
+  });
 });
 
 describe("nextStep", () => {

--- a/src/lib/onboarding-flow.ts
+++ b/src/lib/onboarding-flow.ts
@@ -81,9 +81,31 @@ export function stepsFor(ctx: FlowContext): OnboardingStep[] {
   return [...survey, ...setup];
 }
 
-/** Where the flow goes once the survey is behind us. */
-function firstSetupStep(ctx: FlowContext): OnboardingStep {
-  return ctx.hasIncomingInvite ? "invite-accept" : "workspace";
+/**
+ * Where the flow goes once the survey is behind us.
+ *
+ * The survey resumes on its answers. Setup has only one answer of that kind:
+ * an agent either exists or it does not, and nothing else in setup leaves a
+ * row behind — a workspace is created by the signup trigger whether or not
+ * anybody named it, and a skipped document step is indistinguishable from an
+ * unvisited one. So `hasAgent` is the whole of what a cold return can know.
+ *
+ * Before this asked, and returned `workspace` unconditionally: a reload with
+ * no `?step=` walked somebody back through naming their workspace and creating
+ * their first agent, both of which they had already done. The second one is
+ * not idempotent, so they got a second agent with the same persona. Walked in
+ * a browser on 2026-08-31 and it happened on the first reload.
+ */
+function resumeStep(ctx: FlowContext): OnboardingStep {
+  if (ctx.hasIncomingInvite) return "invite-accept";
+  if (!ctx.hasAgent) return "workspace";
+
+  // `knowledge` exists exactly when an agent does — see `stepsFor` — so this
+  // is never the fallback in practice. It is written as one anyway because the
+  // alternative is asserting that here, and a wrong assertion in a resume path
+  // strands somebody on a blank screen.
+  const steps = stepsFor(ctx);
+  return steps[steps.indexOf("agent") + 1] ?? "knowledge";
 }
 
 /**
@@ -92,19 +114,28 @@ function firstSetupStep(ctx: FlowContext): OnboardingStep {
  * An unanswered prerequisite beats any request, which is what makes a
  * hand-edited `?step=` harmless and a half-finished run resumable — one rule
  * covering both.
+ *
+ * A step that has already done its work beats a request too, and there is
+ * exactly one of those. Every other step can be shown twice with no
+ * consequence — renaming a workspace, adding another document, sending
+ * invitations again — while `agent` creates something each time it is
+ * submitted. The back button asks for `?step=agent` by name, so leaving it
+ * requestable would have kept the duplicate a click away after the resume
+ * above was fixed.
  */
 export function resolveStep(requested: string | undefined, ctx: FlowContext): OnboardingStep {
   const missing = REQUIRED.find(({ answer }) => !ctx.answers[answer]);
   if (missing) return missing.step;
 
   const steps = stepsFor(ctx);
-  if (requested && (steps as string[]).includes(requested)) {
+  const spent = requested === "agent" && ctx.hasAgent;
+  if (requested && !spent && (steps as string[]).includes(requested)) {
     return requested as OnboardingStep;
   }
 
   // No usable request. Resume at setup rather than at `source`: the referral
   // question is optional, and one that was skipped should stay skipped.
-  return firstSetupStep(ctx);
+  return resumeStep(ctx);
 }
 
 /**


### PR DESCRIPTION
Found by walking the first run in a browser on production — covan-ai/covan-cloud#30, which exists because nobody had.

## What happened

Reload `/welcome` with no `?step=` mid-onboarding and you are sent back to **naming your workspace**, even though the workspace is named and the agent is created. Click forward and the agent step — which has no idempotency check — creates **a second agent** with the same persona. My test account finished onboarding with two.

`resolveStep` returns `firstSetupStep(ctx)` whenever the URL asks for nothing, and `firstSetupStep` is `"workspace"` unconditionally. The survey resumes properly on its answers; setup never resumed at all.

`newestAgent`'s comment in the same file almost names it — *"state does not survive the reload that `?step=knowledge` is otherwise perfectly able to resume from"* — the query param was the resume mechanism, and bare `/welcome` never used it.

## What decides the resume

Setup leaves exactly one trace: an agent exists or it does not. A workspace is created by the signup trigger whether or not anybody named it, and a skipped document step is indistinguishable from an unvisited one. So `hasAgent` is the whole of what a cold return can know, and resume lands on whatever follows `agent` in this flow.

## And the back button

The resume fix alone would have left the duplicate one click away, because the back button asks for `?step=agent` by name. `agent` is now the one step a request cannot reopen once it has done its work — deliberately a special case, not a rule: every other step is safe to show twice (rename the workspace, add another document, send invitations again), and only this one creates something each time it is submitted.

341 frontend tests, typecheck and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)