### PR TITLE
Give every email a second half that looks like the product

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -101,33 +101,33 @@ anyone in.
 The four notes above are the ones that bite. This is the complete reference —
 every line in `.env.docker.example`, in the order it appears there.
 
-| Variable                                               | Default in the template    | What it does                                                                                                                     |
-| ------------------------------------------------------ | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `OPENAI_API_KEY`                                       | _empty — you must set it_  | Chat completions and `text-embedding-3-small`. Nothing else needs an account.                                                    |
-| `OPENAI_BASE_URL`                                      | _empty — means OpenAI_     | Optional. Sends completions to an OpenAI-compatible endpoint instead. See below — it does not move everything.                   |
-| `OPENAI_MODEL`                                         | _empty_                    | Optional. Forces one model for every completion, overriding the per-agent picker. Needed whenever `OPENAI_BASE_URL` is set.      |
-| `EMBEDDING_BASE_URL`                                   | _empty — means OpenAI_     | Optional. Sends document embeddings to an OpenAI-compatible endpoint. Deliberately does **not** follow `OPENAI_BASE_URL`.        |
-| `EMBEDDING_MODEL`                                      | _empty_                    | Optional. Defaults to `text-embedding-3-small`. Set it whenever `EMBEDDING_BASE_URL` is set.                                     |
-| `EMBEDDING_DIMENSIONS`                                 | _empty — means 1536_       | Optional. The width `document_chunks.embedding` was declared with. Changing it is a schema change — see below. Refuses to boot on anything but a positive whole number. |
-| `RAG_MIN_SIMILARITY`                                   | _empty — means 0.25_       | Optional. Cosine-similarity floor below which a retrieved chunk is dropped. `0` disables it. Tuned for `text-embedding-3-small`; another model wants its own. |
-| `POSTGRES_PASSWORD`                                    | `covan-local-dev-password` | The database password. `auth`, `rest`, `realtime` and `migrate` all connect with it.                                             |
-| `POSTGRES_PORT`                                        | `54322`                    | **Host** port only, for `psql` or a GUI client. Inside the compose network Postgres is always on 5432.                           |
+| Variable                                               | Default in the template    | What it does                                                                                                                                                                                                                                 |
+| ------------------------------------------------------ | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OPENAI_API_KEY`                                       | _empty — you must set it_  | Chat completions and `text-embedding-3-small`. Nothing else needs an account.                                                                                                                                                                |
+| `OPENAI_BASE_URL`                                      | _empty — means OpenAI_     | Optional. Sends completions to an OpenAI-compatible endpoint instead. See below — it does not move everything.                                                                                                                               |
+| `OPENAI_MODEL`                                         | _empty_                    | Optional. Forces one model for every completion, overriding the per-agent picker. Needed whenever `OPENAI_BASE_URL` is set.                                                                                                                  |
+| `EMBEDDING_BASE_URL`                                   | _empty — means OpenAI_     | Optional. Sends document embeddings to an OpenAI-compatible endpoint. Deliberately does **not** follow `OPENAI_BASE_URL`.                                                                                                                    |
+| `EMBEDDING_MODEL`                                      | _empty_                    | Optional. Defaults to `text-embedding-3-small`. Set it whenever `EMBEDDING_BASE_URL` is set.                                                                                                                                                 |
+| `EMBEDDING_DIMENSIONS`                                 | _empty — means 1536_       | Optional. The width `document_chunks.embedding` was declared with. Changing it is a schema change — see below. Refuses to boot on anything but a positive whole number.                                                                      |
+| `RAG_MIN_SIMILARITY`                                   | _empty — means 0.25_       | Optional. Cosine-similarity floor below which a retrieved chunk is dropped. `0` disables it. Tuned for `text-embedding-3-small`; another model wants its own.                                                                                |
+| `POSTGRES_PASSWORD`                                    | `covan-local-dev-password` | The database password. `auth`, `rest`, `realtime` and `migrate` all connect with it.                                                                                                                                                         |
+| `POSTGRES_PORT`                                        | `54322`                    | **Host** port only, for `psql` or a GUI client. Inside the compose network Postgres is always on 5432.                                                                                                                                       |
 | `JWT_SECRET`                                           | Supabase demo secret       | Signs and verifies every access token. Changing it invalidates `ANON_KEY` and `SERVICE_ROLE_KEY`, which are JWTs signed with it. Also passed to the API as `SUPABASE_JWT_SECRET`, which is what makes API keys work — see [The API](api.md). |
-| `ANON_KEY`                                             | Supabase demo key          | The public API key. It reaches the browser by design; row level security is what protects the data behind it.                    |
-| `SERVICE_ROLE_KEY`                                     | Supabase demo key          | Bypasses row level security entirely. Server-side only — it must never reach a browser.                                          |
-| `JWT_EXPIRY`                                           | `3600`                     | Access-token lifetime in seconds. Refresh is automatic in the client.                                                            |
-| `SECRET_KEY_BASE`                                      | local placeholder          | Realtime's Phoenix session/cookie signing base. `openssl rand -base64 48`.                                                       |
-| `REALTIME_DB_ENC_KEY`                                  | `supabaserealtime`         | Realtime's own column encryption key. Upstream's default; regenerate for anything networked.                                     |
-| `ROUTINE_SECRET_KEY`                                   | local placeholder          | AES-GCM key for `delivery_channels.secret_ciphertext`. Must decode to 16, 24 or 32 bytes, or saving a delivery channel fails.    |
-| `SUPABASE_PUBLIC_URL`                                  | `http://localhost:8000`    | Where the **browser** reaches Supabase. Applied when `covan-web` starts; no rebuild.                                             |
-| `VITE_API_URL`                                         | `http://localhost:8787`    | Where the **browser** reaches the Covan API. Same — restart, not rebuild.                                                        |
-| `SITE_URL`                                             | `http://localhost:3000`    | The origin GoTrue puts in confirmation and password-reset links.                                                                 |
-| `ALLOWED_ORIGIN`                                       | `http://localhost:3000`    | Comma-separated **exact** origins the API accepts credentialed requests from. Also feeds the routine SSRF guard. No wildcards.   |
-| `KONG_HTTP_PORT` / `COVAN_API_PORT` / `COVAN_WEB_PORT` | `8000` / `8787` / `3000`   | Host ports. Change them if something already owns those, and update the `VITE_` URLs to match.                                   |
-| `ROUTINE_TICK_MS`                                      | `60000`                    | How often the Node entry point asks whether any routine is due. Per-routine frequency lives in the database, not here.           |
-| `RESEND_API_KEY` / `RESEND_FROM`                       | _empty_                    | Optional. Email for routine deliveries and team invitations, via [Resend](https://resend.com). Blank means neither is sent.      |
-| `VITE_TERMS_URL` / `VITE_PRIVACY_URL`                  | _empty_                    | Optional. Where the sign-up form's two links point. Blank uses the built-in `/terms` and `/privacy`. See below.                  |
-| `COVAN_VERSION`                                        | `latest`                   | Which published image tag to run. `latest` follows releases; `edge` follows `main`; a semver like `0.1.0` pins one.              |
+| `ANON_KEY`                                             | Supabase demo key          | The public API key. It reaches the browser by design; row level security is what protects the data behind it.                                                                                                                                |
+| `SERVICE_ROLE_KEY`                                     | Supabase demo key          | Bypasses row level security entirely. Server-side only — it must never reach a browser.                                                                                                                                                      |
+| `JWT_EXPIRY`                                           | `3600`                     | Access-token lifetime in seconds. Refresh is automatic in the client.                                                                                                                                                                        |
+| `SECRET_KEY_BASE`                                      | local placeholder          | Realtime's Phoenix session/cookie signing base. `openssl rand -base64 48`.                                                                                                                                                                   |
+| `REALTIME_DB_ENC_KEY`                                  | `supabaserealtime`         | Realtime's own column encryption key. Upstream's default; regenerate for anything networked.                                                                                                                                                 |
+| `ROUTINE_SECRET_KEY`                                   | local placeholder          | AES-GCM key for `delivery_channels.secret_ciphertext`. Must decode to 16, 24 or 32 bytes, or saving a delivery channel fails.                                                                                                                |
+| `SUPABASE_PUBLIC_URL`                                  | `http://localhost:8000`    | Where the **browser** reaches Supabase. Applied when `covan-web` starts; no rebuild.                                                                                                                                                         |
+| `VITE_API_URL`                                         | `http://localhost:8787`    | Where the **browser** reaches the Covan API. Same — restart, not rebuild.                                                                                                                                                                    |
+| `SITE_URL`                                             | `http://localhost:3000`    | The origin GoTrue puts in confirmation and password-reset links.                                                                                                                                                                             |
+| `ALLOWED_ORIGIN`                                       | `http://localhost:3000`    | Comma-separated **exact** origins the API accepts credentialed requests from. Also feeds the routine SSRF guard. No wildcards.                                                                                                               |
+| `KONG_HTTP_PORT` / `COVAN_API_PORT` / `COVAN_WEB_PORT` | `8000` / `8787` / `3000`   | Host ports. Change them if something already owns those, and update the `VITE_` URLs to match.                                                                                                                                               |
+| `ROUTINE_TICK_MS`                                      | `60000`                    | How often the Node entry point asks whether any routine is due. Per-routine frequency lives in the database, not here.                                                                                                                       |
+| `RESEND_API_KEY` / `RESEND_FROM`                       | _empty_                    | Optional. Email for routine deliveries and team invitations, via [Resend](https://resend.com). Blank means neither is sent.                                                                                                                  |
+| `VITE_TERMS_URL` / `VITE_PRIVACY_URL`                  | _empty_                    | Optional. Where the sign-up form's two links point. Blank uses the built-in `/terms` and `/privacy`. See below.                                                                                                                              |
+| `COVAN_VERSION`                                        | `latest`                   | Which published image tag to run. `latest` follows releases; `edge` follows `main`; a semver like `0.1.0` pins one.                                                                                                                          |
 
 Three more values the API reads are set by `docker-compose.yml` rather than by
 you: `SUPABASE_URL` (`http://kong:8000` — the compose network address, not
@@ -157,8 +157,7 @@ OPENAI_API_KEY=ignored-by-ollama-but-still-required
 ```
 
 Set both. The model list Covan ships is a list of OpenAI's names, so with only
-the base URL set every agent would ask your endpoint for `gpt-4o` and get a
-404. `OPENAI_MODEL` overrides that list outright, per-agent picker included —
+the base URL set every agent would ask your endpoint for `gpt-4o` and get a 404. `OPENAI_MODEL` overrides that list outright, per-agent picker included —
 which means the model dropdown in agent settings has no effect while it is set.
 It still shows OpenAI's models; ignore it.
 
@@ -226,7 +225,7 @@ fact about the model you chose rather than about Covan. In short:
 
 The API refuses to start on an `EMBEDDING_DIMENSIONS` that is not a positive
 whole number, or a `RAG_MIN_SIMILARITY` outside 0–1, naming the variable. A
-width that is merely *wrong* rather than malformed is caught at the first
+width that is merely _wrong_ rather than malformed is caught at the first
 embedding call instead, which is why step 1 is an upload rather than a restart.
 
 ## Terms and privacy
@@ -512,6 +511,31 @@ person yourself. Set one without the other and the two paths differ: an
 invitation checks for both and quietly reports that nothing was emailed, while a
 routine posts anyway and records whatever Resend answers as a failed run. So if
 you set one, set both.
+
+### The two emails Supabase sends, and where their design lives
+
+Confirming an address and resetting a password are sent by Supabase, not by this
+Worker, so no secret above affects them and nothing in this repository is on
+their path at runtime. Their default is unstyled — a sentence and a bare link —
+and it is the first thing a new account ever receives.
+
+`supabase/templates/` holds a styled version of each, rendered from the same
+shell as every other Covan email:
+
+| File                  | Paste into                                   |
+| --------------------- | -------------------------------------------- |
+| `confirm-signup.html` | Authentication → Emails → **Confirm signup** |
+| `reset-password.html` | Authentication → Emails → **Reset password** |
+
+The subject lines that go with them are in
+`worker/src/lib/emails/auth.ts`. Both files keep Supabase's
+`{{ .ConfirmationURL }}` placeholder, which is what the button points at — change
+anything else you like, but not that, or the button leads nowhere.
+
+Edit the source rather than the files: `bun run build:email-templates` in
+`worker/` rewrites them, and a test fails if the checked-in copies drift from it.
+`supabase/config.toml` can point a **local** stack at template files, but there is
+no way to push a template to a hosted project — pasting is the whole procedure.
 
 `SUPABASE_JWT_SECRET` is the project's JWT signing secret — Supabase dashboard,
 Settings → API — and it is what turns on [API keys](api.md). A key carries no

--- a/supabase/templates/confirm-signup.html
+++ b/supabase/templates/confirm-signup.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<style>
+  @media (prefers-color-scheme: dark) {
+    /* body as well as the table: the table paints only as far as its own
+       height, so a tall window keeps a band of light paper under a dark mail. */
+    body, .paper { background: #1a1613 !important; }
+    .card { background: #221d19 !important; border-color: #3a322b !important; }
+    .ink, .ink *, .wordmark { color: #f2efe9 !important; }
+    .muted, .muted a { color: #a89e92 !important; }
+    /* DESIGN.md derives the dark ladder in reverse from the same ink and
+       inverts the button fill — which is also the only thing that keeps this
+       button a shape, since an ink fill on a dark card is ink on ink.
+       Ordered after the .ink rule so it wins on the label. */
+    .btn { background: #f2efe9 !important; }
+    .btn-label { color: #221d19 !important; }
+  }
+</style>
+</head>
+<body style="margin:0;padding:0;background:#f7f7f4">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0">Confirm your address to activate your Covan account.</div>
+<table role="presentation" class="paper" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f7f7f4;padding:32px 16px">
+  <tr>
+    <td align="center">
+      <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:560px">
+        <tr>
+          <td style="padding:0 4px 18px">
+            <!-- The wordmark, with the amber as a 10px square mark: a pointer at
+                 the smallest size the system uses, nowhere near the 44px ceiling. -->
+            <span style="display:inline-block;width:10px;height:10px;background:#f48d16;vertical-align:middle"></span>
+            <span class="wordmark" style="font-family:'DM Sans','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:600;letter-spacing:-0.01em;color:#251f19;vertical-align:middle;padding-left:8px">Covan</span>
+          </td>
+        </tr>
+        <tr>
+          <td class="card ink" style="background:#ffffff;border:1px solid #e8e6dd;border-radius:8px;padding:32px 28px">
+            <h1 style="margin:0 0 18px;font-family:'DM Sans','Segoe UI',Helvetica,Arial,sans-serif;font-size:22px;font-weight:600;line-height:1.25;letter-spacing:-0.01em;color:#251f19">Confirm your address</h1>
+            <div style="font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif"><p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19">You are one click from a Covan account. Confirming tells us the address is really yours — after that you can sign in.</p><p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19">If a colleague invited you, the invitation is matched to this address and will be waiting once you are in.</p></div>
+            
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:8px 0 4px">
+        <tr>
+          <td class="btn" style="background:#251f19;border-radius:8px">
+            <a href="{{ .ConfirmationURL }}" class="btn-label" style="display:inline-block;padding:12px 22px;font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:15px;font-weight:500;color:#f7f7f4;text-decoration:none">Confirm my address</a>
+          </td>
+        </tr>
+      </table>
+            
+      <hr style="border:none;border-top:1px solid #e8e6dd;margin:28px 0 16px">
+      <p style="margin:0;font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5;color:#6b6157">If you did not create a Covan account, you can ignore this — nothing was set up.</p>
+          </td>
+        </tr>
+        <tr>
+          <td class="muted" style="padding:18px 4px 0;font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:1.5;color:#6b6157">
+            Sent by Covan · <a href="https://covan.app" style="color:#6b6157">covan.app</a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/supabase/templates/reset-password.html
+++ b/supabase/templates/reset-password.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<style>
+  @media (prefers-color-scheme: dark) {
+    /* body as well as the table: the table paints only as far as its own
+       height, so a tall window keeps a band of light paper under a dark mail. */
+    body, .paper { background: #1a1613 !important; }
+    .card { background: #221d19 !important; border-color: #3a322b !important; }
+    .ink, .ink *, .wordmark { color: #f2efe9 !important; }
+    .muted, .muted a { color: #a89e92 !important; }
+    /* DESIGN.md derives the dark ladder in reverse from the same ink and
+       inverts the button fill — which is also the only thing that keeps this
+       button a shape, since an ink fill on a dark card is ink on ink.
+       Ordered after the .ink rule so it wins on the label. */
+    .btn { background: #f2efe9 !important; }
+    .btn-label { color: #221d19 !important; }
+  }
+</style>
+</head>
+<body style="margin:0;padding:0;background:#f7f7f4">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0">A link to choose a new Covan password.</div>
+<table role="presentation" class="paper" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f7f7f4;padding:32px 16px">
+  <tr>
+    <td align="center">
+      <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:560px">
+        <tr>
+          <td style="padding:0 4px 18px">
+            <!-- The wordmark, with the amber as a 10px square mark: a pointer at
+                 the smallest size the system uses, nowhere near the 44px ceiling. -->
+            <span style="display:inline-block;width:10px;height:10px;background:#f48d16;vertical-align:middle"></span>
+            <span class="wordmark" style="font-family:'DM Sans','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:600;letter-spacing:-0.01em;color:#251f19;vertical-align:middle;padding-left:8px">Covan</span>
+          </td>
+        </tr>
+        <tr>
+          <td class="card ink" style="background:#ffffff;border:1px solid #e8e6dd;border-radius:8px;padding:32px 28px">
+            <h1 style="margin:0 0 18px;font-family:'DM Sans','Segoe UI',Helvetica,Arial,sans-serif;font-size:22px;font-weight:600;line-height:1.25;letter-spacing:-0.01em;color:#251f19">Reset your password</h1>
+            <div style="font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif"><p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19">Somebody asked for a new password on the Covan account at this address. The link below opens the page where you can choose one.</p><p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19">The link expires, and your current password keeps working until you set a new one.</p></div>
+            
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:8px 0 4px">
+        <tr>
+          <td class="btn" style="background:#251f19;border-radius:8px">
+            <a href="{{ .ConfirmationURL }}" class="btn-label" style="display:inline-block;padding:12px 22px;font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:15px;font-weight:500;color:#f7f7f4;text-decoration:none">Choose a new password</a>
+          </td>
+        </tr>
+      </table>
+            
+      <hr style="border:none;border-top:1px solid #e8e6dd;margin:28px 0 16px">
+      <p style="margin:0;font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5;color:#6b6157">If this was not you, ignore this message — your password has not changed and nobody was let in.</p>
+          </td>
+        </tr>
+        <tr>
+          <td class="muted" style="padding:18px 4px 0;font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:1.5;color:#6b6157">
+            Sent by Covan · <a href="https://covan.app" style="color:#6b6157">covan.app</a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/worker/package.json
+++ b/worker/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/covan-ai/covan/issues"
   },
   "type": "module",
+  "//build:email-templates": "Rewrites supabase/templates/*.html from src/lib/emails/auth.ts. Those files are pasted into the hosted project's dashboard by hand; auth-files.test.ts fails when they drift from the source.",
   "//engines": "Matches the frontend's floor so one `node` satisfies both halves of the repo, even though the API itself runs on Workers or Bun. See README.md.",
   "engines": {
     "node": ">=22"
@@ -25,6 +26,7 @@
     "dry:cron": "wrangler deploy -c wrangler.cron.toml --dry-run",
     "tail:cron": "wrangler tail -c wrangler.cron.toml",
     "typecheck": "tsc --noEmit",
+    "build:email-templates": "bun run scripts/build-email-templates.ts",
     "dry": "wrangler deploy --dry-run",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/worker/scripts/build-email-templates.ts
+++ b/worker/scripts/build-email-templates.ts
@@ -1,0 +1,22 @@
+/**
+ * Write `supabase/templates/*.html` from `src/lib/emails/auth.ts`.
+ *
+ * Run from the worker directory: `bun run build:email-templates`.
+ *
+ * The files exist to be pasted into the hosted project's dashboard
+ * (Authentication → Emails), which is the only way a template reaches GoTrue on
+ * a hosted Supabase project — `supabase/config.toml` configures a local stack
+ * and cannot push anything. `auth-files.test.ts` fails if what is checked in
+ * stops matching what this would write.
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { authEmailTemplates } from "../src/lib/emails/auth";
+
+const dir = join(import.meta.dirname, "../../supabase/templates");
+mkdirSync(dir, { recursive: true });
+
+for (const template of authEmailTemplates) {
+  writeFileSync(join(dir, template.filename), `${template.html}\n`, "utf8");
+  console.log(`wrote supabase/templates/${template.filename}  (subject: ${template.subject})`);
+}

--- a/worker/src/lib/email-layout.test.ts
+++ b/worker/src/lib/email-layout.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { emailShell } from "./email-layout";
+
+/**
+ * The chrome every Covan mail shares: the paper background, the raised card,
+ * the wordmark and the one ink button.
+ *
+ * `bodyHtml` arrives already rendered — from `email-markdown` for a routine, or
+ * written by hand for an invitation — so the shell never escapes it. Everything
+ * the shell is handed as *text* it must escape itself, and the first test is
+ * that one: a heading carries a workspace name, which is whatever somebody
+ * typed into a form.
+ */
+describe("emailShell", () => {
+  it("escapes the text it is given, and not the HTML body it is handed", () => {
+    const html = emailShell({
+      preheader: "A preheader",
+      heading: "<script>alert(1)</script> invited you",
+      bodyHtml: "<p>Already HTML.</p>",
+    });
+
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("<p>Already HTML.</p>");
+  });
+
+  it("renders an action as a link to its destination", () => {
+    const html = emailShell({
+      preheader: "p",
+      heading: "h",
+      bodyHtml: "",
+      action: { label: "Sign in to accept", url: "https://covan.app" },
+    });
+
+    expect(html).toContain('href="https://covan.app"');
+    expect(html).toContain("Sign in to accept");
+  });
+
+  // A routine's digest has nowhere in particular to send anybody, so the shell
+  // has to come without a button rather than with an empty one.
+  it("renders no button when there is no action", () => {
+    const html = emailShell({ preheader: "p", heading: "h", bodyHtml: "<p>x</p>" });
+
+    // The footer's covan.app link is the only anchor a button-less mail has.
+    expect(html.match(/<a /g)).toHaveLength(1);
+  });
+
+  /**
+   * Found by rendering these in a dark browser rather than by reading them.
+   *
+   * An ink button on a dark card is ink on ink: the fill stops being a shape and
+   * the mail loses its only call to action. DESIGN.md's dark mode answers this
+   * exact question — it derives the ladder in reverse and **inverts the button
+   * fill** — so the rule is the product's, not this file's invention. The
+   * wordmark and the page behind the card had the same problem, one shade apart.
+   */
+  it("inverts the button fill in dark mode, and carries the page with it", () => {
+    const html = emailShell({
+      preheader: "p",
+      heading: "h",
+      bodyHtml: "",
+      action: { label: "Go", url: "https://covan.app" },
+    });
+
+    const dark = html.slice(html.indexOf("prefers-color-scheme: dark"), html.indexOf("</style>"));
+    expect(dark, "the button fill is not inverted").toMatch(/\.btn\b/);
+    expect(dark, "the wordmark is left dark-on-dark").toMatch(/\.wordmark\b/);
+    // `body` carries its own background: the outer table only paints as far as
+    // its own height, leaving the rest of a tall window in light paper.
+    expect(dark, "the page behind the card stays light").toMatch(/\bbody\b/);
+  });
+});

--- a/worker/src/lib/email-layout.ts
+++ b/worker/src/lib/email-layout.ts
@@ -1,0 +1,135 @@
+import { escapeHtml } from "./escape-html";
+
+/**
+ * The chrome every Covan mail shares.
+ *
+ * Built to DESIGN.md rather than to a mail template's habits: warm neutrals with
+ * one amber accent used as a pointer, ink for the primary button (§1, the amber
+ * lives in a chip and never in a button), squares rather than circles (§3), and
+ * the 8px card radius from the radius ladder.
+ *
+ * Three constraints come from the medium rather than the design system:
+ *
+ * - **Every rule is inline.** A `<style>` block is dropped by enough clients
+ *   that anything load-bearing has to sit on the element it styles. The one
+ *   `<style>` here carries the dark-mode overrides only, so a client that
+ *   discards it still gets the light design rather than an unstyled page.
+ * - **Tables, not divs.** Outlook renders through Word, which does not lay out
+ *   with flexbox or grid. A centred single-column table is what works there and
+ *   costs nothing anywhere else.
+ * - **No external images.** No logo from a CDN and no tracking pixel, so nothing
+ *   depends on "load remote content" being clicked, and a mail nobody opens
+ *   stays a mail nobody opened rather than a datapoint.
+ */
+
+const PAPER = "#f7f7f4";
+const CARD = "#ffffff";
+const HAIRLINE = "#e8e6dd";
+const INK = "#251f19";
+const MUTED = "#6b6157";
+const AMBER = "#f48d16";
+
+// DM Sans does every display job in the app and Geist everything else, but a
+// mail client loads neither: a webfont either fails to apply or renders after
+// the reader has already seen the fallback. So the stack asks for them in case
+// they are installed locally and names the system faces that will actually be
+// used.
+const DISPLAY = "'DM Sans','Segoe UI',Helvetica,Arial,sans-serif";
+const BODY = "Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif";
+
+export type EmailAction = { label: string; url: string };
+
+export type EmailShellInput = {
+  /**
+   * The line an inbox shows next to the subject. Worth setting deliberately:
+   * left unset, clients quietly use the first words of the body, which for a
+   * routine is whatever the model happened to open with.
+   */
+  preheader: string;
+  heading: string;
+  /** Already HTML, and therefore never escaped here. */
+  bodyHtml: string;
+  action?: EmailAction;
+  /** Small print under the rule. Plain text; escaped like everything else. */
+  footnote?: string;
+};
+
+function button(action: EmailAction): string {
+  // A table rather than a padded anchor, because Outlook ignores padding on an
+  // inline element and would render this as bare underlined text.
+  return `
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:8px 0 4px">
+        <tr>
+          <td class="btn" style="background:${INK};border-radius:8px">
+            <a href="${escapeHtml(action.url)}" class="btn-label" style="display:inline-block;padding:12px 22px;font-family:${BODY};font-size:15px;font-weight:500;color:${PAPER};text-decoration:none">${escapeHtml(action.label)}</a>
+          </td>
+        </tr>
+      </table>`;
+}
+
+export function emailShell(input: EmailShellInput): string {
+  const action = input.action ? button(input.action) : "";
+  const footnote = input.footnote
+    ? `
+      <hr style="border:none;border-top:1px solid ${HAIRLINE};margin:28px 0 16px">
+      <p style="margin:0;font-family:${BODY};font-size:13px;line-height:1.5;color:${MUTED}">${escapeHtml(input.footnote)}</p>`
+    : "";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<style>
+  @media (prefers-color-scheme: dark) {
+    /* body as well as the table: the table paints only as far as its own
+       height, so a tall window keeps a band of light paper under a dark mail. */
+    body, .paper { background: #1a1613 !important; }
+    .card { background: #221d19 !important; border-color: #3a322b !important; }
+    .ink, .ink *, .wordmark { color: #f2efe9 !important; }
+    .muted, .muted a { color: #a89e92 !important; }
+    /* DESIGN.md derives the dark ladder in reverse from the same ink and
+       inverts the button fill — which is also the only thing that keeps this
+       button a shape, since an ink fill on a dark card is ink on ink.
+       Ordered after the .ink rule so it wins on the label. */
+    .btn { background: #f2efe9 !important; }
+    .btn-label { color: #221d19 !important; }
+  }
+</style>
+</head>
+<body style="margin:0;padding:0;background:${PAPER}">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0">${escapeHtml(input.preheader)}</div>
+<table role="presentation" class="paper" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:${PAPER};padding:32px 16px">
+  <tr>
+    <td align="center">
+      <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:560px">
+        <tr>
+          <td style="padding:0 4px 18px">
+            <!-- The wordmark, with the amber as a 10px square mark: a pointer at
+                 the smallest size the system uses, nowhere near the 44px ceiling. -->
+            <span style="display:inline-block;width:10px;height:10px;background:${AMBER};vertical-align:middle"></span>
+            <span class="wordmark" style="font-family:${DISPLAY};font-size:17px;font-weight:600;letter-spacing:-0.01em;color:${INK};vertical-align:middle;padding-left:8px">Covan</span>
+          </td>
+        </tr>
+        <tr>
+          <td class="card ink" style="background:${CARD};border:1px solid ${HAIRLINE};border-radius:8px;padding:32px 28px">
+            <h1 style="margin:0 0 18px;font-family:${DISPLAY};font-size:22px;font-weight:600;line-height:1.25;letter-spacing:-0.01em;color:${INK}">${escapeHtml(input.heading)}</h1>
+            <div style="font-family:${BODY}">${input.bodyHtml}</div>
+            ${action}
+            ${footnote}
+          </td>
+        </tr>
+        <tr>
+          <td class="muted" style="padding:18px 4px 0;font-family:${BODY};font-size:12px;line-height:1.5;color:${MUTED}">
+            Sent by Covan · <a href="https://covan.app" style="color:${MUTED}">covan.app</a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>`;
+}

--- a/worker/src/lib/email-markdown.test.ts
+++ b/worker/src/lib/email-markdown.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "./email-markdown";
+
+/**
+ * The small subset of Markdown a routine summary actually arrives in.
+ *
+ * Nothing constrains that summary's format — `lib/routines/summarise.ts` asks
+ * the model for prose and takes whatever comes back — so this converts what
+ * models reliably emit (headings, emphasis, lists, links, paragraphs) and
+ * leaves everything else as the text it already was.
+ *
+ * The escaping tests come first and are the reason this file exists at all: the
+ * summary is model output derived from fetched web pages, so it is untrusted
+ * input on its way into an HTML document.
+ */
+describe("renderMarkdown", () => {
+  it("escapes markup that arrives in the source text", () => {
+    const html = renderMarkdown("Watch out for <script>alert(1)</script> in feeds.");
+
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("makes a paragraph of each blank-line-separated block", () => {
+    const html = renderMarkdown("First thought.\n\nSecond thought.");
+
+    expect(html).toContain("First thought.</p>");
+    expect(html).toContain("Second thought.</p>");
+    expect(html.match(/<p[ >]/g)).toHaveLength(2);
+  });
+
+  it("renders emphasis rather than printing its asterisks", () => {
+    const html = renderMarkdown("Revenue was **up 12%** and *steady*.");
+
+    expect(html).toContain("<strong>up 12%</strong>");
+    expect(html).toContain("<em>steady</em>");
+    expect(html).not.toContain("**");
+  });
+
+  it("turns a hash-prefixed line into a heading", () => {
+    const html = renderMarkdown("## What changed\n\nTwo things.");
+
+    expect(html).toContain(">What changed</h2>");
+    expect(html).not.toContain("##");
+  });
+
+  // Squares, not circles — DESIGN.md §3. The marker is drawn rather than left to
+  // the client's own `list-style`, which is a disc everywhere by default.
+  it("collects consecutive dash lines into one list", () => {
+    const html = renderMarkdown("- First item\n- Second item");
+
+    expect(html.match(/<ul[ >]/g)).toHaveLength(1);
+    expect(html.match(/<li[ >]/g)).toHaveLength(2);
+    expect(html).toContain("First item");
+    expect(html).toContain("square");
+  });
+
+  it("renders a markdown link as an anchor", () => {
+    const html = renderMarkdown("See [the changelog](https://example.com/changes).");
+
+    expect(html).toContain('href="https://example.com/changes"');
+    expect(html).toContain(">the changelog</a>");
+  });
+
+  // The link text comes from a page the routine fetched, so the scheme is the
+  // attacker-controlled part. Anything but http(s) keeps its brackets and stays
+  // text — visible, inert, and obviously not a link.
+  it("refuses a link whose scheme is not http or https", () => {
+    const html = renderMarkdown("[click me](javascript:alert(1))");
+
+    expect(html).not.toContain("href");
+    expect(html).toContain("click me");
+  });
+
+  // A link is parked behind a placeholder while bare URLs are matched, and put
+  // back afterwards. If that placeholder were a bare number, the restore pass
+  // would find the digits in "12%" first and paste an anchor into the middle of
+  // the prose. Numbers next to links is the ordinary shape of a summary.
+  it("leaves numbers in the prose alone while restoring links", () => {
+    const html = renderMarkdown("Signups rose 12% — see [the report](https://example.com/r).");
+
+    expect(html).toContain("Signups rose 12%");
+    expect(html).toContain('href="https://example.com/r"');
+    expect(html.match(/<a /g)).toHaveLength(1);
+  });
+
+  it("links a bare URL the model left in the prose", () => {
+    const html = renderMarkdown("Source: https://example.com/post");
+
+    expect(html).toContain('href="https://example.com/post"');
+  });
+});

--- a/worker/src/lib/email-markdown.ts
+++ b/worker/src/lib/email-markdown.ts
@@ -1,0 +1,158 @@
+import { escapeHtml } from "./escape-html";
+
+/**
+ * Escape first, convert second.
+ *
+ * Everything below builds HTML out of a string that came back from a model,
+ * which in turn read fetched web pages — so the source is untrusted and the
+ * order is not negotiable. Escaping after conversion would undo the tags this
+ * function had just decided to emit.
+ */
+
+/**
+ * Styles are inline because a mail client is allowed to drop a `<style>` block
+ * and several do. Every rule that matters therefore sits on the element it
+ * styles, which is verbose in the source and the only thing that renders
+ * everywhere.
+ */
+const P = 'style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19"';
+const H = 'style="margin:24px 0 10px;font-size:17px;font-weight:600;color:#251f19"';
+// `list-style:square` rather than the default disc: DESIGN.md §3 makes every
+// bullet, mark and avatar in the product a square, and a mail is not the place
+// the rule stops.
+const UL = 'style="margin:0 0 16px;padding-left:20px;list-style:square"';
+const LI = 'style="margin:0 0 6px;font-size:15px;line-height:1.55;color:#251f19"';
+
+/**
+ * Inline marks, applied to text that is already escaped.
+ *
+ * Bold before italic, because `**x**` would otherwise match the single-asterisk
+ * rule twice and come out as `<em><em>x</em></em>`. Both patterns refuse to span
+ * a newline, so an asterisk used as a bullet or left dangling in prose stays the
+ * character it is instead of swallowing the rest of the paragraph.
+ */
+function inlineMarks(escaped: string): string {
+  return links(
+    escaped
+      .replace(/\*\*([^\n*]+)\*\*/g, "<strong>$1</strong>")
+      .replace(/(^|[^*])\*([^\n*]+)\*(?!\*)/g, "$1<em>$2</em>"),
+  );
+}
+
+/**
+ * The only two schemes that become an `href`.
+ *
+ * A routine summarises pages it fetched, so both halves of `[text](url)` are
+ * attacker-controlled and the scheme is the half that matters: `javascript:` in
+ * an anchor is a link that runs rather than navigates. Anything else keeps its
+ * brackets and stays visible text — inert, and obviously not a link.
+ */
+function isSafeUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
+const A = 'style="color:#251f19;text-decoration:underline"';
+
+/**
+ * Markdown links first, then bare URLs.
+ *
+ * The two passes cannot simply run in sequence over the same string: the first
+ * writes URLs into `href` attributes, and the second would then find them there
+ * and link them again, inside out. So each finished anchor is parked behind a
+ * placeholder from a private-use codepoint — which escaping guarantees is not in
+ * the text — and put back once the bare-URL pass is done.
+ */
+function links(text: string): string {
+  const parked: string[] = [];
+  const park = (html: string) => {
+    parked.push(html);
+    return `${parked.length - 1}`;
+  };
+
+  const withMarkdownLinks = text.replace(
+    /\[([^\]\n]+)\]\(([^)\s]+)\)/g,
+    (whole, label: string, url: string) =>
+      isSafeUrl(url) ? park(`<a href="${url}" ${A}>${label}</a>`) : whole,
+  );
+
+  // Trailing punctuation is not part of the address: a sentence ending "see
+  // https://example.com." should not link the full stop.
+  const withBareLinks = withMarkdownLinks.replace(/https?:\/\/[^\s<]+/gi, (url) => {
+    const trimmed = url.replace(/[.,;:)\]]+$/, "");
+    return park(`<a href="${trimmed}" ${A}>${trimmed}</a>`) + url.slice(trimmed.length);
+  });
+
+  return withBareLinks.replace(/(\d+)/g, (_, i: string) => parked[Number(i)]);
+}
+
+/** A blank line — one or more — is what separates two blocks. */
+function blocksOf(source: string): string[] {
+  return source
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0);
+}
+
+const BULLET = /^[-*]\s+(.*)$/;
+const HEADING = /^#{1,6}\s+(.*)$/;
+
+/**
+ * One block, which is not the same as one element.
+ *
+ * A model writes a lead line and its bullets with no blank line between them —
+ * "Three things stood out:" followed by three dashes — so a block is walked line
+ * by line and a run of bullets becomes a list wherever it starts. Splitting only
+ * on blank lines would have made that whole block one paragraph with the dashes
+ * still in it, which is the thing this file exists to stop.
+ */
+function renderBlock(block: string): string {
+  const out: string[] = [];
+  let bullets: string[] = [];
+  let prose: string[] = [];
+
+  const flushBullets = () => {
+    if (bullets.length === 0) return;
+    const items = bullets.map((b) => `<li ${LI}>${b}</li>`).join("");
+    out.push(`<ul ${UL}>${items}</ul>`);
+    bullets = [];
+  };
+  const flushProse = () => {
+    if (prose.length === 0) return;
+    // A single newline inside a paragraph is a wrap the model chose, not a
+    // break the reader asked for — but dropping it entirely runs two sentences
+    // together, so it becomes a `<br>`.
+    out.push(`<p ${P}>${prose.join("<br>")}</p>`);
+    prose = [];
+  };
+
+  for (const rawLine of block.split("\n")) {
+    const line = inlineMarks(escapeHtml(rawLine.trim()));
+    if (line.length === 0) continue;
+
+    const heading = line.match(HEADING);
+    if (heading) {
+      flushBullets();
+      flushProse();
+      out.push(`<h2 ${H}>${heading[1]}</h2>`);
+      continue;
+    }
+
+    const bullet = line.match(BULLET);
+    if (bullet) {
+      flushProse();
+      bullets.push(bullet[1]);
+      continue;
+    }
+
+    flushBullets();
+    prose.push(line);
+  }
+
+  flushBullets();
+  flushProse();
+  return out.join("\n");
+}
+
+export function renderMarkdown(source: string): string {
+  return blocksOf(source).map(renderBlock).join("\n");
+}

--- a/worker/src/lib/email.test.ts
+++ b/worker/src/lib/email.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { sendEmail } from "./email";
+
+/**
+ * What Resend is actually asked for.
+ *
+ * The HTML half exists so a mail can look like the product; the text half stays
+ * because a client that strips styles has to be left with something to read.
+ * Both go in one request, so these tests read the request body rather than
+ * asserting that a mock was called.
+ */
+function captureRequest() {
+  const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+    calls.push({ url: String(url), body: JSON.parse(String(init?.body)) });
+    return new Response("{}", { status: 200 });
+  });
+  return { calls, fetchImpl: fetchImpl as unknown as typeof fetch };
+}
+
+const DEPS = { apiKey: "re_test", from: "Covan <no-reply@mail.covan.app>" };
+
+describe("sendEmail", () => {
+  it("sends the HTML part alongside the text one", async () => {
+    const { calls, fetchImpl } = captureRequest();
+
+    await sendEmail(
+      {
+        to: "someone@example.com",
+        subject: "Subject",
+        text: "The plain text half.",
+        html: "<p>The HTML half.</p>",
+      },
+      { ...DEPS, fetchImpl },
+    );
+
+    expect(calls[0].body.text).toBe("The plain text half.");
+    expect(calls[0].body.html).toBe("<p>The HTML half.</p>");
+  });
+
+  // Not the same as sending `html: null`. A caller with nothing to style has to
+  // produce the request it produced before this field existed, or every
+  // text-only mail starts depending on how Resend reads an empty HTML body.
+  it("omits the HTML key entirely when there is no HTML", async () => {
+    const { calls, fetchImpl } = captureRequest();
+
+    await sendEmail(
+      { to: "someone@example.com", subject: "Subject", text: "Text only." },
+      { ...DEPS, fetchImpl },
+    );
+
+    expect(calls[0].body).not.toHaveProperty("html");
+  });
+});

--- a/worker/src/lib/email.ts
+++ b/worker/src/lib/email.ts
@@ -21,6 +21,15 @@ export type Email = {
   to: string;
   subject: string;
   text: string;
+  /**
+   * The optional HTML half.
+   *
+   * Optional rather than required, and an addition rather than a replacement:
+   * `text` remains what every caller must supply, so a client that strips HTML —
+   * or a caller that has nothing worth styling — is never left with an empty
+   * message. Resend takes both in one request and lets the client choose.
+   */
+  html?: string;
 };
 
 /**
@@ -52,6 +61,10 @@ export function sendEmail(email: Email, deps: EmailDeps): Promise<Response> {
       to: [email.to],
       subject: email.subject,
       text: email.text,
+      // `JSON.stringify` drops an undefined value, so a caller with no HTML
+      // sends the same request it always did rather than an explicit null that
+      // Resend would have to interpret.
+      html: email.html,
     }),
   });
 }

--- a/worker/src/lib/emails/auth-files.test.ts
+++ b/worker/src/lib/emails/auth-files.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { authEmailTemplates } from "./auth";
+
+/**
+ * The files in `supabase/templates/` are what somebody pastes into the hosted
+ * project's dashboard, and nothing at runtime reads them — so nothing at runtime
+ * would notice them going stale. This is that noticing.
+ *
+ * Regenerate with `bun run build:email-templates` from the worker directory.
+ */
+const TEMPLATE_DIR = join(import.meta.dirname, "../../../../supabase/templates");
+
+describe("supabase/templates", () => {
+  for (const template of authEmailTemplates) {
+    it(`${template.filename} matches the shell it was rendered from`, () => {
+      const onDisk = readFileSync(join(TEMPLATE_DIR, template.filename), "utf8");
+      expect(onDisk.trim()).toBe(template.html.trim());
+    });
+  }
+});

--- a/worker/src/lib/emails/auth.test.ts
+++ b/worker/src/lib/emails/auth.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { authEmailTemplates } from "./auth";
+
+/**
+ * Supabase sends the two mails a new account needs — confirm your address, and
+ * reset your password — and neither is sent by this Worker. They are pasted into
+ * the hosted project's dashboard, which is why they live here as rendered HTML
+ * rather than as a function anything calls: written in the same shell as every
+ * other Covan mail, so the first message a person ever receives from the product
+ * looks like the product.
+ *
+ * `supabase/templates/` holds the files to paste. `render-auth-templates.test.ts`
+ * is what stops those files drifting from this source.
+ */
+describe("authEmailTemplates", () => {
+  it("covers the two flows the app actually uses", () => {
+    expect(authEmailTemplates.map((t) => t.filename)).toEqual([
+      "confirm-signup.html",
+      "reset-password.html",
+    ]);
+  });
+
+  // Supabase substitutes these server-side. Get the name wrong and the button
+  // renders as an empty href — a mail that looks finished and goes nowhere.
+  it("gives every template a working confirmation link", () => {
+    for (const template of authEmailTemplates) {
+      expect(template.html, template.filename).toContain("{{ .ConfirmationURL }}");
+    }
+  });
+
+  it("renders each one in the Covan shell", () => {
+    for (const template of authEmailTemplates) {
+      expect(template.html, template.filename).toContain("<!doctype html>");
+      expect(template.html, template.filename).toContain("Covan");
+    }
+  });
+});

--- a/worker/src/lib/emails/auth.ts
+++ b/worker/src/lib/emails/auth.ts
@@ -1,0 +1,57 @@
+import { emailShell } from "../email-layout";
+
+/**
+ * The two mails Supabase sends on this product's behalf.
+ *
+ * Nothing in this Worker sends them — GoTrue does, from templates stored in the
+ * hosted project. They are written here anyway, in the same shell as every other
+ * Covan mail, because the confirmation is the first thing a new account ever
+ * receives and Supabase's default is an unstyled sentence and a bare link.
+ *
+ * `{{ .ConfirmationURL }}` is substituted by Supabase, not by us. It is written
+ * into the `action` URL and therefore passes through the shell's escaping —
+ * harmless, since the braces and dots it is made of are not characters that
+ * escaping touches.
+ *
+ * To use them: `supabase/templates/*.html` holds the rendered files, and
+ * Authentication → Emails in the dashboard is where they are pasted. See
+ * `docs/self-hosting.md`.
+ */
+
+const P = "margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19";
+
+export const authEmailTemplates = [
+  {
+    filename: "confirm-signup.html",
+    subject: "Confirm your Covan address",
+    html: emailShell({
+      preheader: "Confirm your address to activate your Covan account.",
+      heading: "Confirm your address",
+      bodyHtml: [
+        `<p style="${P}">You are one click from a Covan account. Confirming tells us the address is really yours — after that you can sign in.</p>`,
+        `<p style="${P}">If a colleague invited you, the invitation is matched to this address and will be waiting once you are in.</p>`,
+      ].join(""),
+      action: { label: "Confirm my address", url: "{{ .ConfirmationURL }}" },
+      footnote: "If you did not create a Covan account, you can ignore this — nothing was set up.",
+    }),
+  },
+  {
+    filename: "reset-password.html",
+    subject: "Reset your Covan password",
+    html: emailShell({
+      preheader: "A link to choose a new Covan password.",
+      heading: "Reset your password",
+      bodyHtml: [
+        `<p style="${P}">Somebody asked for a new password on the Covan account at this address. The link below opens the page where you can choose one.</p>`,
+        // Said plainly because the honest answer to "did someone try to get into
+        // my account?" is that a reset request proves nothing about them
+        // succeeding — and the reassurance is only true while the old password
+        // still works, which it does until this link is used.
+        `<p style="${P}">The link expires, and your current password keeps working until you set a new one.</p>`,
+      ].join(""),
+      action: { label: "Choose a new password", url: "{{ .ConfirmationURL }}" },
+      footnote:
+        "If this was not you, ignore this message — your password has not changed and nobody was let in.",
+    }),
+  },
+];

--- a/worker/src/lib/escape-html.ts
+++ b/worker/src/lib/escape-html.ts
@@ -1,0 +1,20 @@
+/**
+ * The one place that turns text into text-inside-HTML.
+ *
+ * Both halves of an email need this and they need it to agree: `email-markdown`
+ * escapes a model's summary before converting it, and `email-layout` escapes the
+ * workspace and people's names it puts in the chrome around it. A second copy
+ * that handled one character differently would be a hole in whichever file was
+ * not being read at the time.
+ *
+ * The quote is escaped along with the angle brackets because some of this text
+ * lands in an attribute — a preheader, an `alt` — where `<` alone is harmless
+ * and `"` is what ends the attribute early.
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/worker/src/lib/routines/delivery.test.ts
+++ b/worker/src/lib/routines/delivery.test.ts
@@ -48,6 +48,48 @@ describe("deliver", () => {
     expect(payload.subject).toBe("r/saas");
   });
 
+  // The summary is whatever the model wrote, and models write Markdown. Until
+  // this was rendered, a digest arrived with its asterisks and dashes intact —
+  // the routine's own output looked like a draft of itself.
+  it("renders the summary's markdown into the HTML half", async () => {
+    const fetchImpl = vi.fn(ok);
+    const channel = {
+      kind: "email" as const,
+      secret_ciphertext: await encryptSecret("deniz@example.com", KEY),
+    };
+    await deliver(
+      channel,
+      { subject: "r/saas", body: "## Today\n\n- **Pricing** changed\n- Nothing else" },
+      deps(fetchImpl),
+    );
+
+    const payload = JSON.parse(
+      (fetchImpl.mock.calls[0] as unknown as [string, RequestInit])[1].body as string,
+    );
+    expect(payload.html).toContain("<strong>Pricing</strong>");
+    expect(payload.html).toContain("<li");
+    expect(payload.html).not.toContain("##");
+    // The text half stays the summary exactly as the model wrote it.
+    expect(payload.text).toBe("## Today\n\n- **Pricing** changed\n- Nothing else");
+  });
+
+  // Slack renders its own markup from the text field and has no HTML half to
+  // send, so the rendering above must not follow the message down this path.
+  it("leaves the slack payload as text", async () => {
+    const fetchImpl = vi.fn(ok);
+    const channel = {
+      kind: "slack_webhook" as const,
+      secret_ciphertext: await encryptSecret("https://hooks.slack.com/services/E/E/E", KEY),
+    };
+    await deliver(channel, { subject: "r/saas", body: "**bold**" }, deps(fetchImpl));
+
+    const body = JSON.parse(
+      (fetchImpl.mock.calls[0] as unknown as [string, RequestInit])[1].body as string,
+    );
+    expect(body).not.toHaveProperty("html");
+    expect(body.text).toContain("**bold**");
+  });
+
   it("throws when the channel rejects the message", async () => {
     const fetchImpl = vi.fn(async () => new Response("invalid_token", { status: 403 }));
     const channel = {

--- a/worker/src/lib/routines/delivery.ts
+++ b/worker/src/lib/routines/delivery.ts
@@ -1,5 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { sendEmail } from "../email";
+import { emailShell } from "../email-layout";
+import { renderMarkdown } from "../email-markdown";
 import { decryptSecret } from "./crypto";
 
 export type DeliveryChannel = {
@@ -16,6 +18,25 @@ export type DeliveryDeps = {
 
 /** How much of a failing upstream's body reaches routine_runs.error. */
 const MAX_ERROR_BODY = 200;
+
+/** How much of the summary an inbox gets to show beside the subject. */
+const MAX_PREHEADER = 140;
+
+/**
+ * The inbox preview line.
+ *
+ * Taken from the summary's own first line, with its Markdown stripped: left
+ * unset, a client takes the opening of the HTML body, which for a digest that
+ * starts with a heading is the heading — the subject again, twice on one row.
+ */
+function preheaderOf(body: string): string {
+  const firstLine =
+    body
+      .split("\n")
+      .map((line) => line.replace(/^[#>\-*\s]+/, "").trim())
+      .find((line) => line.length > 0) ?? "";
+  return firstLine.replace(/[*_`]/g, "").slice(0, MAX_PREHEADER);
+}
 
 /** The narrow slice of the Supabase client this module needs. */
 export type DeliveryDb = Pick<SupabaseClient, "from">;
@@ -35,7 +56,24 @@ export async function deliver(
           body: JSON.stringify({ text: `*${message.subject}*\n${message.body}` }),
         })
       : await sendEmail(
-          { to: secret, subject: message.subject, text: message.body },
+          {
+            to: secret,
+            subject: message.subject,
+            text: message.body,
+            // The summary is model output and arrives as Markdown, because
+            // nothing in `summarise.ts` asks it not to. Rendering it here rather
+            // than constraining the prompt keeps the text half exactly what the
+            // model wrote — which is what Slack and the run record already show.
+            html: emailShell({
+              preheader: preheaderOf(message.body),
+              heading: message.subject,
+              bodyHtml: renderMarkdown(message.body),
+              // Not "Sent by a Covan routine": the shell's own footer already
+              // opens with "Sent by Covan", and the two stack into one column
+              // that says it twice.
+              footnote: "This digest was produced by a routine running on its schedule.",
+            }),
+          },
           { fetchImpl: deps.fetchImpl, apiKey: deps.resendApiKey, from: deps.resendFrom },
         );
 

--- a/worker/src/routes/invitations.test.ts
+++ b/worker/src/routes/invitations.test.ts
@@ -647,6 +647,29 @@ describe("POST /invitations — telling the invitee", () => {
     );
   });
 
+  it("sends an HTML half that carries the same facts as the text one", async () => {
+    let sent: { url: string; body: Record<string, unknown> } | undefined;
+    const { app } = appWithMail(async (input, init) => {
+      sent = { url: String(input), body: JSON.parse(String(init?.body)) };
+      return new Response("{}", { status: 200 });
+    });
+
+    await json(app, "POST", "/invitations", { email: "new@example.com", role: "member" }, MAIL_ENV);
+
+    const html = String(sent?.body.html);
+    // Same three facts the text half is held to, because the two halves are one
+    // message and a reader sees only one of them.
+    expect(html).toContain("Acme");
+    expect(html).toContain("new@example.com");
+    expect(html).toContain(MAIL_ENV.ALLOWED_ORIGIN);
+    expect(html, "the HTML mail offered a link that accepts the invitation").not.toMatch(
+      /\/invitations?\/[\w-]+\/accept|token=/,
+    );
+    // The text half is not replaced by the HTML one; a client that strips
+    // styles still has the whole message.
+    expect(String(sent?.body.text)).toContain("new@example.com");
+  });
+
   it("still creates the invitation when Resend refuses", async () => {
     const { app } = appWithMail(async () => new Response("nope", { status: 422 }));
 

--- a/worker/src/routes/invitations.ts
+++ b/worker/src/routes/invitations.ts
@@ -5,6 +5,8 @@ import { toEpochMs } from "../lib/dto";
 import type { PendingInvitationDTO, IncomingInvitationDTO } from "../lib/dto";
 import { getActiveWorkspaceId } from "../lib/workspace";
 import { canSendEmail, sendEmail } from "../lib/email";
+import { emailShell } from "../lib/email-layout";
+import { escapeHtml } from "../lib/escape-html";
 
 const invitations = new Hono<AppEnv>();
 
@@ -17,8 +19,12 @@ const invitations = new Hono<AppEnv>();
  * in a URL would be a second, weaker one guarding the same door. What the
  * recipient needs to know is which address to use; that is what this says.
  *
- * Plain text, no HTML part: it is four sentences, and an HTML mail that renders
- * as a blank card in a client that strips styles is worse than no HTML at all.
+ * Two halves, not two mails. The text below was the whole message for as long as
+ * this route existed, on the reasoning that an HTML mail which renders as a
+ * blank card in a client that strips styles is worse than no HTML at all. That
+ * reasoning still holds and is why `text` is unchanged and still says
+ * everything: the HTML is an addition Resend carries in the same request, and a
+ * client that drops it falls back to prose that was never a fallback.
  */
 function invitationEmail(args: {
   workspaceName: string;
@@ -56,8 +62,26 @@ function invitationEmail(args: {
       "If you were not expecting this, you can ignore it. Nothing happens until",
       "you accept.",
     ].join("\n"),
+    html: emailShell({
+      preheader: `${args.inviterName} invited you to ${args.workspaceName} on Covan.`,
+      heading: `${args.inviterName} invited you to ${args.workspaceName}`,
+      // Written here rather than run through `email-markdown`: this prose is
+      // ours and fixed, so it needs no parser — only the two interpolated names,
+      // which the shell escapes for us.
+      bodyHtml: [
+        `<p style="${P}">You have been invited as ${asRole}.</p>`,
+        `<p style="${P}">Covan is where a team keeps its AI agents: the agents and the knowledge they read are shared, and your own conversations stay yours.</p>`,
+        `<p style="${P}">Sign in with <strong>${escapeHtml(args.email)}</strong> — that address is what the invitation is matched to, so a different one will not find it. If you do not have an account yet, sign up with that same address.</p>`,
+      ].join(""),
+      action: { label: "Sign in to accept", url: args.appUrl },
+      footnote:
+        "If you were not expecting this, you can ignore it. Nothing happens until you accept.",
+    }),
   };
 }
+
+/** The body paragraph rule, inline for the same reason every other rule is. */
+const P = "margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19";
 
 const createInviteSchema = z.object({
   // Trimmed inside the schema, the way createWorkspaceSchema does it in


### PR DESCRIPTION
Covan sent plain text and nothing else. For the invitation that was a decision, written down where it was made: an HTML mail that renders as a blank card in a client which strips styles is worse than no HTML at all. That reasoning survives here — **the text half of every message is unchanged and still says everything**. The HTML is an addition Resend carries in the same request, so a client that drops it falls back to prose that was never a fallback.

### What this touches

| | |
|---|---|
| `lib/escape-html.ts` | new — the one place that turns text into text-inside-HTML, because both halves below need it and need it to agree |
| `lib/email-layout.ts` | new — the shell: paper ground, raised card, amber square mark, ink button, tables and inline rules, no external images |
| `lib/email-markdown.ts` | new — the Markdown subset a summary actually arrives in |
| `lib/email.ts` | `html` becomes an optional second part; a caller that supplies none sends the request it always did |
| `routes/invitations.ts`, `lib/routines/delivery.ts` | the two senders. The Slack path is untouched |
| `supabase/templates/` | new — the two mails Supabase sends, rendered from the same shell |

### The routine digest is where this shows

Nothing in `summarise.ts` asks the model for a format, so summaries arrive as Markdown and the mail printed it: the asterisks, the dashes and the hashes, a digest that looked like a draft of itself.

`email-markdown` **escapes before it converts**, and that order is not negotiable — the body is model output derived from fetched pages, so the scheme in `[text](url)` is the attacker-controlled half. Anything but http(s) keeps its brackets and stays inert text. Finished anchors are parked behind a private-use placeholder while bare URLs are matched, because a placeholder made of digits would be restored over the 0 in "up 12%".

### The two Supabase sends

Confirming an address and resetting a password come from GoTrue, and no secret in this repository is on their path. The confirmation is the first thing a new account ever receives and it was an unstyled sentence with a bare link. `supabase/templates/*.html` holds a styled version of each, to be pasted into the dashboard — the only way a template reaches a hosted project. `bun run build:email-templates` rewrites them and `auth-files.test.ts` fails when the checked-in copies drift. The procedure is in `docs/self-hosting.md`.

### Three things the dark render caught that reading could not

An ink button on a dark card is ink on ink and stops being a shape; the wordmark sat dark-on-dark; and the outer table paints only as far as its own height, so a tall window kept a band of light paper under a dark mail. DESIGN.md had already answered the first — its dark mode inverts the button fill.

### Testing

668 worker tests, 349 frontend, types and lint clean. Each guard was proved by breaking the implementation and watching the right test go red: the placeholder reduced to digits, the scheme check opened up, the button removed.