### PR TITLE
The mails a product owes you

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -522,10 +522,18 @@ and it is the first thing a new account ever receives.
 `supabase/templates/` holds a styled version of each, rendered from the same
 shell as every other Covan email:
 
-| File                  | Paste into                                   |
-| --------------------- | -------------------------------------------- |
-| `confirm-signup.html` | Authentication → Emails → **Confirm signup** |
-| `reset-password.html` | Authentication → Emails → **Reset password** |
+| File                    | Paste into                                                                                   |
+| ----------------------- | -------------------------------------------------------------------------------------------- |
+| `confirm-signup.html`   | Authentication → Emails → **Confirm signup**                                                 |
+| `reset-password.html`   | Authentication → Emails → **Reset password**                                                 |
+| `password-changed.html` | Authentication → Emails → **Password changed** — and enable it; Supabase ships it turned off |
+
+The third is worth the extra click. It is the only message in the set somebody
+reads in order to discover they have been broken into: a password change nobody
+asked for is the first visible evidence of a stolen session. It carries no link,
+deliberately — it announces something already done, and a credential email with
+a link in it is the exact shape of the phishing this message exists to help
+someone notice.
 
 The subject lines that go with them are in
 `worker/src/lib/emails/auth.ts`. Both files keep Supabase's

--- a/supabase/migrations/0036_a_warning_that_only_arrives_once.sql
+++ b/supabase/migrations/0036_a_warning_that_only_arrives_once.sql
@@ -26,8 +26,6 @@
 -- the same question twice.
 -- =========================================================================
 
-begin;
-
 alter table public.notification_preferences
   add column if not exists quota_warned_for timestamptz;
 
@@ -37,10 +35,13 @@ comment on column public.notification_preferences.quota_warned_for is
 -- The row is written by the API on the caller's behalf, so the existing
 -- own-row insert and update policies from 0015 already cover it. Stated here
 -- rather than assumed, because a column that nothing may write is the failure
--- 0023 exists to explain.
-
-insert into covan_meta.migrations (filename)
-values ('0036_a_warning_that_only_arrives_once.sql')
-on conflict do nothing;
-
-commit;
+-- 0023 exists to explain, and `tests/rls/notification-preferences.test.ts` is
+-- where it is held down.
+--
+-- No `begin`/`commit` and no ledger insert in this file, which is the convention
+-- every migration here follows: `docker/migrate.sh` wraps each file in its own
+-- transaction and records it in `covan_meta.migrations` itself. Doing either
+-- here fails loudly — the transaction warns that one is already in progress, and
+-- the insert violates the ledger's primary key. Applying this to the hosted
+-- database by hand is the case that DOES need both, since there is no script
+-- there; that wrapper belongs in the pasted SQL, not in this file.

--- a/supabase/migrations/0036_a_warning_that_only_arrives_once.sql
+++ b/supabase/migrations/0036_a_warning_that_only_arrives_once.sql
@@ -1,0 +1,46 @@
+-- =========================================================================
+-- A quota warning that only arrives once a period
+--
+-- `0015` gave people two switches for what the routine engine tells them. This
+-- adds the one piece of state a *third* notice needs, and it is state rather
+-- than a switch: the warning fires when an allowance crosses three quarters
+-- spent, which is a condition that stays true for every request afterwards.
+-- Without somewhere to record that it has already been sent, the first message
+-- past the threshold would be followed by one per reply until the month rolled
+-- over.
+--
+-- The column holds the period it warned *for*, not the moment it was sent. The
+-- question being asked is "have I already warned about this allowance", and the
+-- period's own reset time answers it exactly — no arithmetic about month
+-- boundaries, and nothing to get wrong when a period is not a calendar month.
+-- A fresh period brings a different reset time, so the comparison fails and one
+-- warning goes out.
+--
+-- Nullable with no default: null means never warned, which is every row that
+-- exists today and every row a self-hosted Covan will ever have. There is no
+-- allowance to warn about when `QUOTA_MONTHLY_TOKENS` is unset, so this column
+-- simply stays null there.
+--
+-- No new switch to go with it. `quota_exhausted` already means "tell me about
+-- my allowance", and splitting that into two toggles would ask people to answer
+-- the same question twice.
+-- =========================================================================
+
+begin;
+
+alter table public.notification_preferences
+  add column if not exists quota_warned_for timestamptz;
+
+comment on column public.notification_preferences.quota_warned_for is
+  'The reset time of the period a low-quota warning was last sent for. Null means never. Compared for equality against the current period''s reset time, so a new period sends exactly one warning.';
+
+-- The row is written by the API on the caller's behalf, so the existing
+-- own-row insert and update policies from 0015 already cover it. Stated here
+-- rather than assumed, because a column that nothing may write is the failure
+-- 0023 exists to explain.
+
+insert into covan_meta.migrations (filename)
+values ('0036_a_warning_that_only_arrives_once.sql')
+on conflict do nothing;
+
+commit;

