### PR TITLE
Stop asking the API who is signed in before anybody is

### DIFF
--- a/src/lib/agents-store.tsx
+++ b/src/lib/agents-store.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { api, type Bundle } from "./api-client";
 import { canWriteAsRole } from "./roles";
 import { chatBundleMarker, chatBundleName, findChatBundle } from "./chat-uploads";
+import { useHasSession } from "./session-presence";
 
 export type Agent = {
   id: string;
@@ -122,26 +123,39 @@ const StoreCtx = createContext<Store | null>(null);
 export function AgentsProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
 
+  // This provider wraps every route, public ones included — the command
+  // palette lives inside it and is rendered at the root. So the five queries
+  // below have to ask whether there is anybody to ask FOR. Without this they
+  // ran on `/`, `/privacy`, `/sign-in` and `/sign-up`, answered 401, and were
+  // retried three times each: twenty requests to the API before the visitor
+  // had an account. `=== true` and not `!== false` on purpose — see
+  // useHasSession for why the third state matters.
+  const signedIn = useHasSession() === true;
+
   const { data: agents = [] } = useQuery({
     queryKey: ["agents"],
     queryFn: () => api.agents.list(),
+    enabled: signedIn,
   });
   const { data: sessions = [] } = useQuery({
     queryKey: ["sessions"],
     queryFn: () => api.sessions.list(),
+    enabled: signedIn,
   });
   const { data: favorites = [] } = useQuery({
     queryKey: ["favorites"],
     queryFn: () => api.favorites.list(),
+    enabled: signedIn,
   });
   const { data: bundles = [] } = useQuery({
     queryKey: ["bundles"],
     queryFn: () => api.bundles.list(),
+    enabled: signedIn,
   });
   // Already in the cache; the app shell fetches it. `me.members` carries the
   // caller's own row, so the role comes from the server rather than from
   // anything the client could have decided for itself.
-  const { data: me } = useQuery({ queryKey: ["me"], queryFn: () => api.me() });
+  const { data: me } = useQuery({ queryKey: ["me"], queryFn: () => api.me(), enabled: signedIn });
 
   // Undefined while `me` loads. Defaulting to false would flicker every write
   // control out of existence on each cold load, which reads as "you have been

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,5 +1,5 @@
 import { supabase } from "./supabase/client";
-import { errorMessage } from "./api-error";
+import { ApiError, errorMessage } from "./api-error";
 import type { WorkspaceRole } from "./roles";
 import type { Agent, ChatSession, Idea, Message } from "./agents-store";
 import type { AnswerPatch, OnboardingAnswers } from "./onboarding-flow";
@@ -68,15 +68,9 @@ export type Bundle = {
 
 export type IdeaSuggestion = { title: string; detail: string | null };
 
-export class ApiError extends Error {
-  status: number;
-
-  constructor(status: number, message: string) {
-    super(message);
-    this.name = "ApiError";
-    this.status = status;
-  }
-}
+// Defined in api-error.ts and re-exported here, so every call site keeps its
+// one import. See the note there for why it moved.
+export { ApiError };
 
 // Exposed so callers that need a raw `fetch` (e.g. SSE streaming, which the
 // JSON-only `request()` helper below doesn't support) can attach the same

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -6,6 +6,26 @@
  * down the other is the kind of difference nobody notices until someone is
  * looking at it.
  */
+/**
+ * A refusal that reached a server and came back with a number.
+ *
+ * Lives here rather than in `api-client.ts`, which it did until anything
+ * needed to reason about a status without also wanting a Supabase client:
+ * that module constructs one at import time from `VITE_` variables, so
+ * importing the error class pulled the whole authenticated transport — and its
+ * configuration — into a plain unit test. `api-client` re-exports it, so every
+ * existing call site is unchanged.
+ */
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
 export function errorMessage(status: number, body: unknown, fallback: string): string {
   const shape = body as { error?: unknown; resetsAt?: unknown } | null | undefined;
   const stated = typeof shape?.error === "string" ? shape.error : null;

--- a/src/lib/query-retry.test.ts
+++ b/src/lib/query-retry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { shouldRetryQuery } from "./query-retry";
+import { ApiError } from "./api-error";
+
+describe("shouldRetryQuery", () => {
+  it("does not retry an answer the server already gave", () => {
+    // The one measured on covan.app: five queries, four attempts each, on a
+    // page nobody had signed in to.
+    for (const status of [400, 401, 403, 404, 409, 422]) {
+      expect(shouldRetryQuery(0, new ApiError(status, "no")), `${status}`).toBe(false);
+    }
+  });
+
+  it("retries the two 4xx that mean later", () => {
+    expect(shouldRetryQuery(0, new ApiError(408, "timeout"))).toBe(true);
+    expect(shouldRetryQuery(0, new ApiError(429, "slow down"))).toBe(true);
+  });
+
+  it("retries a server error and a dropped connection", () => {
+    expect(shouldRetryQuery(0, new ApiError(500, "boom"))).toBe(true);
+    expect(shouldRetryQuery(0, new ApiError(503, "away"))).toBe(true);
+    // Not an ApiError at all: a network failure never reached a server, which
+    // is the case retrying was written for.
+    expect(shouldRetryQuery(0, new TypeError("Failed to fetch"))).toBe(true);
+  });
+
+  it("still stops after react-query's usual number of attempts", () => {
+    expect(shouldRetryQuery(2, new ApiError(500, "boom"))).toBe(true);
+    expect(shouldRetryQuery(3, new ApiError(500, "boom"))).toBe(false);
+    expect(shouldRetryQuery(3, new TypeError("Failed to fetch"))).toBe(false);
+  });
+});

--- a/src/lib/query-retry.ts
+++ b/src/lib/query-retry.ts
@@ -1,0 +1,24 @@
+import { ApiError } from "./api-error";
+
+/** react-query's default: the first attempt plus three more. */
+const MAX_ATTEMPTS = 3;
+
+/**
+ * Whether a failed query is worth attempting again.
+ *
+ * react-query retries everything three times, which is right for a dropped
+ * connection and wrong for an answer. A 401 means there is no session, a 403
+ * means this caller may not, a 404 means it is not there — none of those
+ * changes because the same request is sent again a second later. Sending it
+ * four times turns one wrong request into four, which is how a page with no
+ * session made twenty.
+ *
+ * 408 and 429 are excluded from the rule rather than included in it: both are
+ * the server saying "later", which is the one 4xx that means try again.
+ */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+  if (failureCount >= MAX_ATTEMPTS) return false;
+  if (!(error instanceof ApiError)) return true;
+  if (error.status === 408 || error.status === 429) return true;
+  return error.status < 400 || error.status >= 500;
+}

--- a/src/lib/session-presence.ts
+++ b/src/lib/session-presence.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import { supabase } from "./supabase/client";
+
+/**
+ * Whether there is somebody signed in, as a fact a query can be gated on.
+ *
+ * `undefined` until the first answer arrives, and that third state is the
+ * point: `false` would mean "nobody is signed in", which is not what a page
+ * knows during the tick it takes to read the stored session. A query gated on
+ * `=== true` therefore waits rather than fires, and a query gated on `!== false`
+ * would not.
+ *
+ * This exists because the store it feeds sits above every route. `/`,
+ * `/privacy`, `/sign-in` and `/sign-up` all mounted it, all five of its queries
+ * ran, all five answered 401, and react-query retried each three times — twenty
+ * requests to the API before anybody had an account, on the page a visitor is
+ * most likely to see. Measured on the deployed site, not inferred.
+ */
+export function useHasSession(): boolean | undefined {
+  const [hasSession, setHasSession] = useState<boolean | undefined>(undefined);
+
+  useEffect(() => {
+    let active = true;
+
+    void supabase.auth.getSession().then(({ data }) => {
+      if (active) setHasSession(Boolean(data.session));
+    });
+
+    // Covers signing in, signing out, and the token refresh that would
+    // otherwise leave a signed-in page gated on a stale `false`.
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (active) setHasSession(Boolean(session));
+    });
+
+    return () => {
+      active = false;
+      subscription.subscription.unsubscribe();
+    };
+  }, []);
+
+  return hasSession;
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,9 +1,15 @@
 import { QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
+import { shouldRetryQuery } from "./lib/query-retry";
 
 export const getRouter = () => {
-  const queryClient = new QueryClient();
+  // The retry rule is set here rather than per query, because the queries that
+  // need it are the ones nobody thought about. A 401, a 403 or a 404 is an
+  // answer; asking again a second later gets the same one. See query-retry.ts.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: shouldRetryQuery } },
+  });
 
   const router = createRouter({
     routeTree,


### PR DESCRIPTION
Third of three from walking the first run in a browser — covan-ai/covan-cloud#30.

## What was measured

Opening `/`, `/privacy`, `/sign-in` or `/sign-up` on covan.app sent **twenty requests to `api.covan.app`, all 401**, before the visitor had an account:

```
1.6s  401 GET /sessions /bundles /me /agents /favorites
2.7s  401 GET  (all five again)
4.8s  401 GET  (all five again)
8.8s  401 GET  (all five again)
```

Five because `AgentsProvider` wraps every route — the command palette lives inside it and renders at the root — and none of its queries asked whether there was anybody to ask *for*. Four attempts each because react-query retries everything three times.

That is a visitor reading the landing page or the privacy policy, paying for Worker invocations and spending rate-limit allowance on questions with no possible answer.

## Both halves, because either alone leaves the other wrong

**The queries wait on a session.** `useHasSession` returns `undefined` until the first answer and the queries check `=== true` — `!== false` would fire during the tick it takes to read the stored session, which is this bug in a smaller form. It subscribes to `onAuthStateChange`, so signing in starts them and a token refresh does not stop them.

**The retry rule treats an answer as an answer.** A 401, a 403 or a 404 does not change because the same request is sent again a second later; sending it four times turns one wrong request into four. `408` and `429` are excluded from the rule rather than included in it — both are the server saying *later*, which is the one 4xx that means try again. Set on the QueryClient rather than per query, because the queries that need it are the ones nobody thought about.

## One move that is not cosmetic

`ApiError` now lives in `api-error.ts` and is re-exported from `api-client.ts`, so every existing import is unchanged. It had to move: `api-client.ts` constructs a Supabase client at import time from `VITE_` variables, so importing the error class dragged the whole authenticated transport — and its configuration — into a plain unit test of a pure function.

## Verification

The unit tests cover the retry predicate exhaustively. The twenty-to-zero claim is about the deployed bundle and will be re-measured against covan.app after this deploys, the same way it was found.

345 frontend tests, typecheck, lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)