### PR TITLE
Keep one eslint config, not two that drift

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -93,6 +93,15 @@ export default tseslint.config(
     files: ["**/*.test.{ts,tsx}", "tests/**/*.ts"],
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
+      // Same argument, for a rule that arrived with react-hooks 7. A test
+      // harness component exists to hand its innards back to the test —
+      // `mermaid-blocks.test.tsx` renders a div, keeps a ref to it, and passes
+      // that ref out through an `onRef` prop so the assertions can reach the
+      // DOM the component under test is given. That is a callback during
+      // render, which `react-hooks/refs` reports and is right to report in
+      // application code. Here the alternative is an effect that fires after
+      // the child has already rendered, which is later than the test needs it.
+      "react-hooks/refs": "off",
     },
   },
   {


### PR DESCRIPTION
Follow-on to #69, and small.

`eslint.config.js` is byte-identical in covan and covan-cloud, and #69 was about to end that. `eslint-plugin-react-hooks` 7 brought `react-hooks/refs`, and covan-cloud has a test harness that trips it: `mermaid-blocks.test.tsx` renders a div, keeps a ref to it, and hands that ref back to the test through an `onRef` prop so the assertions can reach the DOM the component under test is given. That is a callback during render — which the rule is right to report in application code, and wrong to report in scaffolding.

The override goes in the block that already exists for exactly this argument: the one turning `no-explicit-any` off for tests, whose comment says a mock exists to be the shape the code under test happens to touch. Same reasoning, second rule.

**Nothing in this repository triggers it today, and that is the point.** The alternative was letting the two configs differ by one rule for as long as nobody noticed. A config that is the same file in both places gets read once; a config that differs by a line is one nobody diffs again.

0 lint errors, the same 14 warnings as after #69, and no source change at all.