--- a/supabase/templates/password-changed.html
+++ b/supabase/templates/password-changed.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<meta name="supported-color-schemes" content="light dark">
+<style>
+  @media (prefers-color-scheme: dark) {
+    /* body as well as the table: the table paints only as far as its own
+       height, so a tall window keeps a band of light paper under a dark mail. */
+    body, .paper { background: #1a1613 !important; }
+    .card { background: #221d19 !important; border-color: #3a322b !important; }
+    .ink, .ink *, .wordmark { color: #f2efe9 !important; }
+    .muted, .muted a { color: #a89e92 !important; }
+    /* DESIGN.md derives the dark ladder in reverse from the same ink and
+       inverts the button fill — which is also the only thing that keeps this
+       button a shape, since an ink fill on a dark card is ink on ink.
+       Ordered after the .ink rule so it wins on the label. */
+    .btn { background: #f2efe9 !important; }
+    .btn-label { color: #221d19 !important; }
+  }
+</style>
+</head>
+<body style="margin:0;padding:0;background:#f7f7f4">
+<div style="display:none;max-height:0;overflow:hidden;opacity:0">The password on your Covan account was just changed.</div>
+<table role="presentation" class="paper" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f7f7f4;padding:32px 16px">
+  <tr>
+    <td align="center">
+      <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:560px">
+        <tr>
+          <td style="padding:0 4px 18px">
+            <!-- The wordmark, with the amber as a 10px square mark: a pointer at
+                 the smallest size the system uses, nowhere near the 44px ceiling. -->
+            <span style="display:inline-block;width:10px;height:10px;background:#f48d16;vertical-align:middle"></span>
+            <span class="wordmark" style="font-family:'DM Sans','Segoe UI',Helvetica,Arial,sans-serif;font-size:17px;font-weight:600;letter-spacing:-0.01em;color:#251f19;vertical-align:middle;padding-left:8px">Covan</span>
+          </td>
+        </tr>
+        <tr>
+          <td class="card ink" style="background:#ffffff;border:1px solid #e8e6dd;border-radius:8px;padding:32px 28px">
+            <h1 style="margin:0 0 18px;font-family:'DM Sans','Segoe UI',Helvetica,Arial,sans-serif;font-size:22px;font-weight:600;line-height:1.25;letter-spacing:-0.01em;color:#251f19">Your password was changed</h1>
+            <div style="font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif"><p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19">The password on your Covan account has just been changed, and the new one is in use from now on.</p><p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19">If that was you, there is nothing to do.</p><p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19"><strong>If it was not you</strong>, somebody else has access to this account. Use "Forgot password" on the sign-in page to take it back — that sends a link to this address, which they cannot read.</p></div>
+            
+            
+          </td>
+        </tr>
+        <tr>
+          <td class="muted" style="padding:18px 4px 0;font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:12px;line-height:1.5;color:#6b6157">
+            Sent by Covan · <a href="https://covan.app" style="color:#6b6157">covan.app</a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/tests/rls/notification-preferences.test.ts
+++ b/tests/rls/notification-preferences.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+import { closeSql, createTestUser, destroyTestUsers, type TestUser } from "./harness";
+
+/*
+ * Who may write the row that decides which notices somebody gets.
+ *
+ * `0015` created this table with three own-row policies and no test, which was
+ * survivable while every column on it was a switch the person themselves flipped
+ * on a settings screen. `0036` changes that: `quota_warned_for` is written by
+ * the API on the caller's behalf, in the middle of a chat request, to record
+ * that a warning has already gone out.
+ *
+ * That makes two things worth holding down. The column has to be writable at all
+ * — a column nothing may write is the failure `0023` exists to explain, and it
+ * would show up here as a warning that fires once per reply forever, because the
+ * stamp that suppresses it never lands. And it has to stay writable by its owner
+ * only, or one person could suppress another's warning by stamping a period they
+ * are not in.
+ *
+ * The suite drives a real Postgres through PostgREST, so what passes here is
+ * what the Worker's request-scoped client actually gets.
+ */
+
+const PERIOD = "2026-10-01T00:00:00.000Z";
+
+let alice: TestUser;
+let bob: TestUser;
+
+beforeAll(async () => {
+  alice = await createTestUser("prefs-alice");
+  bob = await createTestUser("prefs-bob");
+});
+
+afterAll(async () => {
+  await destroyTestUsers();
+  await closeSql();
+});
+
+describe("notification_preferences", () => {
+  it("lets somebody stamp their own quota warning", async () => {
+    const { error } = await alice.client
+      .from("notification_preferences")
+      .upsert({ user_id: alice.id, quota_warned_for: PERIOD }, { onConflict: "user_id" });
+
+    expect(error).toBeNull();
+
+    const { data } = await alice.client
+      .from("notification_preferences")
+      .select("quota_warned_for")
+      .eq("user_id", alice.id)
+      .maybeSingle();
+
+    expect(data?.quota_warned_for).toBe(PERIOD);
+  });
+
+  // The row is keyed by user_id and the insert policy checks it against
+  // auth.uid(), so this is refused rather than silently written — if it were
+  // not, suppressing somebody else's warning would be one request away.
+  it("refuses to stamp somebody else's", async () => {
+    const { error } = await bob.client
+      .from("notification_preferences")
+      .upsert({ user_id: alice.id, quota_warned_for: PERIOD }, { onConflict: "user_id" });
+
+    expect(error).not.toBeNull();
+  });
+
+  // A missing row is the normal state — nobody has one until something writes
+  // it — and it has to keep meaning "every notice is on".
+  it("has no row until something writes one", async () => {
+    const { data, error } = await bob.client
+      .from("notification_preferences")
+      .select("user_id")
+      .eq("user_id", bob.id)
+      .maybeSingle();
+
+    expect(error).toBeNull();
+    expect(data).toBeNull();
+  });
+});

--- a/tests/rls/notification-preferences.test.ts
+++ b/tests/rls/notification-preferences.test.ts
@@ -39,36 +39,60 @@ afterAll(async () => {
 
 describe("notification_preferences", () => {
   it("lets somebody stamp their own quota warning", async () => {
-    const { error } = await alice.client
+    const { error } = await alice.db
       .from("notification_preferences")
       .upsert({ user_id: alice.id, quota_warned_for: PERIOD }, { onConflict: "user_id" });
 
     expect(error).toBeNull();
 
-    const { data } = await alice.client
+    const { data } = await alice.db
       .from("notification_preferences")
       .select("quota_warned_for")
       .eq("user_id", alice.id)
       .maybeSingle();
 
-    expect(data?.quota_warned_for).toBe(PERIOD);
+    // Compared as an instant: the column is a timestamptz and PostgREST spells
+    // it back as "+00:00" rather than the "Z" it was written with.
+    expect(Date.parse(String(data?.quota_warned_for))).toBe(Date.parse(PERIOD));
   });
 
-  // The row is keyed by user_id and the insert policy checks it against
-  // auth.uid(), so this is refused rather than silently written — if it were
-  // not, suppressing somebody else's warning would be one request away.
-  it("refuses to stamp somebody else's", async () => {
-    const { error } = await bob.client
+  /**
+   * Asserted on the outcome rather than on the refusal.
+   *
+   * Whether this comes back as an error or as zero rows affected depends on
+   * which half of the upsert Postgres reaches: an insert trips the WITH CHECK,
+   * while a conflict turns it into an update whose USING clause matches nothing.
+   * Both are correct and the test should not care which happened — what it has
+   * to hold down is that Alice's stamp did not move, because a stamp somebody
+   * else can write is a warning somebody else can suppress.
+   */
+  it("does not let one person stamp another's", async () => {
+    await alice.db
       .from("notification_preferences")
       .upsert({ user_id: alice.id, quota_warned_for: PERIOD }, { onConflict: "user_id" });
 
-    expect(error).not.toBeNull();
+    await bob.db
+      .from("notification_preferences")
+      .upsert(
+        { user_id: alice.id, quota_warned_for: "2027-01-01T00:00:00.000Z" },
+        { onConflict: "user_id" },
+      );
+
+    const { data } = await alice.db
+      .from("notification_preferences")
+      .select("quota_warned_for")
+      .eq("user_id", alice.id)
+      .maybeSingle();
+
+    // Compared as an instant: the column is a timestamptz and PostgREST spells
+    // it back as "+00:00" rather than the "Z" it was written with.
+    expect(Date.parse(String(data?.quota_warned_for))).toBe(Date.parse(PERIOD));
   });
 
   // A missing row is the normal state — nobody has one until something writes
   // it — and it has to keep meaning "every notice is on".
   it("has no row until something writes one", async () => {
-    const { data, error } = await bob.client
+    const { data, error } = await bob.db
       .from("notification_preferences")
       .select("user_id")
       .eq("user_id", bob.id)

--- a/worker/src/lib/emails/auth.test.ts
+++ b/worker/src/lib/emails/auth.test.ts
@@ -13,19 +13,37 @@ import { authEmailTemplates } from "./auth";
  * is what stops those files drifting from this source.
  */
 describe("authEmailTemplates", () => {
-  it("covers the two flows the app actually uses", () => {
+  it("covers the flows the app actually uses", () => {
     expect(authEmailTemplates.map((t) => t.filename)).toEqual([
       "confirm-signup.html",
       "reset-password.html",
+      "password-changed.html",
     ]);
   });
 
-  // Supabase substitutes these server-side. Get the name wrong and the button
+  // Supabase substitutes this server-side. Get the name wrong and the button
   // renders as an empty href — a mail that looks finished and goes nowhere.
-  it("gives every template a working confirmation link", () => {
-    for (const template of authEmailTemplates) {
-      expect(template.html, template.filename).toContain("{{ .ConfirmationURL }}");
-    }
+  it.each(["confirm-signup.html", "reset-password.html"])(
+    "%s asks somebody to follow a link, so it carries one",
+    (filename) => {
+      const template = authEmailTemplates.find((t) => t.filename === filename);
+      expect(template?.html).toContain("{{ .ConfirmationURL }}");
+    },
+  );
+
+  /**
+   * The odd one out, and on purpose.
+   *
+   * A password-changed notice announces something already done — there is
+   * nothing to confirm. It is also the message a person reads at the exact
+   * moment they suspect they have been broken into, which is the worst possible
+   * moment to have taught them that Covan puts credential links in email. So it
+   * names the sign-in page's own "Forgot password" instead of linking anywhere.
+   */
+  it("puts no link in the message about a password that already changed", () => {
+    const changed = authEmailTemplates.find((t) => t.filename === "password-changed.html");
+    expect(changed?.html).not.toContain("{{ .ConfirmationURL }}");
+    expect(changed?.html).toContain("Forgot password");
   });
 
   it("renders each one in the Covan shell", () => {

--- a/worker/src/lib/emails/auth.ts
+++ b/worker/src/lib/emails/auth.ts
@@ -54,4 +54,27 @@ export const authEmailTemplates = [
         "If this was not you, ignore this message — your password has not changed and nobody was let in.",
     }),
   },
+  {
+    // Supabase can send this and does not by default: it is
+    // `auth.email.notification.password_changed`, off until somebody turns it
+    // on. Worth turning on. It is the only message in the whole set that a
+    // person reads in order to find out they have been broken into — a password
+    // change nobody asked for is the first evidence of a stolen session, and
+    // silence there is the difference between an hour and a month.
+    //
+    // No button, and deliberately: it announces something already done. A link
+    // in a mail about credentials is also exactly the shape of the phishing this
+    // message would otherwise help somebody fall for.
+    filename: "password-changed.html",
+    subject: "Your Covan password was changed",
+    html: emailShell({
+      preheader: "The password on your Covan account was just changed.",
+      heading: "Your password was changed",
+      bodyHtml: [
+        `<p style="${P}">The password on your Covan account has just been changed, and the new one is in use from now on.</p>`,
+        `<p style="${P}">If that was you, there is nothing to do.</p>`,
+        `<p style="${P}"><strong>If it was not you</strong>, somebody else has access to this account. Use "Forgot password" on the sign-in page to take it back — that sends a link to this address, which they cannot read.</p>`,
+      ].join(""),
+    }),
+  },
 ];

--- a/worker/src/lib/emails/closed.ts
+++ b/worker/src/lib/emails/closed.ts
@@ -1,0 +1,46 @@
+import { emailShell } from "../email-layout";
+import { paragraphs } from "./prose";
+
+/**
+ * The receipt for a closed account.
+ *
+ * The only message here that is sent to somebody who no longer has an account,
+ * and the reason it exists: everything else about this action disappears with
+ * it. There is no row left to check, no screen to return to, and no way to sign
+ * in and confirm. Under the KVKK and the GDPR the erasure is the obligation and
+ * a record of it is what makes the obligation demonstrable — to the person first
+ * and to an auditor second.
+ *
+ * It promises only what the route actually did. Workspaces that survived because
+ * somebody else is still in them are not named: the person is gone from them,
+ * which is the part that concerns them, and listing rooms they can no longer see
+ * would be a strange last thing to send.
+ */
+export function accountClosedEmail(args: { email: string }) {
+  return {
+    to: args.email,
+    subject: "Your Covan account is closed",
+    text: [
+      "Your Covan account has been deleted.",
+      "",
+      "Gone with it: your profile, your conversations, the agents and documents",
+      "of any workspace nobody else was in, and the files behind them.",
+      "",
+      "Kept, deliberately: messages you wrote in a workspace that other people",
+      "are still using. They stay so the conversation still reads, with your",
+      "name detached from them.",
+      "",
+      "There is nothing left to sign in to, and this address can be used to",
+      "start again from scratch whenever you like.",
+    ].join("\n"),
+    html: emailShell({
+      preheader: "Your Covan account has been deleted.",
+      heading: "Your account is closed",
+      bodyHtml: paragraphs(
+        "<strong>Gone with it:</strong> your profile, your conversations, the agents and documents of any workspace nobody else was in, and the files behind them.",
+        "<strong>Kept, deliberately:</strong> messages you wrote in a workspace other people are still using. They stay so the conversation still reads, with your name detached from them.",
+        "There is nothing left to sign in to, and this address can be used to start again from scratch whenever you like.",
+      ),
+    }),
+  };
+}

--- a/worker/src/lib/emails/invitation.ts
+++ b/worker/src/lib/emails/invitation.ts
@@ -1,0 +1,70 @@
+import { emailShell } from "../email-layout";
+import { escapeHtml } from "../escape-html";
+import { paragraphs } from "./prose";
+
+/**
+ * The invitation email.
+ *
+ * Deliberately not a link that accepts anything. Acceptance runs through
+ * `accept_invitation`, which matches the invitation's email against the
+ * caller's verified JWT email — so the address IS the credential, and a token
+ * in a URL would be a second, weaker one guarding the same door. What the
+ * recipient needs to know is which address to use; that is what this says.
+ *
+ * Two halves, not two mails. The text below was the whole message for as long as
+ * this route existed, on the reasoning that an HTML mail which renders as a
+ * blank card in a client that strips styles is worse than no HTML at all. That
+ * reasoning still holds and is why `text` is unchanged and still says
+ * everything: the HTML is an addition Resend carries in the same request, and a
+ * client that drops it falls back to prose that was never a fallback.
+ */
+export function invitationEmail(args: {
+  workspaceName: string;
+  inviterName: string;
+  role: string;
+  email: string;
+  appUrl: string;
+}) {
+  const asRole = args.role === "admin" ? "an admin" : "a member";
+  return {
+    to: args.email,
+    subject: `${args.inviterName} invited you to ${args.workspaceName} on Covan`,
+    // Hard-wrapped, and every interpolated value sits on a line of its own —
+    // an address or a workspace name in the middle of a sentence pushes the
+    // wrap around and turns a tidy paragraph into a ragged one for exactly the
+    // people whose names are longest.
+    text: [
+      `${args.inviterName} invited you to join ${args.workspaceName} on Covan,`,
+      `as ${asRole}.`,
+      "",
+      "Covan is where a team keeps its AI agents: the agents and the knowledge",
+      "they read are shared, and your own conversations stay yours.",
+      "",
+      "To accept, sign in and the invitation will be waiting:",
+      "",
+      `  ${args.appUrl}`,
+      "",
+      "Sign in with the address this was sent to:",
+      "",
+      `  ${args.email}`,
+      "",
+      "If you do not have an account yet, sign up with that same address — it is",
+      "what the invitation is matched to, so a different one will not find it.",
+      "",
+      "If you were not expecting this, you can ignore it. Nothing happens until",
+      "you accept.",
+    ].join("\n"),
+    html: emailShell({
+      preheader: `${args.inviterName} invited you to ${args.workspaceName} on Covan.`,
+      heading: `${args.inviterName} invited you to ${args.workspaceName}`,
+      bodyHtml: paragraphs(
+        `You have been invited as ${asRole}.`,
+        "Covan is where a team keeps its AI agents: the agents and the knowledge they read are shared, and your own conversations stay yours.",
+        `Sign in with <strong>${escapeHtml(args.email)}</strong> — that address is what the invitation is matched to, so a different one will not find it. If you do not have an account yet, sign up with that same address.`,
+      ),
+      action: { label: "Sign in to accept", url: args.appUrl },
+      footnote:
+        "If you were not expecting this, you can ignore it. Nothing happens until you accept.",
+    }),
+  };
+}

--- a/worker/src/lib/emails/joined.ts
+++ b/worker/src/lib/emails/joined.ts
@@ -1,0 +1,49 @@
+import { emailShell } from "../email-layout";
+import { escapeHtml } from "../escape-html";
+import { paragraphs } from "./prose";
+
+/**
+ * "They accepted" — sent to whoever did the inviting.
+ *
+ * An invitation is the one thing in this product that finishes somewhere other
+ * than where it started. The admin sends it and then has no way of knowing
+ * whether it worked: the pending list *empties* on acceptance, so the only
+ * visible trace of success is an absence, which reads exactly like the mail
+ * having been ignored.
+ *
+ * The person is named by the address the invitation went to rather than by the
+ * name on their profile. That address is the thing the inviter typed and the
+ * thing they will recognise; a display name they have never seen answers a
+ * question nobody asked.
+ */
+export function joinedEmail(args: {
+  inviterEmail: string;
+  joinerEmail: string;
+  workspaceName: string;
+  appUrl: string;
+}) {
+  return {
+    to: args.inviterEmail,
+    subject: `${args.joinerEmail} joined ${args.workspaceName}`,
+    text: [
+      `${args.joinerEmail} accepted your invitation and is now in`,
+      `${args.workspaceName}.`,
+      "",
+      "They can see the workspace's agents and everything those agents read.",
+      "Their own conversations are private to them, the same as yours.",
+      "",
+      "The team list is here:",
+      "",
+      `  ${args.appUrl}/team`,
+    ].join("\n"),
+    html: emailShell({
+      preheader: `${args.joinerEmail} accepted your invitation.`,
+      heading: `${args.joinerEmail} joined ${args.workspaceName}`,
+      bodyHtml: paragraphs(
+        `They accepted your invitation and are now in <strong>${escapeHtml(args.workspaceName)}</strong>.`,
+        "They can see the workspace's agents and everything those agents read. Their own conversations are private to them, the same as yours.",
+      ),
+      action: { label: "See the team", url: `${args.appUrl}/team` },
+    }),
+  };
+}

--- a/worker/src/lib/emails/membership.ts
+++ b/worker/src/lib/emails/membership.ts
@@ -1,0 +1,85 @@
+import { emailShell } from "../email-layout";
+import { escapeHtml } from "../escape-html";
+import { paragraphs } from "./prose";
+
+/**
+ * The two notes a person gets when somebody else changes what they may do.
+ *
+ * Both exist for the same reason. Losing a workspace, or being moved to a role
+ * that cannot write, is not self-announcing: the product simply behaves
+ * differently the next time it is opened — colleagues' agents are gone, or a
+ * save comes back refused with no visible cause. Every other silent capability
+ * change in this codebase has been treated as a bug worth fixing, and these are
+ * the two the interface still made silently.
+ *
+ * Neither carries a button. There is nothing to click that would undo it, and a
+ * link into a workspace somebody has just been removed from would be a door that
+ * refuses them a second time.
+ */
+export function removedFromWorkspaceEmail(args: { email: string; workspaceName: string }) {
+  return {
+    to: args.email,
+    subject: `You were removed from ${args.workspaceName} on Covan`,
+    text: [
+      `You no longer have access to ${args.workspaceName} on Covan.`,
+      "",
+      "Its agents and the documents they read are no longer visible to you, and",
+      "any API keys you had stop working with it at the same moment.",
+      "",
+      "Your account itself is untouched: other workspaces you belong to still",
+      "work, and your own conversations are still yours.",
+      "",
+      "If this was not expected, the people to ask are that workspace's admins.",
+    ].join("\n"),
+    html: emailShell({
+      preheader: `You no longer have access to ${args.workspaceName}.`,
+      heading: `You were removed from ${args.workspaceName}`,
+      bodyHtml: paragraphs(
+        "Its agents and the documents they read are no longer visible to you, and any API keys you had stop working with it at the same moment.",
+        "Your account itself is untouched: other workspaces you belong to still work, and your own conversations are still yours.",
+        "If this was not expected, the people to ask are that workspace's admins.",
+      ),
+    }),
+  };
+}
+
+/**
+ * A role change, described by what it lets somebody do rather than by its name.
+ *
+ * "You are now a viewer" means nothing to a person who has never read the docs.
+ * What they need is the sentence after it, which is why each role carries its
+ * own — and why the viewer line leads with what still works, since that is the
+ * role people are most likely to read as a demotion and a shut door.
+ */
+const WHAT_IT_MEANS: Record<string, string> = {
+  admin:
+    "As an admin you can invite and remove people, change roles, and edit anything the workspace holds.",
+  member:
+    "As a member you can create and change agents, upload documents, and set up routines — everything except managing who is in the workspace.",
+  viewer:
+    "As a viewer you can still chat with every agent, ask about every document, and keep your own conversations and routines. What you cannot do is change the things the workspace shares: agents, uploads and the ideas board are read-only for you now.",
+};
+
+export function roleChangedEmail(args: { email: string; workspaceName: string; role: string }) {
+  const meaning = WHAT_IT_MEANS[args.role] ?? `Your role in this workspace is now ${args.role}.`;
+  return {
+    to: args.email,
+    subject: `Your role in ${args.workspaceName} changed`,
+    text: [
+      `An admin changed your role in ${args.workspaceName} to ${args.role}.`,
+      "",
+      meaning,
+      "",
+      "If this was not expected, the people to ask are that workspace's admins.",
+    ].join("\n"),
+    html: emailShell({
+      preheader: `You are now ${args.role} in ${args.workspaceName}.`,
+      heading: `Your role in ${args.workspaceName} changed`,
+      bodyHtml: paragraphs(
+        `An admin changed your role to <strong>${escapeHtml(args.role)}</strong>.`,
+        meaning,
+        "If this was not expected, the people to ask are that workspace's admins.",
+      ),
+    }),
+  };
+}

--- a/worker/src/lib/emails/prose.ts
+++ b/worker/src/lib/emails/prose.ts
@@ -1,0 +1,20 @@
+/**
+ * The body of a hand-written email.
+ *
+ * Every message in this folder is our own prose rather than a model's, so none
+ * of them goes through `email-markdown` — there is nothing to parse and nothing
+ * untrusted to escape. What they do share is the paragraph rule, which has to be
+ * inline for the same reason every other rule in `email-layout` is: a mail
+ * client is allowed to drop a `<style>` block, and several do.
+ *
+ * Interpolated values are the exception. A workspace name or somebody's own name
+ * is whatever they typed into a form, so it passes through `escapeHtml` at the
+ * call site — the shell escapes what it is handed as text, and this helper is
+ * handed HTML.
+ */
+export const P = "margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19";
+
+/** Wrap each already-HTML fragment in the shared paragraph rule. */
+export function paragraphs(...html: string[]): string {
+  return html.map((line) => `<p style="${P}">${line}</p>`).join("");
+}

--- a/worker/src/lib/emails/quota.ts
+++ b/worker/src/lib/emails/quota.ts
@@ -1,0 +1,65 @@
+import { emailShell } from "../email-layout";
+import { paragraphs } from "./prose";
+
+/**
+ * The allowance is running low.
+ *
+ * Written in replies rather than tokens, because nobody budgets in tokens. The
+ * conversion is deliberately rough and says so: what a reply costs varies by
+ * more than an order of magnitude between a bare question and a long
+ * conversation grounded in uploads, so a precise-looking number here would be a
+ * worse lie than an approximate one. `src/lib/quota.ts` does the same sum on
+ * screen using the person's own measured average; this has no such average to
+ * hand, so it rounds to something honest.
+ *
+ * No alarm. The allowance resets on its own, running out is not a failure, and
+ * a mail that reads like an incident about a number that fixes itself would
+ * teach people to ignore the next one.
+ */
+const ASSUMED_TOKENS_PER_REPLY = 3700;
+
+export function quotaLowEmail(args: {
+  email: string;
+  used: number;
+  limit: number;
+  resetsAt: string;
+  appUrl: string;
+}) {
+  const left = Math.max(0, Math.floor((args.limit - args.used) / ASSUMED_TOKENS_PER_REPLY));
+  const resets = new Date(args.resetsAt).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "long",
+  });
+
+  const roughly =
+    left === 0
+      ? "That is enough for very little else this period."
+      : `That leaves roughly ${left} more ${left === 1 ? "reply" : "replies"}, depending on how much your agents are asked to read.`;
+
+  return {
+    to: args.email,
+    subject: "Your Covan allowance is running low",
+    text: [
+      `You have used about three quarters of this period's allowance.`,
+      "",
+      roughly,
+      "",
+      `It resets on ${resets}, and nothing is lost in the meantime — your`,
+      "agents, documents and conversations all stay exactly as they are.",
+      "",
+      "If you would rather not hear about this, the switch is in Settings under",
+      "notifications.",
+    ].join("\n"),
+    html: emailShell({
+      preheader: `About three quarters spent. Resets on ${resets}.`,
+      heading: "Your allowance is running low",
+      bodyHtml: paragraphs(
+        "You have used about three quarters of this period's allowance.",
+        roughly,
+        `It resets on <strong>${resets}</strong>, and nothing is lost in the meantime — your agents, documents and conversations all stay exactly as they are.`,
+        "If you would rather not hear about this, the switch is in Settings under notifications.",
+      ),
+      action: { label: "Open Covan", url: args.appUrl },
+    }),
+  };
+}

--- a/worker/src/lib/emails/send.ts
+++ b/worker/src/lib/emails/send.ts
@@ -1,0 +1,52 @@
+import type { Context } from "hono";
+import type { AppEnv } from "../../types";
+import { deferred } from "../defer";
+import { canSendEmail, sendEmail, type Email } from "../email";
+
+/**
+ * Send a courtesy email without making the request wait for it, or depend on it.
+ *
+ * Every caller of this is a route that has already done the thing the email is
+ * about: somebody has been removed, an account has been closed, a person has
+ * joined. The message is a courtesy, and a courtesy must not be able to fail the
+ * operation it describes — nor delay a response while Resend is slow. So this
+ * checks configuration, defers past the response, and swallows the outcome.
+ *
+ * `deferred` is what makes that safe on Workers, where work started and not
+ * awaited can be cancelled the moment the response is sent.
+ *
+ * Note what this is NOT for: the invitation email answers `emailed` in its
+ * response so the dialog can say what happened, and the routine delivery IS the
+ * run rather than a courtesy about it. Both of those wait, and both belong on
+ * `sendEmail` directly.
+ */
+export function notify(c: Context<AppEnv>, email: Email): void {
+  if (!canSendEmail(c.env)) return;
+
+  deferred(
+    c,
+    sendEmail(email, {
+      fetchImpl: fetch.bind(globalThis),
+      apiKey: c.env.RESEND_API_KEY as string,
+      from: c.env.RESEND_FROM as string,
+    }),
+  );
+}
+
+/**
+ * The origin to put in a link.
+ *
+ * `ALLOWED_ORIGIN` is a comma-separated list, because a deployment reachable at
+ * more than one origin sets several. The first is the canonical one, and putting
+ * the raw variable in a mail would send somebody a URL with a comma in it.
+ *
+ * `c.env?` for the same reason `canSendEmail` takes an optional env: Hono hands
+ * a handler an undefined `env` when no bindings are supplied, which is every
+ * route test in this Worker and also a deployment that configures no mail. This
+ * is usually evaluated as an argument to a message builder, so it runs *before*
+ * `notify` gets to decline — reading through an undefined env here turned a
+ * working route into a 500.
+ */
+export function appUrlOf(c: Context<AppEnv>): string {
+  return (c.env?.ALLOWED_ORIGIN ?? "").split(",")[0].trim();
+}

--- a/worker/src/lib/emails/welcome.ts
+++ b/worker/src/lib/emails/welcome.ts
@@ -1,0 +1,60 @@
+import { emailShell } from "../email-layout";
+import { paragraphs } from "./prose";
+
+/**
+ * The welcome email, sent when somebody finishes their first run.
+ *
+ * Not sent on confirmation, because there is no hook for it: Supabase sends the
+ * confirmation mail and nothing tells this Worker when the link was clicked.
+ * Finishing onboarding is the better moment anyway — by then the person has a
+ * workspace and has answered what they want Covan for, so this can say what to
+ * do next instead of only saying hello.
+ *
+ * What it does NOT do is sell anything or start a sequence. Every other message
+ * this product sends is transactional — something happened, here it is — and one
+ * marketing email in that set would be the one that teaches people to ignore the
+ * rest.
+ */
+export function welcomeEmail(args: { email: string; appUrl: string }) {
+  return {
+    to: args.email,
+    subject: "Welcome to Covan",
+    text: [
+      "Your workspace is ready.",
+      "",
+      "Covan works best once an agent has something to read. Three steps get",
+      "you there:",
+      "",
+      "  1. Upload what your team already relies on — a handbook, a policy, a",
+      "     deck. Covan reads it and cites it in answers.",
+      "  2. Give an agent a persona. 'You are our senior support lead' is",
+      "     enough; it will answer like one.",
+      "  3. Invite the people who will ask it things. The agents and their",
+      "     knowledge are shared; each person's conversations stay their own.",
+      "",
+      "Open Covan:",
+      "",
+      `  ${args.appUrl}`,
+      "",
+      "If an answer is ever wrong, the fix is usually a document rather than a",
+      "prompt — add it, and every teammate's next answer improves too.",
+    ].join("\n"),
+    html: emailShell({
+      preheader: "Your workspace is ready — here is how to make an agent useful.",
+      heading: "Your workspace is ready",
+      bodyHtml:
+        paragraphs(
+          "Covan works best once an agent has something to read. Three steps get you there:",
+        ) +
+        `<ol style="margin:0 0 16px;padding-left:20px">
+          <li style="margin:0 0 8px;font-size:15px;line-height:1.55;color:#251f19"><strong>Upload what your team already relies on</strong> — a handbook, a policy, a deck. Covan reads it and cites it in answers.</li>
+          <li style="margin:0 0 8px;font-size:15px;line-height:1.55;color:#251f19"><strong>Give an agent a persona.</strong> "You are our senior support lead" is enough; it will answer like one.</li>
+          <li style="margin:0 0 8px;font-size:15px;line-height:1.55;color:#251f19"><strong>Invite the people who will ask it things.</strong> The agents and their knowledge are shared; each person's conversations stay their own.</li>
+        </ol>` +
+        paragraphs(
+          "If an answer is ever wrong, the fix is usually a document rather than a prompt — add it, and every teammate's next answer improves too.",
+        ),
+      action: { label: "Open Covan", url: args.appUrl },
+    }),
+  };
+}

--- a/worker/src/lib/entitlements/guard.ts
+++ b/worker/src/lib/entitlements/guard.ts
@@ -1,5 +1,7 @@
 import type { Context } from "hono";
 import type { AppEnv } from "../../types";
+import { deferred } from "../defer";
+import { warnIfLow } from "./warn";
 
 /**
  * Pre-flight check for a route that is about to spend tokens.
@@ -51,4 +53,16 @@ export async function recordQuota(c: Context<AppEnv>, tokens: number): Promise<v
   } catch (err) {
     console.error("failed to record token usage", err);
   }
+
+  // Here rather than in each of the six routes that spend: this function is
+  // already the one thing they all call afterwards, and a seventh paid endpoint
+  // added a year from now gets the warning without anybody remembering to wire
+  // it. `warnIfLow` returns before it reads anything when there is no allowance,
+  // which is every self-hosted deployment.
+  //
+  // Deferred rather than awaited. On a metered deployment this is a snapshot and
+  // a preferences read, and awaiting it would put two queries between the last
+  // token of a reply and the person seeing it — on every reply, to send at most
+  // one message a month.
+  deferred(c, warnIfLow(c));
 }

--- a/worker/src/lib/entitlements/warn.test.ts
+++ b/worker/src/lib/entitlements/warn.test.ts
@@ -102,6 +102,25 @@ describe("warnIfLow", () => {
     expect(sent).toEqual([]);
   });
 
+  /**
+   * The stamp comes back in Postgres's spelling, not ours.
+   *
+   * `quota_warned_for` is a `timestamptz`. It is written from `toISOString()`
+   * — `2026-10-01T00:00:00.000Z` — and PostgREST hands it back as
+   * `2026-10-01T00:00:00+00:00`. Same instant, different string, so comparing
+   * the two as text is always false and the warning fires on every reply for
+   * the rest of the period: exactly the behaviour `0036` exists to prevent,
+   * reintroduced by the check that reads it.
+   */
+  it("recognises its own stamp in the format the database returns it", async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    captureSends(sent);
+
+    await warnIfLow(ctx({ used: 900, limit: 1000, warnedFor: "2026-10-01T00:00:00+00:00", sent }));
+
+    expect(sent).toEqual([]);
+  });
+
   it("warns again once the period has rolled over", async () => {
     const sent: Array<Record<string, unknown>> = [];
     captureSends(sent);

--- a/worker/src/lib/entitlements/warn.test.ts
+++ b/worker/src/lib/entitlements/warn.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import { warnIfLow, WARN_AT } from "./warn";
+
+/**
+ * The warning that arrives before the allowance is gone.
+ *
+ * Until this existed the first thing anybody heard about their quota was a
+ * refusal — `guardQuota` answering 402 in the middle of a conversation. The
+ * screen has shown a "low" state at three quarters spent since `lib/quota.ts`
+ * was written; this is the same threshold, said out loud, once.
+ *
+ * `WARN_AT` is imported rather than repeated so the two cannot drift into
+ * disagreeing about what "low" means.
+ */
+const PERIOD = "2026-10-01T00:00:00.000Z";
+
+function ctx(options: {
+  used: number;
+  limit: number | null;
+  warnedFor?: string | null;
+  quotaExhausted?: boolean;
+  sent?: Array<Record<string, unknown>>;
+  upserts?: Array<Record<string, unknown>>;
+}) {
+  const prefs = {
+    quota_exhausted: options.quotaExhausted ?? true,
+    quota_warned_for: options.warnedFor ?? null,
+  };
+
+  const db = {
+    from: () => ({
+      select: () => ({
+        eq: () => ({ maybeSingle: async () => ({ data: prefs, error: null }) }),
+      }),
+      upsert: async (values: Record<string, unknown>) => {
+        options.upserts?.push(values);
+        return { error: null };
+      },
+    }),
+  };
+
+  return {
+    env: {
+      RESEND_API_KEY: "re_test",
+      RESEND_FROM: "Covan <x@y.z>",
+      ALLOWED_ORIGIN: "https://c.app",
+    },
+    get: (key: string) =>
+      key === "user"
+        ? { id: "u1", email: "someone@example.com" }
+        : key === "db"
+          ? db
+          : {
+              snapshot: async () => ({
+                used: options.used,
+                limit: options.limit,
+                resetsAt: PERIOD,
+              }),
+            },
+  } as never;
+}
+
+function captureSends(sent: Array<Record<string, unknown>>) {
+  vi.spyOn(globalThis, "fetch").mockImplementation((async (_i: unknown, init?: RequestInit) => {
+    sent.push(JSON.parse(String(init?.body)));
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch);
+}
+
+describe("warnIfLow", () => {
+  it("warns once the allowance is mostly spent", async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    const upserts: Array<Record<string, unknown>> = [];
+    captureSends(sent);
+
+    await warnIfLow(ctx({ used: Math.ceil(1000 * WARN_AT), limit: 1000, sent, upserts }));
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toEqual(["someone@example.com"]);
+    // The period is stamped so the next reply does not send a second one.
+    expect(upserts[0]).toMatchObject({ user_id: "u1", quota_warned_for: PERIOD });
+  });
+
+  it("stays quiet while there is plenty left", async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    captureSends(sent);
+
+    await warnIfLow(ctx({ used: 100, limit: 1000, sent }));
+
+    expect(sent).toEqual([]);
+  });
+
+  // The condition stays true for every request after the threshold, which is
+  // exactly why the stamp exists: without it the warning becomes one message
+  // per reply until the period rolls over.
+  it("does not warn twice in the same period", async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    captureSends(sent);
+
+    await warnIfLow(ctx({ used: 900, limit: 1000, warnedFor: PERIOD, sent }));
+
+    expect(sent).toEqual([]);
+  });
+
+  it("warns again once the period has rolled over", async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    captureSends(sent);
+
+    await warnIfLow(ctx({ used: 900, limit: 1000, warnedFor: "2026-09-01T00:00:00.000Z", sent }));
+
+    expect(sent).toHaveLength(1);
+  });
+
+  // `limit: null` is what the open build's `unlimitedEntitlements` answers. A
+  // self-hosted Covan brings its own OpenAI key and has no allowance to warn
+  // about, so this whole feature has to be silent there.
+  it("says nothing when there is no allowance at all", async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    captureSends(sent);
+
+    await warnIfLow(ctx({ used: 999_999, limit: null, sent }));
+
+    expect(sent).toEqual([]);
+  });
+
+  // One question, one switch. `quota_exhausted` already means "tell me about my
+  // allowance"; asking people to answer that twice would be the design mistake.
+  it("respects the switch that already governs quota notices", async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    captureSends(sent);
+
+    await warnIfLow(ctx({ used: 900, limit: 1000, quotaExhausted: false, sent }));
+
+    expect(sent).toEqual([]);
+  });
+});

--- a/worker/src/lib/entitlements/warn.ts
+++ b/worker/src/lib/entitlements/warn.ts
@@ -1,0 +1,75 @@
+import type { Context } from "hono";
+import type { AppEnv } from "../../types";
+import { quotaLowEmail } from "../emails/quota";
+import { appUrlOf, notify } from "../emails/send";
+
+/**
+ * How spent an allowance has to be before it is worth saying so.
+ *
+ * The same three quarters `src/lib/quota.ts` has used to render its "low" state
+ * since it was written. One number for one idea: a screen that says low while a
+ * mailbox stays silent, or the reverse, is two different answers to "am I about
+ * to run out".
+ */
+export const WARN_AT = 0.75;
+
+/**
+ * Say something before the allowance is gone, once per period.
+ *
+ * Until this existed the first news anybody had of their quota was `guardQuota`
+ * answering 402 in the middle of a conversation — a refusal is a poor way to
+ * learn a limit exists. This is the same event announced early enough to do
+ * something about.
+ *
+ * Three properties, and all three are the point:
+ *
+ * - **Once.** Being over the threshold stays true for every request afterwards,
+ *   so a message per reply is what the naive version does. `quota_warned_for`
+ *   holds the period this already fired for and is compared for equality — a
+ *   new period brings a new reset time, so exactly one warning goes out.
+ * - **Silent when unmetered.** `limit: null` is what the open build's
+ *   `unlimitedEntitlements` answers. A self-hosted Covan brings its own OpenAI
+ *   key and has no allowance, so there is nothing to warn about and this returns
+ *   before it reads anything.
+ * - **Never throws.** It is called after the work is done and the reply is on
+ *   its way. Every failure path here is a message not sent, never a request
+ *   turned into an error.
+ */
+export async function warnIfLow(c: Context<AppEnv>): Promise<void> {
+  try {
+    const user = c.get("user");
+    if (!user?.email) return;
+
+    const { used, limit, resetsAt } = await c.get("entitlements").snapshot(user.id);
+    if (limit === null || limit <= 0 || !resetsAt) return;
+    if (used / limit < WARN_AT) return;
+
+    const db = c.get("db");
+    const { data: prefs } = await db
+      .from("notification_preferences")
+      .select("quota_exhausted, quota_warned_for")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    // A missing row means every notice is on — the rule `0015` set and the one
+    // that keeps somebody who has never opened the settings screen hearing about
+    // their own allowance.
+    if (prefs?.quota_exhausted === false) return;
+    if (prefs?.quota_warned_for === resetsAt) return;
+
+    // Stamped before the send rather than after it. The two orders fail
+    // differently: this way a Resend outage costs one missed warning, while the
+    // other way round it costs a message per reply for the rest of the period.
+    const { error } = await db
+      .from("notification_preferences")
+      .upsert(
+        { user_id: user.id, quota_warned_for: resetsAt, updated_at: new Date().toISOString() },
+        { onConflict: "user_id" },
+      );
+    if (error) return;
+
+    notify(c, quotaLowEmail({ email: user.email, used, limit, resetsAt, appUrl: appUrlOf(c) }));
+  } catch (err) {
+    console.error("failed to check whether a quota warning was due", err);
+  }
+}

--- a/worker/src/lib/entitlements/warn.ts
+++ b/worker/src/lib/entitlements/warn.ts
@@ -14,6 +14,20 @@ import { appUrlOf, notify } from "../emails/send";
 export const WARN_AT = 0.75;
 
 /**
+ * Whether two timestamps name the same moment, whatever they are spelled like.
+ *
+ * An unparseable or missing value answers false — "we have not warned yet" — so
+ * a corrupt stamp costs one extra message rather than silencing the warning for
+ * good.
+ */
+function sameInstant(a: string | null | undefined, b: string): boolean {
+  if (!a) return false;
+  const left = Date.parse(a);
+  const right = Date.parse(b);
+  return Number.isFinite(left) && Number.isFinite(right) && left === right;
+}
+
+/**
  * Say something before the allowance is gone, once per period.
  *
  * Until this existed the first news anybody had of their quota was `guardQuota`
@@ -55,7 +69,13 @@ export async function warnIfLow(c: Context<AppEnv>): Promise<void> {
     // that keeps somebody who has never opened the settings screen hearing about
     // their own allowance.
     if (prefs?.quota_exhausted === false) return;
-    if (prefs?.quota_warned_for === resetsAt) return;
+
+    // Compared as instants, not as text. The column is a `timestamptz`: it is
+    // written from `toISOString()` — `…T00:00:00.000Z` — and PostgREST returns
+    // it as `…T00:00:00+00:00`. The same moment spelled two ways, so `===` is
+    // always false and the warning would fire on every reply for the rest of
+    // the period, which is precisely what the column was added to prevent.
+    if (sameInstant(prefs?.quota_warned_for as string | null | undefined, resetsAt)) return;
 
     // Stamped before the send rather than after it. The two orders fail
     // differently: this way a Resend outage costs one missed warning, while the

--- a/worker/src/routes/account.test.ts
+++ b/worker/src/routes/account.test.ts
@@ -7,6 +7,8 @@ import { account, planWorkspaces } from "./account";
 const USER = { id: "user-1", email: "a@example.com" };
 
 const deleteUser = vi.fn();
+
+const MAIL_ENV = { RESEND_API_KEY: "re_test", RESEND_FROM: "Covan <hello@covan.test>" };
 const serviceFrom = vi.fn();
 const storeDelete = vi.fn();
 vi.mock("../lib/supabase", () => ({
@@ -282,6 +284,47 @@ describe("DELETE /account", () => {
 
     expect(status).toBe(500);
     expect(body.error).toMatch(/failed to close your account/);
+  });
+
+  /**
+   * The one receipt a closed account gets.
+   *
+   * Everything else about this action disappears with it: there is no row left
+   * to check, no screen to come back to, and no way to sign in and confirm.
+   * Under the KVKK and the GDPR the erasure is the obligation and the record of
+   * it is what makes the obligation demonstrable — for the person as much as for
+   * the operator.
+   */
+  it("sends a receipt once the account is really gone", async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation((async (_i: unknown, init?: RequestInit) => {
+      sent.push(JSON.parse(String(init?.body)));
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch);
+
+    const app = appWith({ members: [] });
+    const res = await app.request("/account", { method: "DELETE" }, MAIL_ENV as never);
+
+    expect(res.status).toBe(200);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toEqual([USER.email]);
+  });
+
+  // A receipt for a deletion that did not happen is worse than none: it tells
+  // somebody their data is gone while it is still there.
+  it("sends no receipt when the deletion failed", async () => {
+    const sent: unknown[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation((async () => {
+      sent.push(1);
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch);
+    deleteUser.mockResolvedValue({ data: null, error: { message: "still referenced" } });
+
+    const app = appWith({ members: [{ workspace_id: "solo", user_id: USER.id, role: "admin" }] });
+    const res = await app.request("/account", { method: "DELETE" }, MAIL_ENV as never);
+
+    expect(res.status).toBe(500);
+    expect(sent).toEqual([]);
   });
 
   it("closes an account that belongs to no workspace at all", async () => {

--- a/worker/src/routes/account.ts
+++ b/worker/src/routes/account.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import type { AppEnv } from "../types";
 import { serviceClient } from "../lib/supabase";
 import { getDocStore } from "../lib/docstore";
+import { accountClosedEmail } from "../lib/emails/closed";
+import { notify } from "../lib/emails/send";
 
 /**
  * Closing an account.
@@ -226,6 +228,15 @@ account.delete("/account", async (c) => {
     // told their account is gone and it is not.
     console.error("account deletion: deleteUser failed", deleteError);
     return c.json({ error: "failed to close your account" }, 500);
+  }
+
+  // After the deletion succeeded, never before it. A receipt for an erasure that
+  // did not happen is worse than no receipt: it tells somebody their data is
+  // gone while it is still there. The address comes from the token rather than
+  // from the database, which is what makes it still readable now that the
+  // profile row is not.
+  if (user.email) {
+    notify(c, accountClosedEmail({ email: user.email }));
   }
 
   // Last, and best-effort, in that order for the same reason `documents.ts`

--- a/worker/src/routes/invitations.test.ts
+++ b/worker/src/routes/invitations.test.ts
@@ -576,6 +576,68 @@ describe("POST /invitations/:id/accept", () => {
       error: "invitation is not addressed to you",
     });
   });
+
+  /**
+   * Telling the admin somebody arrived.
+   *
+   * An invitation is the one thing in this product that ends somewhere other
+   * than where it started: an admin sends it and then has no way of knowing
+   * whether it worked, short of checking the member list. The pending list even
+   * empties on acceptance, so the only visible trace is an absence.
+   *
+   * The invitation row is read BEFORE the function consumes it — afterwards it
+   * is no longer pending, and the whole reason we can read it at all is that it
+   * is addressed to the caller.
+   */
+  function acceptingApp(fetchImpl: typeof fetch) {
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchImpl);
+    return appWith({
+      rpc: { accept_invitation: () => ({ data: "ws-2", error: null }) },
+      tables: {
+        invitations: {
+          select: () => ({
+            data: { invited_by: "admin-1", workspaces: { name: "Acme" } },
+            error: null,
+          }),
+        },
+        profiles: {
+          select: (ctx: QueryContext) =>
+            ctx.columns?.includes("email")
+              ? { data: { name: "Ada Lovelace", email: "ada@example.com" }, error: null }
+              : { data: { active_workspace_id: WORKSPACE }, error: null },
+        },
+      },
+    });
+  }
+
+  it("tells the person who invited them that they joined", async () => {
+    let sent: Record<string, unknown> | undefined;
+    const { app } = acceptingApp(async (_input, init) => {
+      sent = JSON.parse(String(init?.body));
+      return new Response("{}", { status: 200 });
+    });
+
+    const res = await json(app, "POST", "/invitations/inv-1/accept", undefined, MAIL_ENV);
+
+    expect(res.status).toBe(200);
+    expect(sent?.to).toEqual(["ada@example.com"]);
+    expect(String(sent?.subject)).toContain("Acme");
+    // The person who joined is named by the address the invitation was sent to,
+    // which is the only thing about them the inviter already knew.
+    expect(String(sent?.text)).toContain(USER.email);
+  });
+
+  // The membership is real whether or not the courtesy note arrives. A mail
+  // failure that turned this into a 400 would tell somebody who HAS joined that
+  // they have not.
+  it("still reports the join when the notice cannot be sent", async () => {
+    const { app } = acceptingApp(async () => new Response("nope", { status: 500 }));
+
+    const res = await json(app, "POST", "/invitations/inv-1/accept", undefined, MAIL_ENV);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ workspaceId: "ws-2" });
+  });
 });
 
 describe("POST /invitations — telling the invitee", () => {

--- a/worker/src/routes/invitations.ts
+++ b/worker/src/routes/invitations.ts
@@ -5,83 +5,11 @@ import { toEpochMs } from "../lib/dto";
 import type { PendingInvitationDTO, IncomingInvitationDTO } from "../lib/dto";
 import { getActiveWorkspaceId } from "../lib/workspace";
 import { canSendEmail, sendEmail } from "../lib/email";
-import { emailShell } from "../lib/email-layout";
-import { escapeHtml } from "../lib/escape-html";
+import { invitationEmail } from "../lib/emails/invitation";
+import { joinedEmail } from "../lib/emails/joined";
+import { appUrlOf, notify } from "../lib/emails/send";
 
 const invitations = new Hono<AppEnv>();
-
-/**
- * The invitation email.
- *
- * Deliberately not a link that accepts anything. Acceptance runs through
- * `accept_invitation`, which matches the invitation's email against the
- * caller's verified JWT email — so the address IS the credential, and a token
- * in a URL would be a second, weaker one guarding the same door. What the
- * recipient needs to know is which address to use; that is what this says.
- *
- * Two halves, not two mails. The text below was the whole message for as long as
- * this route existed, on the reasoning that an HTML mail which renders as a
- * blank card in a client that strips styles is worse than no HTML at all. That
- * reasoning still holds and is why `text` is unchanged and still says
- * everything: the HTML is an addition Resend carries in the same request, and a
- * client that drops it falls back to prose that was never a fallback.
- */
-function invitationEmail(args: {
-  workspaceName: string;
-  inviterName: string;
-  role: string;
-  email: string;
-  appUrl: string;
-}) {
-  const asRole = args.role === "admin" ? "an admin" : "a member";
-  return {
-    to: args.email,
-    subject: `${args.inviterName} invited you to ${args.workspaceName} on Covan`,
-    // Hard-wrapped, and every interpolated value sits on a line of its own —
-    // an address or a workspace name in the middle of a sentence pushes the
-    // wrap around and turns a tidy paragraph into a ragged one for exactly the
-    // people whose names are longest.
-    text: [
-      `${args.inviterName} invited you to join ${args.workspaceName} on Covan,`,
-      `as ${asRole}.`,
-      "",
-      "Covan is where a team keeps its AI agents: the agents and the knowledge",
-      "they read are shared, and your own conversations stay yours.",
-      "",
-      "To accept, sign in and the invitation will be waiting:",
-      "",
-      `  ${args.appUrl}`,
-      "",
-      "Sign in with the address this was sent to:",
-      "",
-      `  ${args.email}`,
-      "",
-      "If you do not have an account yet, sign up with that same address — it is",
-      "what the invitation is matched to, so a different one will not find it.",
-      "",
-      "If you were not expecting this, you can ignore it. Nothing happens until",
-      "you accept.",
-    ].join("\n"),
-    html: emailShell({
-      preheader: `${args.inviterName} invited you to ${args.workspaceName} on Covan.`,
-      heading: `${args.inviterName} invited you to ${args.workspaceName}`,
-      // Written here rather than run through `email-markdown`: this prose is
-      // ours and fixed, so it needs no parser — only the two interpolated names,
-      // which the shell escapes for us.
-      bodyHtml: [
-        `<p style="${P}">You have been invited as ${asRole}.</p>`,
-        `<p style="${P}">Covan is where a team keeps its AI agents: the agents and the knowledge they read are shared, and your own conversations stay yours.</p>`,
-        `<p style="${P}">Sign in with <strong>${escapeHtml(args.email)}</strong> — that address is what the invitation is matched to, so a different one will not find it. If you do not have an account yet, sign up with that same address.</p>`,
-      ].join(""),
-      action: { label: "Sign in to accept", url: args.appUrl },
-      footnote:
-        "If you were not expecting this, you can ignore it. Nothing happens until you accept.",
-    }),
-  };
-}
-
-/** The body paragraph rule, inline for the same reason every other rule is. */
-const P = "margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19";
 
 const createInviteSchema = z.object({
   // Trimmed inside the schema, the way createWorkspaceSchema does it in
@@ -336,12 +264,71 @@ invitations.post("/invitations/:id/accept", async (c) => {
   const db = c.get("db");
   const id = c.req.param("id");
 
+  // Read before accepting. `accept_invitation` consumes the row — afterwards it
+  // is no longer pending, and being addressed to the caller is the only reason
+  // row level security lets them see it at all.
+  //
+  // Guarded, because this read exists only to address a courtesy email. Accepting
+  // an invitation is the one action in this file that grants somebody access, and
+  // it must not become conditional on a lookup that nothing else needs.
+  const invite = await Promise.resolve(
+    db.from("invitations").select("invited_by, workspaces(name)").eq("id", id).maybeSingle(),
+  )
+    .then((r) => r.data)
+    .catch(() => null);
+
   const { data, error } = await db.rpc("accept_invitation", { p_invite_id: id });
 
   if (error) {
     return c.json({ error: error.message || "failed to accept invitation" }, 400);
   }
+
+  await notifyInviter(c, invite);
+
   return c.json({ workspaceId: data as string });
 });
+
+/**
+ * Tell the inviter their invitation was taken up.
+ *
+ * Best-effort throughout, and deliberately so: the membership exists whether or
+ * not this note arrives, and a mail failure that propagated would report a join
+ * that really happened as a failure to join. Every unknown — no invitation row,
+ * no `invited_by`, a profile without an address — is a reason to send nothing
+ * rather than to guess a recipient.
+ */
+async function notifyInviter(
+  c: Context<AppEnv>,
+  invite: { invited_by?: unknown; workspaces?: unknown } | null,
+): Promise<void> {
+  try {
+    const joiner = c.get("user").email;
+    const inviterId = invite?.invited_by as string | undefined;
+    if (!joiner || !inviterId) return;
+
+    const { data: inviter } = await c
+      .get("db")
+      .from("profiles")
+      .select("name, email")
+      .eq("id", inviterId)
+      .maybeSingle();
+
+    const inviterEmail = inviter?.email as string | undefined;
+    if (!inviterEmail) return;
+
+    // PostgREST answers an embedded one-to-one as an object and an embedded
+    // list as an array, and which one you get depends on how it reads the
+    // relationship rather than on anything visible here.
+    const ws = invite?.workspaces as { name?: string } | { name?: string }[] | null;
+    const workspaceName = (Array.isArray(ws) ? ws[0]?.name : ws?.name) || "your workspace";
+
+    notify(
+      c,
+      joinedEmail({ inviterEmail, joinerEmail: joiner, workspaceName, appUrl: appUrlOf(c) }),
+    );
+  } catch {
+    // The join succeeded. There is nothing here worth failing it for.
+  }
+}
 
 export { invitations };

--- a/worker/src/routes/onboarding.test.ts
+++ b/worker/src/routes/onboarding.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "../types";
 import { onboarding } from "./onboarding";
 
@@ -51,6 +51,30 @@ function appWithDb(db: unknown) {
   app.route("/", onboarding);
   return app;
 }
+
+const MAIL_ENV = {
+  RESEND_API_KEY: "re_test",
+  RESEND_FROM: "Covan <hello@covan.test>",
+  ALLOWED_ORIGIN: "https://covan.test",
+};
+
+/**
+ * What reached Resend. Every one of these sends is deferred past the response,
+ * so the assertions read the request body rather than a return value — there is
+ * nothing for the route to return about a message it did not wait for.
+ */
+function captureSends() {
+  const calls: Array<Record<string, unknown>> = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation((async (_input: unknown, init?: RequestInit) => {
+    calls.push(JSON.parse(String(init?.body)));
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch);
+  return { calls };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function patch(app: Hono<AppEnv>, body: unknown) {
   return app.request("/onboarding", {
@@ -131,5 +155,50 @@ describe("POST /onboarding/complete", () => {
     expect(res.status).toBe(200);
     // The row already carried a stamp, so nothing was written over it.
     expect(upserts).toEqual([]);
+  });
+
+  /**
+   * The welcome email.
+   *
+   * This route is the only moment the product knows a person has arrived.
+   * Supabase sends the confirmation and nothing tells this Worker when it was
+   * clicked, so "just after confirming" is not a hook we have — and finishing
+   * the first run is the better moment anyway, because by then there is
+   * something to say that is not just "hello".
+   */
+  it("welcomes somebody the first time they finish", async () => {
+    const { db } = fakeDb({ row: { completed_at: null }, error: null });
+    const sent = captureSends();
+
+    const res = await appWithDb(db).request("/onboarding/complete", { method: "POST" }, MAIL_ENV);
+
+    expect(res.status).toBe(200);
+    expect(sent.calls).toHaveLength(1);
+    expect(sent.calls[0].to).toEqual([USER.email]);
+    expect(String(sent.calls[0].subject)).toMatch(/covan/i);
+  });
+
+  // The route already refuses to re-stamp a finished onboarding. The email has
+  // to follow that same guard, or every reload of the last step is another
+  // welcome.
+  it("does not welcome the same person twice", async () => {
+    const { db } = fakeDb({ row: { completed_at: "2026-01-01T00:00:00.000Z" }, error: null });
+    const sent = captureSends();
+
+    await appWithDb(db).request("/onboarding/complete", { method: "POST" }, MAIL_ENV);
+
+    expect(sent.calls).toEqual([]);
+  });
+
+  // Mail is optional configuration, not a dependency: a self-hosted Covan with
+  // no Resend keys still finishes onboarding.
+  it("finishes onboarding when no mail is configured", async () => {
+    const { db } = fakeDb({ row: { completed_at: null }, error: null });
+    const sent = captureSends();
+
+    const res = await appWithDb(db).request("/onboarding/complete", { method: "POST" });
+
+    expect(res.status).toBe(200);
+    expect(sent.calls).toEqual([]);
   });
 });

--- a/worker/src/routes/onboarding.ts
+++ b/worker/src/routes/onboarding.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { AppEnv } from "../types";
 import { ROLES, USE_CASES, TEAM_SIZES, REFERRAL_SOURCES } from "../lib/onboarding";
+import { welcomeEmail } from "../lib/emails/welcome";
+import { appUrlOf, notify } from "../lib/emails/send";
 
 const onboarding = new Hono<AppEnv>();
 
@@ -115,6 +117,12 @@ onboarding.post("/onboarding/complete", async (c) => {
   if (error || !data) {
     console.error("failed to finish onboarding", error);
     return c.json({ error: "failed to finish onboarding" }, 500);
+  }
+
+  // After the stamp, and only on the path that wrote one: the early return above
+  // is what keeps a reload of the last step from being a second welcome.
+  if (user.email) {
+    notify(c, welcomeEmail({ email: user.email, appUrl: appUrlOf(c) }));
   }
 
   return c.json({ completed: true });

--- a/worker/src/routes/workspace.test.ts
+++ b/worker/src/routes/workspace.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "../types";
 import { workspace } from "./workspace";
 import {
@@ -43,12 +43,40 @@ function appWith(spec: FakeDbSpec) {
   return { app, ...fake };
 }
 
-const json = (app: Hono<AppEnv>, method: string, path: string, body?: unknown) =>
-  app.request(path, {
-    method,
-    headers: { "Content-Type": "application/json" },
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
+const json = (
+  app: Hono<AppEnv>,
+  method: string,
+  path: string,
+  body?: unknown,
+  env?: Record<string, string>,
+) =>
+  app.request(
+    path,
+    {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    },
+    // Hono's third argument is the Bindings object, and leaving it undefined is
+    // what a deployment with no mail configured looks like from in here.
+    env,
+  );
+
+const MAIL_ENV = {
+  RESEND_API_KEY: "re_test",
+  RESEND_FROM: "Covan <hello@covan.test>",
+  ALLOWED_ORIGIN: "https://covan.test",
+};
+
+/** What reached Resend. These sends are deferred, so there is no return value. */
+function captureSends() {
+  const calls: Array<Record<string, unknown>> = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation((async (_i: unknown, init?: RequestInit) => {
+    calls.push(JSON.parse(String(init?.body)));
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch);
+  return calls;
+}
 
 /** A caller whose profile points nowhere and who belongs to no workspace. */
 const NO_WORKSPACE = {
@@ -353,6 +381,40 @@ describe("POST /workspace/active", () => {
 });
 
 describe("PATCH /workspace/members/:userId", () => {
+  /**
+   * A demotion to viewer is the quietest change this API makes. The person keeps
+   * every screen they had and simply cannot write on them any more — a save that
+   * refuses with nothing to explain it. The note says what the role means rather
+   * than only naming it, because "you are now a viewer" is not information to
+   * somebody who has never read the docs.
+   */
+  it("tells the member what their new role lets them do", async () => {
+    const { app } = appWith({
+      tables: {
+        workspace_members: {
+          select: () => ({ data: { workspace_id: WORKSPACE }, error: null }),
+          update: () => ({ data: [{ user_id: "user-2", role: "viewer" }], error: null }),
+        },
+        workspaces: { select: () => ({ data: { name: "Acme" }, error: null }) },
+        profiles: {
+          select: (ctx: QueryContext) =>
+            ctx.columns?.includes("email")
+              ? { data: { email: "deniz@example.com" }, error: null }
+              : { data: { active_workspace_id: WORKSPACE }, error: null },
+        },
+      },
+    });
+    const sent = captureSends();
+
+    const res = await json(app, "PATCH", "/workspace/members/user-2", { role: "viewer" }, MAIL_ENV);
+
+    expect(res.status).toBe(200);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toEqual(["deniz@example.com"]);
+    // Not just the word "viewer": the sentence that says chatting still works.
+    expect(String(sent[0].text)).toMatch(/chat with every agent/);
+  });
+
   it("changes a role within the caller's own workspace", async () => {
     let ctx: QueryContext | undefined;
     const { app } = appWith({
@@ -453,6 +515,71 @@ describe("DELETE /workspace/members/:userId", () => {
       { column: "workspace_id", value: WORKSPACE, kind: "eq" },
       { column: "user_id", value: "user-2", kind: "eq" },
     ]);
+  });
+
+  /**
+   * Losing access is not self-announcing.
+   *
+   * Somebody removed from a workspace finds out by opening Covan and seeing
+   * their colleagues' agents gone, or by a question that used to work coming
+   * back empty. The same is true of a demotion to viewer, which turns every
+   * write into a refusal with no visible cause. Both are the product changing
+   * what a person may do without telling them, which is the failure this
+   * codebase already treats as worth fixing.
+   *
+   * The profile is read BEFORE the delete, because afterwards they are no longer
+   * a fellow member and the row is no longer ours to read.
+   */
+  it("tells the person they were removed", async () => {
+    const { app } = appWith({
+      tables: {
+        workspace_members: {
+          select: () => ({ data: { workspace_id: WORKSPACE }, error: null }),
+          delete: () => ({ data: [{ user_id: "user-2" }], error: null }),
+        },
+        workspaces: { select: () => ({ data: { name: "Acme" }, error: null }) },
+        profiles: (() => {
+          const answer = (ctx: QueryContext) =>
+            ctx.columns?.includes("email")
+              ? { data: { email: "deniz@example.com" }, error: null }
+              : { data: { active_workspace_id: WORKSPACE }, error: null };
+          return { select: answer };
+        })(),
+      },
+    });
+    const sent = captureSends();
+
+    const res = await json(app, "DELETE", "/workspace/members/user-2", undefined, MAIL_ENV);
+
+    expect(res.status).toBe(200);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toEqual(["deniz@example.com"]);
+    expect(String(sent[0].subject)).toContain("Acme");
+  });
+
+  // Nobody was removed, so there is nobody to tell. A 403 that still sent a
+  // "you were removed" note would be the worst possible combination.
+  it("sends nothing when the removal was refused", async () => {
+    const { app } = appWith({
+      tables: {
+        workspace_members: {
+          select: () => ({ data: { workspace_id: WORKSPACE }, error: null }),
+          delete: () => ({ data: [], error: null }),
+        },
+        profiles: {
+          select: (ctx: QueryContext) =>
+            ctx.columns?.includes("email")
+              ? { data: { email: "deniz@example.com" }, error: null }
+              : { data: { active_workspace_id: WORKSPACE }, error: null },
+        },
+      },
+    });
+    const sent = captureSends();
+
+    const res = await json(app, "DELETE", "/workspace/members/user-2", undefined, MAIL_ENV);
+
+    expect(res.status).toBe(403);
+    expect(sent).toEqual([]);
   });
 
   it("answers 403 rather than pretending to have removed someone", async () => {

--- a/worker/src/routes/workspace.ts
+++ b/worker/src/routes/workspace.ts
@@ -1,8 +1,12 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { z } from "zod";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import type { AppEnv } from "../types";
 import { getActiveWorkspaceId } from "../lib/workspace";
 import { OPENAI_MODELS } from "../lib/models";
+import { canSendEmail } from "../lib/email";
+import { removedFromWorkspaceEmail, roleChangedEmail } from "../lib/emails/membership";
+import { notify } from "../lib/emails/send";
 
 const workspace = new Hono<AppEnv>();
 
@@ -183,8 +187,55 @@ workspace.patch("/workspace/members/:userId", async (c) => {
   if (!updated || updated.length === 0) {
     return c.json({ error: "only workspace admins can manage members" }, 403);
   }
+
+  const affected = await affectedMember(c, db, workspaceId, targetUserId);
+  if (affected) {
+    notify(
+      c,
+      roleChangedEmail({
+        email: affected.email,
+        workspaceName: affected.workspaceName,
+        role: parsed.data.role,
+      }),
+    );
+  }
+
   return c.json({ ok: true });
 });
+
+/**
+ * The address and workspace name a membership notice needs.
+ *
+ * Entirely best-effort: every unknown answers null, and the caller sends nothing
+ * rather than guessing a recipient. Neither of the two actions that use this is
+ * conditional on it — a removal that happened must not be reported as a failure
+ * because a name lookup did not come back.
+ */
+async function affectedMember(
+  c: Context<AppEnv>,
+  db: SupabaseClient,
+  workspaceId: string,
+  targetUserId: string,
+): Promise<{ email: string; workspaceName: string } | null> {
+  if (!canSendEmail(c.env)) return null;
+
+  try {
+    const [{ data: profile }, { data: ws }] = await Promise.all([
+      db.from("profiles").select("email").eq("id", targetUserId).maybeSingle(),
+      db.from("workspaces").select("name").eq("id", workspaceId).maybeSingle(),
+    ]);
+
+    const email = profile?.email as string | undefined;
+    if (!email) return null;
+
+    return {
+      email,
+      workspaceName: (ws?.name as string | null) || "a workspace",
+    };
+  } catch {
+    return null;
+  }
+}
 
 // DELETE /workspace/members/me — leave the workspace you are currently in.
 //
@@ -266,6 +317,11 @@ workspace.delete("/workspace/members/:userId", async (c) => {
   const workspaceId = await getActiveWorkspaceId(db, user.id);
   if (!workspaceId) return c.json({ error: "no workspace found for user" }, 404);
 
+  // Read before the delete. Afterwards they are not a fellow member any more,
+  // and `workspace_members_select_fellow_members` is the only reason their
+  // profile was ever ours to read.
+  const affected = await affectedMember(c, db, workspaceId, targetUserId);
+
   const { data: deleted, error } = await db
     .from("workspace_members")
     .delete()
@@ -280,6 +336,19 @@ workspace.delete("/workspace/members/:userId", async (c) => {
   if (!deleted || deleted.length === 0) {
     return c.json({ error: "only workspace admins can manage members" }, 403);
   }
+
+  // Only on the path where a row actually went. A refusal that still sent "you
+  // were removed" would be the worst combination available here.
+  if (affected) {
+    notify(
+      c,
+      removedFromWorkspaceEmail({
+        email: affected.email,
+        workspaceName: affected.workspaceName,
+      }),
+    );
+  }
+
   return c.json({ ok: true });
 });
 


### PR DESCRIPTION
Covan sent two emails: an invitation, and whatever a routine had to say. Between signing up and being told a routine died, the product had nothing to say to anybody — including at the two moments where it changes what a person may do.

Six now, and none of them is a sequence. Each is the only notice of something that already happened.

| Email | Fires | Why it has to exist |
|---|---|---|
| **welcome** | `POST /onboarding/complete` | The only moment this Worker knows somebody arrived. Supabase sends the confirmation and nothing tells us when it was clicked. |
| **joined** | invitation accepted → to the admin | The pending list **empties** on acceptance, so success and being ignored looked identical from their end. |
| **closed** | `DELETE /account`, after the deletion | The one receipt an erased account gets — every other trace of it goes with it. |
| **removed** | member deleted → to that person | Losing a workspace is not self-announcing: you find out when your colleagues' agents are gone. |
| **role changed** | role updated → to that person | Quieter still. A demotion to viewer keeps every screen and starts refusing saves. The note says what the role *permits* rather than only naming it. |
| **quota low** | after usage is recorded | At the three quarters `lib/quota.ts` has drawn on screen since it was written. Before this, the first news of an allowance was a 402 mid-conversation. |

### `0036`, and why the last one needs a migration

Being over a threshold stays true for every later request, so without a record the warning is one message per reply until the month turns. The new column holds the period it warned **for**, compared for equality — no arithmetic about month boundaries, and a new period sends exactly one. No new switch beside it: `quota_exhausted` already means "tell me about my allowance", and splitting that in two asks people the same question twice.

**This has to be applied by hand.** CI never applies migrations to production.

### Nothing waits for any of this

`notify` checks configuration, defers past the response, and drops the outcome. A courtesy must not be able to fail the thing it describes — a removal that happened must not be reported as a failure because a name lookup came back empty. The quota check is deferred for a second reason: awaiting it would put two queries between the last token of a reply and the person seeing it, on every reply, to send at most one message a month.

### The open/closed line

The warning lives in the open half deliberately. `metered.ts` is the closed file; `guard.ts` and the `Entitlements` interface are not, and `limit: null` is what the open build answers — so a self-hosted Covan runs this code and stays silent, which is correct rather than lucky.

### Also here

- **A third Supabase template.** `password_changed` is one Supabase can send and does not by default. It is the only message in the set somebody reads in order to discover they have been broken into. It carries no link — it announces something already done, and a credential mail with a link in it is the shape of the phishing it exists to help someone spot.
- **An RLS test for `notification_preferences`.** It had none. `0036` turns it from a table people write on a settings screen into one the API writes mid-request on their behalf, which is a different thing to leave untested.
- The invitation email moves into `lib/emails/` with the other six, so one folder holds what this product says.

### Testing

687 worker tests, 349 frontend, types clean, lint clean. Each notice was proved by removing the send and watching its own test go red.

**Not proved locally: the fail-first for `0036`.** The RLS suite needs a Postgres and Docker is not running on this machine; CI runs it against a real one.