### PR TITLE
Let the allowance estimate improve, instead of correcting itself

### DIFF
--- a/src/components/usage-section.tsx
+++ b/src/components/usage-section.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
-import { quotaFrom } from "@/lib/quota";
+import { quotaFrom, approximateReplies } from "@/lib/quota";
 import { SectionHeading } from "@/components/page-container";
 import { SectionCard, DataRow, EmptyState } from "@/components/section-card";
 import { AgentAvatar } from "@/components/avatars";
@@ -34,6 +34,9 @@ const usd = (n: number) => (n < 0.01 ? "<$0.01" : `$${n.toFixed(2)}`);
 export function UsageSection() {
   const { data: usage, isLoading } = useQuery({ queryKey: ["usage"], queryFn: api.usage });
   const quota = quotaFrom(usage);
+  // Rounded the same way the composer's banner rounds it, so the two surfaces
+  // cannot disagree by a digit that neither of them means.
+  const shown = quota ? approximateReplies(quota.repliesLeft) : 0;
   const agents = usage?.agents ?? [];
   const used = agents.filter((a) => a.messageCount > 0);
 
@@ -76,7 +79,7 @@ export function UsageSection() {
           <p className="mt-3 text-xs text-muted-foreground">
             {quota.level === "spent"
               ? "Used up — new replies are paused"
-              : `About ${quota.repliesLeft} ${quota.repliesLeft === 1 ? "reply" : "replies"} left`}
+              : `About ${shown} ${shown === 1 ? "reply" : "replies"} left`}
             {quota.resetsOn ? ` · resets on ${quota.resetsOn}` : null}
           </p>
           {/* Only once it is actually spent. Somebody with replies left does
@@ -96,10 +99,13 @@ export function UsageSection() {
           )}
 
           <p className="mt-3 border-t border-hairline pt-3 text-xs text-muted-foreground">
-            Counted in tokens, the unit the model is billed in, and converted to replies using what
-            your own replies have cost so far — currently about {compact(quota.perReply)} tokens
-            each. A long conversation with documents attached costs more than a short question, so
-            the estimate moves.
+            Counted in tokens, the unit the model is billed in, and converted to replies at about{" "}
+            {compact(quota.perReply)} tokens each.{" "}
+            {quota.repliesSeen === 0
+              ? "That is a starting assumption until you have sent something; it shifts towards what your own replies actually cost as you go."
+              : "That is mostly what your own replies have cost, weighed against a starting assumption that fades as you send more."}{" "}
+            A long conversation with documents attached costs more than a short question, so the
+            estimate moves.
           </p>
         </SectionCard>
       )}

--- a/src/lib/quota.test.ts
+++ b/src/lib/quota.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from "vitest";
+
+// `quota.ts` exports hooks as well as arithmetic, so importing it reaches
+// `api-client`, which builds a Supabase client from `VITE_*` at import time and
+// throws when they are unset. Nothing below calls the API — every test here is
+// a pure function of one response object — so the transport is stubbed rather
+// than configured.
+vi.mock("./api-client", () => ({ api: {} }));
+
+import { quotaFrom, quotaSentence, approximateReplies } from "./quota";
+import type { UsageResponse } from "./api-client";
+
+/*
+ * The allowance, as a number a person is asked to believe.
+ *
+ * The bug that prompted these tests was not an arithmetic error — both halves
+ * of the estimate were defensible on their own. It was a seam: the banner said
+ * "about 81 replies left" before the first message and "about 801" after it,
+ * and a figure that improves tenfold for no reason the reader can see is worse
+ * than no figure at all.
+ */
+
+const LIMIT = 300_000;
+
+function usage(over: {
+  used?: number;
+  messageCount?: number;
+  totalTokens?: number;
+  resetsAt?: string | null;
+}): UsageResponse {
+  return {
+    agents: [],
+    quota: { used: over.used ?? 0, limit: LIMIT, resetsAt: over.resetsAt ?? null },
+    totals: {
+      messageCount: over.messageCount ?? 0,
+      promptTokens: 0,
+      cachedTokens: 0,
+      measuredPromptTokens: 0,
+      completionTokens: 0,
+      totalTokens: over.totalTokens ?? 0,
+      estCostUsd: 0,
+    },
+  };
+}
+
+describe("the estimate before and after the first reply", () => {
+  it("does not multiply tenfold when one cheap reply arrives", () => {
+    // The measured production case, as one assertion. A first question to a
+    // brand-new agent with no documents is the cheapest message that account
+    // will ever send, so a sample of one is drawn from the bottom of a range
+    // that spans more than an order of magnitude.
+    const before = quotaFrom(usage({}))!;
+    const after = quotaFrom(usage({ used: 370, messageCount: 1, totalTokens: 370 }))!;
+
+    expect(before.repliesLeft).toBe(81);
+    // It may move — the estimate getting better is the point — but not by the
+    // 10x that made it read as a correction rather than a refinement.
+    expect(after.repliesLeft).toBeLessThan(before.repliesLeft * 2);
+  });
+
+  it("keeps moving towards what the replies actually cost", () => {
+    // The prior is outvoted, not permanent. Same cheap 370-token replies, more
+    // of them, and the figure climbs steadily rather than in one jump.
+    const at = (n: number) =>
+      quotaFrom(usage({ used: 370 * n, messageCount: n, totalTokens: 370 * n }))!.repliesLeft;
+
+    expect(at(1)).toBeLessThan(at(10));
+    expect(at(10)).toBeLessThan(at(50));
+    expect(at(50)).toBeLessThan(at(200));
+  });
+
+  it("ends up essentially the caller's own average once there is a real sample", () => {
+    // 200 replies at 370 tokens: the five-reply prior is 2.4% of the weight, so
+    // the estimate is theirs. Anything much wider than this would mean the
+    // prior never really lets go.
+    const q = quotaFrom(usage({ used: 74_000, messageCount: 200, totalTokens: 74_000 }))!;
+    expect(q.perReply).toBeGreaterThan(370);
+    expect(q.perReply).toBeLessThan(370 * 1.3);
+  });
+
+  it("uses the assumption alone before anything has been sent", () => {
+    const q = quotaFrom(usage({}))!;
+    expect(q.perReply).toBe(3700);
+    expect(q.repliesSeen).toBe(0);
+  });
+
+  it("ignores a message count with no tokens behind it", () => {
+    // Replies stored before token accounting existed report a count and no
+    // total. Dividing by them would drag the average towards zero and promise
+    // an allowance nobody has.
+    const q = quotaFrom(usage({ messageCount: 40, totalTokens: 0 }))!;
+    expect(q.perReply).toBe(3700);
+    expect(q.repliesSeen).toBe(0);
+  });
+});
+
+describe("how precisely the number is stated", () => {
+  it("rounds away a digit it does not mean", () => {
+    expect(approximateReplies(801)).toBe(800);
+    expect(approximateReplies(437)).toBe(440);
+    expect(approximateReplies(81)).toBe(81);
+  });
+
+  it("stays exact where the number is something to plan around", () => {
+    // Below twenty it stops being reassurance. "About 5 replies left" and
+    // "about 10" are different pieces of news.
+    for (const n of [0, 1, 3, 7, 19]) expect(approximateReplies(n)).toBe(n);
+  });
+
+  it("never rounds the low-band sentence, which is the one people act on", () => {
+    const q = quotaFrom(usage({ used: LIMIT - 8_000, messageCount: 60, totalTokens: 222_000 }))!;
+    expect(q.level).toBe("low");
+    expect(quotaSentence(q)).toContain(`About ${q.repliesLeft} `);
+  });
+});
+
+describe("what the banner says", () => {
+  it("says the allowance is gone rather than counting to zero", () => {
+    const q = quotaFrom(usage({ used: LIMIT, resetsAt: "2026-10-01T00:00:00.000Z" }))!;
+    expect(q.level).toBe("spent");
+    expect(quotaSentence(q)).toContain("used up");
+  });
+
+  it("says nothing at all for an install with no allowance", () => {
+    // Self-hosted brings its own OpenAI key, and `limit: null` is how the API
+    // says so. Every caller can then render nothing on one check.
+    const selfHosted = { ...usage({}), quota: { used: 0, limit: null, resetsAt: null } };
+    expect(quotaFrom(selfHosted)).toBeNull();
+  });
+});

--- a/src/lib/quota.ts
+++ b/src/lib/quota.ts
@@ -15,9 +15,11 @@ export type QuotaView = {
   limit: number;
   /** 0–1, clamped: usage can legitimately overshoot the limit by one operation. */
   ratio: number;
-  /** The caller's own observed cost per reply — see the note below. */
+  /** Cost per reply, mostly the caller's own once they have sent a few — see the note below. */
   perReply: number;
   repliesLeft: number;
+  /** How many replies the estimate has actually seen. 0 before the first one. */
+  repliesSeen: number;
   /** Localised day and month, e.g. "1 September". `null` if the API omitted it. */
   resetsOn: string | null;
   level: "fine" | "low" | "spent";
@@ -30,21 +32,68 @@ export type QuotaView = {
  */
 const ASSUMED_TOKENS_PER_REPLY = 3700;
 
+/**
+ * How many replies the assumption above is worth, weighed against real ones.
+ *
+ * This exists because switching outright from the assumption to the measurement
+ * produced a number nobody could believe: the banner said **about 81 replies
+ * left**, and after a single reply it said **about 801**. Nothing was bought
+ * and nothing was refunded.
+ *
+ * Neither half was wrong. 3,700 is the middle of what real conversations cost,
+ * and a person's own average is a better guide to their next reply than anybody
+ * else's. The fault was the seam. A first question to a brand-new agent with no
+ * documents is the cheapest message that account will ever send — one measured
+ * at 101 tokens — so a sample of one is drawn from the bottom of a range that
+ * spans more than an order of magnitude, and it was replacing a constant drawn
+ * from the middle. Every new account meets that seam, because everybody has a
+ * first reply.
+ *
+ * So the assumption is not replaced, it is outvoted: it counts as five replies,
+ * and real ones dilute it. The estimate still ends up entirely the caller's own
+ * — after fifty replies the prior is a tenth of the weight — it just gets there
+ * in steps a person can follow instead of in one jump of 10x.
+ */
+const PRIOR_REPLIES = 5;
+
+/**
+ * Round to two significant figures once the number is big enough that the last
+ * digit is noise.
+ *
+ * "About 801 replies" claims a precision the estimate does not have, and worse,
+ * it makes the estimate improving look like an arithmetic correction. Below
+ * twenty it stays exact, because that is where the number stops being
+ * reassurance and starts being something to plan around.
+ */
+export function approximateReplies(n: number): number {
+  if (n < 20) return n;
+  const magnitude = 10 ** (Math.floor(Math.log10(n)) - 1);
+  return Math.round(n / magnitude) * magnitude;
+}
+
 export function quotaFrom(usage: UsageResponse | undefined): QuotaView | null {
   const quota = usage?.quota;
   if (!quota || quota.limit === null || quota.limit <= 0) return null;
 
   // Replies, not tokens, because nobody budgets in tokens — and the conversion
-  // uses THIS user's own average rather than a constant. What a reply costs
-  // varies by more than an order of magnitude: a first question to an agent
-  // with no documents measured 101 tokens, while a long conversation grounded
-  // in uploads averaged 5,335. `totals` is already scoped by row level security
-  // to the caller's own conversations, so it is their average and nobody else's.
+  // leans on THIS user's own replies rather than on a constant. What a reply
+  // costs varies by more than an order of magnitude: a first question to an
+  // agent with no documents measured 101 tokens, while a long conversation
+  // grounded in uploads averaged 5,335. `totals` is already scoped by row level
+  // security to the caller's own conversations, so it is their average and
+  // nobody else's.
+  //
+  // Weighed against the assumption rather than replacing it — see PRIOR_REPLIES
+  // for why, and for the 81-to-801 jump that made it necessary.
   const seen = usage?.totals;
-  const perReply =
-    seen && seen.messageCount > 0 && seen.totalTokens > 0
-      ? Math.max(1, Math.round(seen.totalTokens / seen.messageCount))
-      : ASSUMED_TOKENS_PER_REPLY;
+  const repliesSeen = seen && seen.totalTokens > 0 ? Math.max(0, seen.messageCount) : 0;
+  const perReply = Math.max(
+    1,
+    Math.round(
+      (ASSUMED_TOKENS_PER_REPLY * PRIOR_REPLIES + (seen?.totalTokens ?? 0)) /
+        (PRIOR_REPLIES + repliesSeen),
+    ),
+  );
 
   const ratio = Math.min(quota.used / quota.limit, 1);
   const repliesLeft = Math.max(0, Math.floor((quota.limit - quota.used) / perReply));
@@ -55,7 +104,16 @@ export function quotaFrom(usage: UsageResponse | undefined): QuotaView | null {
   const level: QuotaView["level"] =
     quota.used >= quota.limit ? "spent" : ratio >= 0.75 || repliesLeft <= 3 ? "low" : "fine";
 
-  return { used: quota.used, limit: quota.limit, ratio, perReply, repliesLeft, resetsOn, level };
+  return {
+    used: quota.used,
+    limit: quota.limit,
+    ratio,
+    perReply,
+    repliesLeft,
+    repliesSeen,
+    resetsOn,
+    level,
+  };
 }
 
 /**
@@ -66,10 +124,13 @@ export function quotaSentence(q: QuotaView): string {
   const when = q.resetsOn ? ` It resets on ${q.resetsOn}.` : "";
   if (q.level === "spent") return `This month's allowance is used up.${when}`;
   if (q.level === "low") {
+    // Exact here, whatever `approximateReplies` would do with it: the low band
+    // is where the number stops being reassurance and becomes something to
+    // plan around, and it is small enough to be worth stating precisely.
     const n = q.repliesLeft;
     return `About ${n} ${n === 1 ? "reply" : "replies"} left this month.${when}`;
   }
-  return `About ${q.repliesLeft} replies left this month`;
+  return `About ${approximateReplies(q.repliesLeft)} replies left this month`;
 }
 
 /**


### PR DESCRIPTION
Closes #65. Found in the browser walk (covan-cloud#30), on production, with a real account.

The banner said **about 81 replies left this month**. After one reply it said **about 801**. Nothing was bought and nothing was refunded, and a number that improves tenfold for no reason the reader can see is worse than no number at all.

**Neither half was wrong.** 3,700 tokens is honestly the middle of what real conversations cost, and somebody's own average is a better guide to their next reply than anybody else's. The fault was the seam between them:

```ts
const perReply =
  seen && seen.messageCount > 0 && seen.totalTokens > 0
    ? Math.round(seen.totalTokens / seen.messageCount)   // sample of one
    : ASSUMED_TOKENS_PER_REPLY;                          // middle of the range
```

A first question to a brand-new agent with no documents is the cheapest message that account will ever send — one measured at 101 tokens. So a sample of size one is drawn from the bottom of a range spanning more than an order of magnitude, and it was replacing a constant drawn from the middle. Every new account meets that seam, because everybody has a first reply.

**The assumption is now outvoted rather than replaced.** It weighs five replies; real ones dilute it. The estimate still ends up entirely the caller's own — after fifty replies the prior is a tenth of the weight — it just gets there in steps a person can follow. On the measured case, 81 becomes 95 instead of 801.

Two smaller things came with it:

- `approximateReplies` rounds to two significant figures above twenty. "About 801" claims a precision the estimate does not have, and false precision is what makes an estimate *improving* look like arithmetic being *corrected*. Below twenty it stays exact — that is where the number stops being reassurance and becomes something to plan around — and the `low` band never rounds at all.
- The settings copy said the figure used "what your own replies have cost so far". That was about to stop being true for a new account, so it now says which of the two it is.

**`quota.ts` had no tests.** It does now. The three that matter here were run against the old estimate first and all three failed:

```
× does not multiply tenfold when one cheap reply arrives
× keeps moving towards what the replies actually cost
× ends up essentially the caller's own average once there is a real sample
```

Two of the new tests are not about this change and are there only because the file was untested: a `messageCount` with no tokens behind it — replies stored before token accounting existed — must not drag the average towards zero and promise an allowance nobody has; and `limit: null` must still read as "self-hosted, show nothing".

The `low` and `spent` thresholds are untouched. By the time an account is near its limit the sample is large and the estimate was already stable — this was only ever a first-run problem, which is why only a first-run walk found it.

359 tests, clean typecheck, 0 lint errors. Mirror to covan-cloud to follow, together with #71.