### PR TITLE
Let the web container start a second time

### DIFF
--- a/scripts/web-runtime-config.mjs
+++ b/scripts/web-runtime-config.mjs
@@ -130,7 +130,23 @@ export function assetEtag(bytes) {
  * Throwing when an entry is missing is the point. If a future nitro keeps this
  * manifest somewhere else, that has to fail loudly here rather than ship another
  * image that looks fine until somebody clicks something.
+ *
+ * What must NOT throw is a manifest that is already right. The container runs
+ * this on every start and substitutes from the pristine `.covan-tmpl` copies,
+ * so a restart with unchanged environment variables produces byte-identical
+ * assets and therefore the size and etag already recorded. Asking whether the
+ * replacement changed anything cannot tell that apart from a manifest this
+ * script cannot read — and it got it backwards in both directions: every
+ * restart threw, while an entry genuinely missing its `size` passed, because
+ * rewriting the etag alone counted as a change. That second one is the failure
+ * in the paragraph above, arriving silently.
+ *
+ * So the question is whether the fields are THERE, asked before anything is
+ * replaced.
  */
+const SIZE_FIELD = /"size":\s*\d+/;
+const ETAG_FIELD = /"etag":\s*"(?:[^"\\]|\\.)*"/;
+
 export function updateAssetManifest(manifestText, entries) {
   let out = manifestText;
 
@@ -150,17 +166,23 @@ export function updateAssetManifest(manifestText, entries) {
     const end = out.indexOf("}", start);
     const before = out.slice(start, end);
 
-    const updated = before
-      .replace(/"size":\s*\d+/, `"size": ${bytes.length}`)
-      .replace(/"etag":\s*"(?:[^"\\]|\\.)*"/, `"etag": ${JSON.stringify(assetEtag(bytes))}`);
+    const missing = [
+      SIZE_FIELD.test(before) ? null : "size",
+      ETAG_FIELD.test(before) ? null : "etag",
+    ].filter(Boolean);
 
-    if (updated === before) {
+    if (missing.length > 0) {
       throw new Error(
-        `Cannot start: manifest entry for ${urlPath} has no size or etag to correct.\n` +
+        `Cannot start: manifest entry for ${urlPath} has no ${missing.join(" and no ")} to correct.\n` +
           "Its shape is not what this script expects, and guessing would ship a\n" +
           "bundle that fails in the browser rather than here.",
       );
     }
+
+    const updated = before
+      .replace(SIZE_FIELD, `"size": ${bytes.length}`)
+      .replace(ETAG_FIELD, `"etag": ${JSON.stringify(assetEtag(bytes))}`);
+
     out = out.slice(0, start) + updated + out.slice(end);
   }
 

--- a/scripts/web-runtime-config.test.mjs
+++ b/scripts/web-runtime-config.test.mjs
@@ -164,6 +164,40 @@ describe("the recorded size of a substituted asset", () => {
     expect(out).toContain("otherhashotherhashotherh");
   });
 
+  it("accepts a manifest that is already correct", () => {
+    // The restart case, and it is the ordinary one. The container runs this
+    // script on every start, substituting from the pristine .covan-tmpl copies,
+    // so a restart with UNCHANGED environment variables produces byte-identical
+    // assets — and therefore the size and etag the manifest already holds.
+    //
+    // Treating "the replacement changed nothing" as "the entry has no size or
+    // etag" made that indistinguishable from a manifest this script cannot
+    // read, so the second start of any web container threw and the third and
+    // every one after it did too. Measured against a running covan-web: four
+    // .covan-tmpl copies present, the asset already substituted, and the
+    // container in a restart loop with "Its shape is not what this script
+    // expects".
+    const already = updateAssetManifest(manifest(9999, '"270f-stalehashstalehashstaleh"'), [
+      ["/assets/api-client-XyZ.js", bytes],
+    ]);
+    expect(() =>
+      updateAssetManifest(already, [["/assets/api-client-XyZ.js", bytes]]),
+    ).not.toThrow();
+    expect(updateAssetManifest(already, [["/assets/api-client-XyZ.js", bytes]])).toBe(already);
+  });
+
+  it("refuses an entry missing only its size, which used to pass", () => {
+    // The dangerous half. Under the old check this threw nothing, because
+    // rewriting the etag alone counted as "something changed" — so the size
+    // stayed stale and the browser got a Content-Length it could not satisfy,
+    // which is the exact failure this function exists to prevent. It has to
+    // fail here instead, and it has to say which field.
+    const noSize = manifest(9999, '"270f-stalehashstalehashstaleh"').replace('"size": 9999,', "");
+    expect(() => updateAssetManifest(noSize, [["/assets/api-client-XyZ.js", bytes]])).toThrow(
+      /no size to correct/,
+    );
+  });
+
   it("refuses to start when an asset has no entry, rather than shipping the bug again", () => {
     // If a future nitro keeps this manifest somewhere else, that has to fail
     // here — loudly — instead of producing another image that looks fine until
@@ -173,10 +207,10 @@ describe("the recorded size of a substituted asset", () => {
     ).toThrow(/no manifest entry/);
   });
 
-  it("refuses when the entry has no size to correct", () => {
+  it("refuses when the entry has neither field to correct", () => {
     const shapeless = `const assets = { "/assets/api-client-XyZ.js": { "type": "text/javascript" } };`;
     expect(() => updateAssetManifest(shapeless, [["/assets/api-client-XyZ.js", bytes]])).toThrow(
-      /no size or etag/,
+      /no size and no etag/,
     );
   });
 });


### PR DESCRIPTION
The self-hosted web container starts once and refuses every restart after that. `docker compose restart covan-web`, a host reboot, or Docker restarting it after a crash all leave the frontend down until the image is rebuilt.

Found it looping on this machine — twenty hours of:

```
Cannot start: manifest entry for /assets/…chat-CP6lY4ej.js has no size or etag
to correct. Its shape is not what this script expects, and guessing would ship
a bundle that fails in the browser rather than here.
```

## The shape was fine

The script runs on every start and substitutes from the pristine `.covan-tmpl` copies — which is the design, and the header says so. So a restart with **unchanged** environment variables produces byte-identical assets, and therefore exactly the size and etag the manifest already holds.

`updated === before` asked whether the replacement changed anything. That cannot tell *already correct* apart from *cannot read this*, and on a restart the first one is the ordinary case. Confirmed against the running container before touching anything: four `.covan-tmpl` copies present, the failing asset already substituted, its manifest entry perfectly well-formed.

Note what this implies about when it does **not** fail: an operator who changes `VITE_API_URL` and restarts gets different bytes, a different size, and a clean start. So the container survives exactly the restart nobody does and dies on the one everybody does.

## The other direction, which is worse

An entry genuinely missing its `size` still had its etag rewritten — something changed, so nothing threw. The size stayed stale, the browser got a `Content-Length` it could not satisfy, and React never hydrated: a container that starts, serves pages, and has no working buttons. That is the failure the function's header says it exists to prevent, and the check let it through silently.

The question is now whether the fields are **there**, asked before anything is replaced, and the message names which one is missing.

## Verified against the real thing

Patched script copied into the looping container, `docker start`:

```
covan: corrected the recorded size of 4 asset(s)
covan: configured 7 bundle files
➜ Listening on: http://localhost:3000/
```

`Up (healthy)`, `GET /` → 200, no sentinels left in the served bundle.

Found while walking the first run for covan-ai/covan-cloud#30 — the container was in this state the whole time and nothing else would have looked.

349 frontend tests, 17 in this file, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)