### PR TITLE
Stop a form submitted before hydration from putting the password in the URL

### DIFF
--- a/src/routes/credential-forms.static.test.ts
+++ b/src/routes/credential-forms.static.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Every form that carries a password or an email address posts.
+ *
+ * A `<form>` with no `method` is a GET, and React's `onSubmit` is only attached
+ * once the page hydrates. Submit inside that window — a cold cache, a slow
+ * connection, a fast typist — and the browser does the default: it puts what
+ * was typed in the query string, where it lands in the address bar and in
+ * history. On `/sign-in` that is the password.
+ *
+ * This was found by walking the deployed site rather than by reading it, which
+ * is the reason for a test that reads. The four forms are fixed today; a fifth
+ * one added a year from now inherits the same window, and nothing about writing
+ * it would bring this to mind.
+ *
+ * The file list is derived rather than written down, so a new route is covered
+ * the moment it exists. What is written down is the exemption list, which is
+ * empty and should stay that way — a form asking for a credential has no reason
+ * to prefer GET.
+ */
+
+const ROUTES = join(import.meta.dirname ?? "src/routes", ".");
+
+/**
+ * A field name here means the form around it carries something private.
+ *
+ * Matched on the field's `id`, not on `type="password"`. Both password fields
+ * on `/reset-password` are `type={showPassword ? "text" : "password"}`, so a
+ * pattern looking for the literal attribute skips the one route where every
+ * field is a password — the exact shape most worth catching.
+ */
+const SENSITIVE = /id="(password|confirmPassword|email)"|name="(password|email)"/;
+
+function routeFiles(): string[] {
+  return readdirSync(ROUTES)
+    .filter((f) => f.endsWith(".tsx") && !f.endsWith(".test.tsx"))
+    .sort();
+}
+
+/** Every `<form …>` opening tag in a file, with its attributes. */
+function formTags(source: string): string[] {
+  return [...source.matchAll(/<form\b[^>]*>/g)].map((m) => m[0]);
+}
+
+describe("credential forms", () => {
+  const offenders: string[] = [];
+
+  for (const file of routeFiles()) {
+    const source = readFileSync(join(ROUTES, file), "utf8");
+    if (!SENSITIVE.test(source)) continue;
+    for (const tag of formTags(source)) {
+      if (!/method="post"/.test(tag)) offenders.push(`${file}: ${tag}`);
+    }
+  }
+
+  it("never let the browser fall back to GET", () => {
+    expect(offenders).toEqual([]);
+  });
+
+  it("covers the forms this was written for", () => {
+    // A guard that matches nothing passes forever. This is the assertion that
+    // the file list and the field pattern still find real forms.
+    const covered = routeFiles().filter((f) => {
+      const source = readFileSync(join(ROUTES, f), "utf8");
+      return SENSITIVE.test(source) && formTags(source).length > 0;
+    });
+    expect(covered).toEqual(
+      expect.arrayContaining([
+        "forgot-password.tsx",
+        "reset-password.tsx",
+        "sign-in.tsx",
+        "sign-up.tsx",
+      ]),
+    );
+  });
+});

--- a/src/routes/forgot-password.tsx
+++ b/src/routes/forgot-password.tsx
@@ -77,7 +77,10 @@ function ForgotPassword() {
         </Link>
       }
     >
-      <form onSubmit={handleSubmit} className="space-y-4">
+      {/* method="post" for the reason spelled out in sign-in.tsx: submitted before
+          hydration, a form with no method is a GET and puts what was typed in
+          the URL. */}
+      <form method="post" onSubmit={handleSubmit} className="space-y-4">
         <div className="space-y-1.5">
           <Label htmlFor="email">Work email</Label>
           <div className="relative">

--- a/src/routes/reset-password.tsx
+++ b/src/routes/reset-password.tsx
@@ -169,7 +169,10 @@ function ResetPassword() {
         </Link>
       }
     >
-      <form onSubmit={handleSubmit} className="space-y-4">
+      {/* method="post" for the reason spelled out in sign-in.tsx: submitted before
+          hydration, a form with no method is a GET and puts what was typed in
+          the URL. */}
+      <form method="post" onSubmit={handleSubmit} className="space-y-4">
         <div className="space-y-1.5">
           <Label htmlFor="password">New password</Label>
           <div className="relative">

--- a/src/routes/sign-in.tsx
+++ b/src/routes/sign-in.tsx
@@ -55,7 +55,22 @@ function SignIn() {
         </>
       }
     >
-      <form onSubmit={handleSubmit} className="space-y-4">
+      {/* `method="post"` matters even though `handleSubmit` calls
+          preventDefault and this form is never posted anywhere.
+          There is a window between the HTML arriving and React attaching that
+          handler, and a submit inside it gets the browser's default — which,
+          with no method, is a GET. The password ends up in the query string, in
+          the address bar and in history:
+
+            /sign-in?email=someone%40example.com&password=hunter2
+
+          Not hypothetical; it happened on the first automated pass over the
+          deployed site, filling and clicking faster than hydration. A cold
+          cache or a slow connection is the same race with a person in it.
+          POST puts it in a request body instead, where the page answers 200 and
+          nothing is written down. The three other credential forms carry this
+          for the same reason. */}
+      <form method="post" onSubmit={handleSubmit} className="space-y-4">
         <div className="space-y-1.5">
           <Label htmlFor="email">Work email</Label>
           <div className="relative">

--- a/src/routes/sign-up.tsx
+++ b/src/routes/sign-up.tsx
@@ -97,7 +97,10 @@ function SignUp() {
         </>
       }
     >
-      <form onSubmit={handleSubmit} className="space-y-4">
+      {/* method="post" for the reason spelled out in sign-in.tsx: submitted before
+          hydration, a form with no method is a GET and puts what was typed in
+          the URL. */}
+      <form method="post" onSubmit={handleSubmit} className="space-y-4">
         <div className="space-y-1.5">
           <Label htmlFor="name">Full name</Label>
           <div className="relative">


### PR DESCRIPTION
Second of three from walking the first run in a browser — covan-ai/covan-cloud#30.

## The window

`handleSubmit` calls `preventDefault`, and it does that correctly. But it is only attached once React hydrates, and the HTML is interactive before then. A submit inside that window gets the browser's default, which with no `method` is a **GET**:

```
/sign-in?email=someone%40example.com&password=hunter2
```

— in the address bar, in history, and in anything that reads either.

Not hypothetical. It happened on the very first automated pass over the deployed site, which filled and clicked faster than hydration; waiting six seconds and repeating gave a clean `/sign-in`. A cold cache or a slow connection is the same race with a person in it.

`covan.app` answers `POST /sign-in` with 200, so the fallback now re-renders the page with the fields in a request body instead. No behaviour changes for anybody whose JavaScript has loaded.

## Four forms, one explanation

`sign-in`, `sign-up`, `forgot-password` and `reset-password` all carry a password or an address, and all four take `method="post"`. The reasoning lives in `sign-in.tsx` where it was found; the other three point at it rather than repeat it — four copies of one paragraph is a habit this repo has already paid for once today (#59).

## A static test, because reading did not find this

The guard derives the route list from the directory and holds every `<form>` in a file containing a credential field to `method="post"`. A fifth form written a year from now inherits the same window and nothing about writing it would bring this to mind.

It matches on field **ids**, not on `type="password"` — both fields on `/reset-password` are `type={showPassword ? "text" : "password"}`, so the obvious pattern silently skips the one route where every field is a password. Verified by reverting that file alone: the test names it.

339 frontend tests, typecheck and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)