### PR TITLE
Stop the first-run dots from growing a step

### DIFF
--- a/src/lib/onboarding-flow.test.ts
+++ b/src/lib/onboarding-flow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   stepsFor,
+  plannedStepsFor,
   resolveStep,
   nextStep,
   newestAgent,
@@ -70,6 +71,45 @@ describe("stepsFor", () => {
     // They are joining a workspace that already has agents and bundles. The
     // knowledge they were invited to is somebody else's already.
     expect(stepsFor(ctx({ hasIncomingInvite: true, hasAgent: true }))).not.toContain("knowledge");
+  });
+});
+
+describe("plannedStepsFor", () => {
+  it("does not get longer when the agent is created", () => {
+    // The bug, as one assertion. Walked in a browser: the agent step said
+    // "Step 6 of 7", and creating the agent made it "Step 7 of 8" — the finish
+    // line moved away at the moment the hardest step was finished.
+    const before = plannedStepsFor(ctx({ hasAgent: false }));
+    const after = plannedStepsFor(ctx({ hasAgent: true }));
+    expect(before).toEqual(after);
+  });
+
+  it("counts the knowledge step before there is anything to put in it", () => {
+    // `stepsFor` must not — there is nowhere to put a document until an agent
+    // exists — and that difference is the whole reason there are two functions.
+    expect(stepsFor(ctx({ hasAgent: false }))).not.toContain("knowledge");
+    expect(plannedStepsFor(ctx({ hasAgent: false }))).toContain("knowledge");
+  });
+
+  it("still gets shorter for someone working alone", () => {
+    // Deliberately not fixed. A flow that shortens when you say you are working
+    // alone is a consequence of an answer just given; a step that appears after
+    // you finished one is not.
+    const solo = { ...ANSWERED, teamSize: "solo" };
+    expect(plannedStepsFor(ctx({ answers: solo }))).not.toContain("invite");
+  });
+
+  it("leaves the invited person's much shorter run alone", () => {
+    expect(plannedStepsFor(ctx({ hasIncomingInvite: true }))).toEqual(
+      stepsFor(ctx({ hasIncomingInvite: true })),
+    );
+  });
+
+  it("keeps every step of the real flow, in the same order", () => {
+    // The indicator takes its index from this list, so a step the flow can
+    // reach and the plan does not know about would be `indexOf` === -1.
+    const real = stepsFor(ctx({ hasAgent: true }));
+    expect(plannedStepsFor(ctx({ hasAgent: false }))).toEqual(real);
   });
 });
 

--- a/src/lib/onboarding-flow.ts
+++ b/src/lib/onboarding-flow.ts
@@ -74,11 +74,36 @@ export function stepsFor(ctx: FlowContext): OnboardingStep[] {
   if (ctx.hasIncomingInvite) return [...survey, "invite-accept"];
 
   const setup: OnboardingStep[] = ["workspace", "agent"];
-  // Only once there is somewhere to put a document. The count this changes is
-  // already not fixed — answering "just me" drops the invite step the same way.
+  // Only once there is somewhere to put a document.
   if (ctx.hasAgent) setup.push("knowledge");
   if (ctx.answers.teamSize !== "solo") setup.push("invite");
   return [...survey, ...setup];
+}
+
+/**
+ * The same run, as long as it can turn out to be. What the progress indicator
+ * counts.
+ *
+ * `stepsFor` answers "where does this go next", and `hasAgent` belongs in that
+ * answer: there is nowhere to put a document until an agent exists. It does not
+ * belong in "how long is this", and using one list for both jobs is what made
+ * the dots grow. Walked in a browser on 2026-08-31: the agent step read
+ * **Step 6 of 7**, and creating the agent — the most work anyone does in the
+ * whole flow — made it **Step 7 of 8**. The finish line moved away at the
+ * moment it should have come closer.
+ *
+ * So the count assumes the agent will exist, because from any point at or
+ * before the agent step that is the ordinary outcome. Someone who taps "I'll do
+ * this later" then ends one short of the total, which is the honest shape of
+ * having skipped a step and is nothing like a step appearing out of nowhere.
+ *
+ * `teamSize` is deliberately still allowed to shorten it. That one is a
+ * question the person just answered, and a flow that gets shorter when you say
+ * you are working alone is legible in a way that a step arriving after you
+ * finished one is not.
+ */
+export function plannedStepsFor(ctx: FlowContext): OnboardingStep[] {
+  return stepsFor({ ...ctx, hasAgent: true });
 }
 
 /**

--- a/src/routes/_authed.welcome.tsx
+++ b/src/routes/_authed.welcome.tsx
@@ -8,6 +8,7 @@ import {
   nextStep,
   newestAgent,
   stepsFor,
+  plannedStepsFor,
   type AnswerPatch,
   type OnboardingAnswers,
   type OnboardingStep,
@@ -148,7 +149,10 @@ function Welcome() {
   }
 
   const step = resolveStep(requested, ctx);
+  // Two lists on purpose: `stepsFor` is where the flow goes, `plannedStepsFor`
+  // is how long it is. See the note on plannedStepsFor for why they differ.
   const steps = stepsFor(ctx);
+  const planned = plannedStepsFor(ctx);
 
   const goTo = (next: OnboardingStep | "done") => {
     if (next === "done") {
@@ -192,8 +196,8 @@ function Welcome() {
     <WelcomeLayout
       title={copy.title}
       subtitle={copy.subtitle}
-      stepIndex={Math.max(0, steps.indexOf(step))}
-      stepCount={steps.length}
+      stepIndex={Math.max(0, planned.indexOf(step))}
+      stepCount={planned.length}
     >
       {step === "role" && (
         <QuestionCard


### PR DESCRIPTION
Closes #67. Found in the browser walk (covan-cloud#30).

The agent step read **Step 6 of 7**. Creating the agent — the most work anybody does in the whole flow — made it **Step 7 of 8**. A dot appeared, and the finish line moved further away at the moment it should have come closer.

**One list was doing two jobs.** `stepsFor` answers *where does this go next*, and `hasAgent` belongs in that answer — there is nowhere to put a document until an agent exists, so `knowledge` is genuinely unreachable before one. It does not belong in *how long is this*, and `_authed.welcome.tsx` was handing the same list to the indicator as `stepCount`.

So there are two lists now, and the difference between them is the fix:

```ts
export function plannedStepsFor(ctx: FlowContext): OnboardingStep[] {
  return stepsFor({ ...ctx, hasAgent: true });
}
```

Someone who taps "I'll do this later" on the agent step now ends one short of the total. That is the honest shape of having skipped a step, and it is nothing like a step arriving out of nowhere.

**`teamSize` is still allowed to shorten the flow, and there is a test saying so.** It was tempting to stabilise that too — count the invite step always and skip it silently — but a flow that gets shorter when you say you are working alone is a legible consequence of an answer just given. The growth had no cause the person could see. Only one of the two is a bug.

The indicator takes its `stepIndex` from the same list as its count, or a step the flow can reach but the plan does not know about would be `indexOf === -1`; there is a test for that as well.

354 tests, clean typecheck, 0 lint errors. Mirror to covan-cloud to follow.