### PR TITLE
Take the react-hooks major, and the two real bugs it found

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "eslint": "^10.9.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
-        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.4",
         "globals": "^17.11.0",
         "jsdom": "^30.0.1",
@@ -640,7 +640,7 @@
 
     "eslint-plugin-prettier": ["eslint-plugin-prettier@5.5.6", "", { "dependencies": { "prettier-linter-helpers": "^1.0.1", "synckit": "^0.11.13" }, "peerDependencies": { "@types/eslint": ">=8.0.0", "eslint": ">=8.0.0", "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0", "prettier": ">=3.0.0" }, "optionalPeers": ["@types/eslint", "eslint-config-prettier"] }, "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ=="],
 
-    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@5.2.0", "", { "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg=="],
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
 
     "eslint-plugin-react-refresh": ["eslint-plugin-react-refresh@0.5.4", "", { "peerDependencies": { "eslint": "^9 || ^10" } }, "sha512-7bqTKz7T0r+HKWFarNXByDE9/5+73wI2ru+M3zuqGbR7s/b/5/pQJXZoufWlrngqGqoZto73ZkGumCdLxk+4rw=="],
 
@@ -703,6 +703,10 @@
     "h3-v2": ["h3@2.0.1-rc.20", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.13" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
+
+    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
@@ -872,7 +876,7 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "seroval": ["seroval@1.6.2", "", {}, "sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ=="],
 
@@ -1000,11 +1004,9 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
-
-    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -1039,6 +1041,8 @@
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "cmdk/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,26 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      // `eslint-plugin-react-hooks` 7 brought the React Compiler rules into
+      // `recommended`: two rules became sixteen. Fourteen of them pass, and the
+      // two that did not — `static-components` and `refs` — were fixed rather
+      // than silenced, because each was one site and each was a real defect.
+      //
+      // This one is different, and the difference is worth writing down. It
+      // reports eleven sites, and every one of them is the same shape: read
+      // something that only exists in a browser — `matchMedia`, `localStorage`,
+      // the theme the init script chose, a form field seeded from a query that
+      // resolves a beat after first render — and put it into state after mount.
+      // The rule is right that this costs a second render, and right that
+      // `useSyncExternalStore` is the answer for most of them. It is a
+      // behavioural refactor of eleven call sites across the chat, settings,
+      // theme and onboarding surfaces, and it does not belong in the commit
+      // that upgrades the plugin: a dependency bump that quietly rewrites how
+      // the theme loads is a dependency bump nobody can review.
+      //
+      // A warning, not off, so the count stays visible and a twelfth site
+      // announces itself. The eleven are enumerated in covan#68.
+      "react-hooks/set-state-in-effect": "warn",
       "no-restricted-imports": [
         "error",
         {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint": "^10.9.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.4",
     "globals": "^17.11.0",
     "jsdom": "^30.0.1",

--- a/src/components/routines/routines-list.tsx
+++ b/src/components/routines/routines-list.tsx
@@ -38,57 +38,95 @@ export function RoutinesList({
     );
   }
 
-  const Group = ({ title, items }: { title: string; items: Routine[] }) =>
-    items.length === 0 ? null : (
-      <section className="mt-8">
-        <SectionHeading title={title} />
-        <SectionCard padded={false} className="mt-3 overflow-hidden">
-          <ul className="divide-y divide-hairline">
-            {items.map((r) => (
-              <li key={r.id}>
-                <Link
-                  to="/agents/$agentId/routines/$routineId"
-                  params={{ agentId, routineId: r.id }}
-                  className="flex items-center gap-3 px-5 py-3.5 transition-colors duration-200 hover:bg-surface-hover"
-                >
-                  <div className="min-w-0 flex-1">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <span className="truncate font-dm text-[17px] font-medium leading-tight">
-                        {r.name}
-                      </span>
-                      {r.visibility === "shared" && <Chip tone="on">Shared</Chip>}
-                    </div>
-                    {/* The "·" separators are their own aria-hidden nodes so each
-                        fact stays a readable unit rather than one run-on string. */}
-                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
-                      <span className="tabular-nums">{cronToProse(r.scheduleCron)}</span>
-                      {r.userId !== currentUserId && (
-                        <>
-                          <span aria-hidden>·</span>
-                          <span>by {memberNames[r.userId] ?? "a teammate"}</span>
-                        </>
-                      )}
-                      {r.status === "active" && r.nextRunAt !== null && (
-                        <>
-                          <span aria-hidden>·</span>
-                          <span className="tabular-nums">next {formatRelative(r.nextRunAt)}</span>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                  <RoutineStatus routine={r} className="max-w-[45%] shrink-0 justify-end" />
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </SectionCard>
-      </section>
-    );
-
   return (
     <>
-      <Group title="Team routines" items={team} />
-      <Group title="My routines" items={mine} />
+      <Group
+        title="Team routines"
+        items={team}
+        agentId={agentId}
+        currentUserId={currentUserId}
+        memberNames={memberNames}
+      />
+      <Group
+        title="My routines"
+        items={mine}
+        agentId={agentId}
+        currentUserId={currentUserId}
+        memberNames={memberNames}
+      />
     </>
+  );
+}
+
+/**
+ * One titled group of routines, or nothing when the group is empty.
+ *
+ * Defined here rather than inside `RoutinesList`, which is where it used to
+ * live. A component declared in a render body is a new component *type* on
+ * every render, so React cannot match it against the previous tree: it unmounts
+ * the old one and mounts a fresh one, losing DOM state and re-running effects
+ * for the whole subtree each time the parent renders. It looked like a closure
+ * and behaved like a remount. `eslint-plugin-react-hooks` 7 reports it as
+ * `react-hooks/static-components`; before 7 nothing did.
+ *
+ * The three values it used to close over are props now, which is the whole cost.
+ */
+function Group({
+  title,
+  items,
+  agentId,
+  currentUserId,
+  memberNames,
+}: {
+  title: string;
+  items: Routine[];
+  agentId: string;
+  currentUserId: string | null;
+  memberNames: Record<string, string>;
+}) {
+  return items.length === 0 ? null : (
+    <section className="mt-8">
+      <SectionHeading title={title} />
+      <SectionCard padded={false} className="mt-3 overflow-hidden">
+        <ul className="divide-y divide-hairline">
+          {items.map((r) => (
+            <li key={r.id}>
+              <Link
+                to="/agents/$agentId/routines/$routineId"
+                params={{ agentId, routineId: r.id }}
+                className="flex items-center gap-3 px-5 py-3.5 transition-colors duration-200 hover:bg-surface-hover"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="truncate font-dm text-[17px] font-medium leading-tight">
+                      {r.name}
+                    </span>
+                    {r.visibility === "shared" && <Chip tone="on">Shared</Chip>}
+                  </div>
+                  {/* The "·" separators are their own aria-hidden nodes so each
+                        fact stays a readable unit rather than one run-on string. */}
+                  <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                    <span className="tabular-nums">{cronToProse(r.scheduleCron)}</span>
+                    {r.userId !== currentUserId && (
+                      <>
+                        <span aria-hidden>·</span>
+                        <span>by {memberNames[r.userId] ?? "a teammate"}</span>
+                      </>
+                    )}
+                    {r.status === "active" && r.nextRunAt !== null && (
+                      <>
+                        <span aria-hidden>·</span>
+                        <span className="tabular-nums">next {formatRelative(r.nextRunAt)}</span>
+                      </>
+                    )}
+                  </div>
+                </div>
+                <RoutineStatus routine={r} className="max-w-[45%] shrink-0 justify-end" />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </SectionCard>
+    </section>
   );
 }

--- a/src/lib/use-dictation.ts
+++ b/src/lib/use-dictation.ts
@@ -87,8 +87,18 @@ export function useDictation(onText: (text: string) => void): Dictation {
   // The composer re-renders on every keystroke, so the callback it passes is a
   // new function each time. Held in a ref, the recorder's handlers can be set up
   // once and still call the current one.
+  //
+  // The assignment is in an effect rather than in the render body, where it used
+  // to be. Writing a ref during render makes the render impure: React may run it
+  // twice, or throw it away and run it again, and a ref written on a render that
+  // was discarded is a value nothing put there. It is harmless here today — the
+  // ref is only read from a MediaRecorder callback, long after any render has
+  // settled — and it is still the sort of thing that is only harmless until the
+  // hook is used somewhere else. `react-hooks/refs` reports it in v7.
   const onTextRef = useRef(onText);
-  onTextRef.current = onText;
+  useEffect(() => {
+    onTextRef.current = onText;
+  }, [onText]);
 
   const release = useCallback(() => {
     if (tickRef.current !== null) {


### PR DESCRIPTION
`eslint-plugin-react-hooks` 5.2.0 → 7.1.1, from the list in #1. Supersedes #64, which should be closed rather than merged.

**Why Dependabot's version could never go green.** All six of its open PRs across both repos fail identically, in 10–27 seconds:

```
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

It edits `package.json` and cannot regenerate a Bun lockfile. That is an install failure, not a verdict on any of the upgrades — worth knowing before reading six red PRs as six broken dependencies.

**What the upgrade actually brings.** v7 folds the React Compiler rules into `recommended`: two rules become sixteen. `eslint.config.js` spreads `recommended.rules`, so all fourteen new ones arrived at once. Fourteen pass on this codebase. Two did not, and both were real bugs rather than style:

`react-hooks/static-components` — `Group` in `routines-list.tsx` was declared inside its parent's render body, making it a new component *type* on every render. React cannot match a new type against the previous tree, so it unmounted the group and mounted a fresh one each time the parent rendered, losing DOM state and re-running effects for the whole subtree. It read like a closure and behaved like a remount. Hoisted to module scope; the three values it closed over are props now, which is the entire cost.

`react-hooks/refs` — `use-dictation.ts` assigned `onTextRef.current` in the render body. A ref written during render is a value put there by a render React is free to discard. It is harmless *here* because the ref is only read from a `MediaRecorder` callback, long after any render has settled — and harmless in the way that lasts exactly until the hook is used somewhere else. Moved into an effect.

**The third rule, and why it is a warning.** `react-hooks/set-state-in-effect` reports eleven sites. Every one is the same shape — read `matchMedia`, `localStorage`, the theme the init script chose, or a query result that resolves a beat after first render, and put it into state after mount. The rule is right, and `useSyncExternalStore` is the answer for most of them. It is also a behavioural refactor of eleven call sites across the chat, settings, theme and onboarding surfaces, and a dependency bump that quietly rewrites how the theme loads is a dependency bump nobody can review.

So: `warn`, not `off` — the count stays visible and a twelfth site announces itself — with the reasoning in `eslint.config.js` next to the three overrides that already carry theirs, and the eleven enumerated in #68. CI runs `eslint .` without `--max-warnings`, so this does not paper over a red build; the build was green either way once the two errors were fixed.

**State of #1 after this.** Eight of the ten majors are already done (`eslint` 10, `@eslint/js` 10, `@types/node` 26, `jsdom` 30, `@testing-library/jest-dom` 7, `@vitejs/plugin-react` 6, `globals` 17, and `@cloudflare/workers-types` 5 in `worker/`). This is the ninth. That leaves `typescript` 5.9 → 7 in both the root and `worker/`, which #1 says should be its own piece of work with its own day — and having now seen that TypeScript 7 is a different compiler rather than a newer one, that is right.

0 lint errors, 14 warnings (the 11 above plus 3 `react-refresh` that predate this), clean typecheck, 349 tests. Mirror to covan-cloud to follow.