### PR TITLE
Read the browser during render, instead of copying it into state after

### DIFF
--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,19 +1,36 @@
 import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
+const QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
 
+function subscribe(onStoreChange: () => void) {
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener("change", onStoreChange);
+  return () => mql.removeEventListener("change", onStoreChange);
+}
+
+/**
+ * Whether the viewport is narrower than the layout's one breakpoint.
+ *
+ * `useSyncExternalStore` rather than state seeded from an effect, which is what
+ * this was. The old shape rendered `false` once, then set state after mount and
+ * rendered again — so a phone got one frame of the desktop layout on every
+ * mount, and `react-hooks/set-state-in-effect` reported it. This subscribes to
+ * the media query and reads it during render instead, which is the whole job
+ * this hook has.
+ *
+ * The reading is `mql.matches`, not `window.innerWidth`. The old code
+ * registered on the media query and then measured the window, two sources for
+ * one answer that disagree while a scrollbar is being counted.
+ *
+ * The server snapshot is `false` — there is no viewport during a server render,
+ * and false is what the previous `!!isMobile` gave before mount, so the first
+ * paint is unchanged.
+ */
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
-    mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
-
-  return !!isMobile;
+  return React.useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(QUERY).matches,
+    () => false,
+  );
 }

--- a/src/lib/theme.test.tsx
+++ b/src/lib/theme.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { useTheme } from "./theme";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+/*
+ * Both hooks mirror something outside React — the device's colour scheme, the
+ * stored preference, the viewport width — and both used to copy it into state
+ * after mount. These tests are about the copy being gone: what the hook returns
+ * has to follow the browser, including when the browser changes underneath it.
+ *
+ * jsdom implements no `matchMedia` at all, so there is a small one here rather
+ * than in `test-setup.ts`: only these two hooks need it, and a global stub
+ * would let a future test rely on media queries working without saying so.
+ */
+type Listener = (event: MediaQueryListEvent) => void;
+
+const media = new Map<string, { matches: boolean; listeners: Set<Listener> }>();
+
+function setMedia(query: string, matches: boolean) {
+  const entry = media.get(query);
+  if (!entry) {
+    media.set(query, { matches, listeners: new Set() });
+    return;
+  }
+  entry.matches = matches;
+  for (const listener of [...entry.listeners]) listener({ matches } as MediaQueryListEvent);
+}
+
+beforeEach(() => {
+  media.clear();
+  localStorage.clear();
+  document.documentElement.classList.remove("dark");
+  window.matchMedia = ((query: string) => {
+    if (!media.has(query)) media.set(query, { matches: false, listeners: new Set() });
+    const entry = media.get(query)!;
+    return {
+      get matches() {
+        return entry.matches;
+      },
+      media: query,
+      addEventListener: (_: string, listener: Listener) => entry.listeners.add(listener),
+      removeEventListener: (_: string, listener: Listener) => entry.listeners.delete(listener),
+    };
+  }) as unknown as typeof window.matchMedia;
+});
+
+afterEach(() => {
+  media.clear();
+});
+
+const DARK = "(prefers-color-scheme: dark)";
+
+describe("useTheme", () => {
+  it("follows the device when nothing has been chosen", () => {
+    setMedia(DARK, true);
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.preference).toBe("system");
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("reads the stored choice on the very first render", () => {
+    // The point of the change. This used to be "light" for one render and then
+    // the stored value, so anything drawn from it flickered.
+    localStorage.setItem("theme", "dark");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("dark");
+    expect(result.current.mounted).toBe(true);
+  });
+
+  it("lets an explicit choice beat the device", () => {
+    setMedia(DARK, true);
+    localStorage.setItem("theme", "light");
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("light");
+  });
+
+  it("follows the device changing while the page is open", () => {
+    setMedia(DARK, false);
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("light");
+
+    act(() => setMedia(DARK, true));
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("stops following the device once somebody chooses", () => {
+    setMedia(DARK, false);
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setPreference("light"));
+    act(() => setMedia(DARK, true));
+
+    expect(result.current.theme).toBe("light");
+    expect(result.current.preference).toBe("light");
+  });
+
+  it("stores nothing for 'system', because absence is what means system", () => {
+    localStorage.setItem("theme", "dark");
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setPreference("system"));
+
+    expect(localStorage.getItem("theme")).toBeNull();
+  });
+
+  it("puts the class on the document, which is what the page is actually styled by", () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => result.current.setPreference("dark"));
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    act(() => result.current.setPreference("light"));
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("agrees with a second hook in the same page", () => {
+    // Two components both calling useTheme is the ordinary case — the shell and
+    // the command palette both do. They share one subscription list, so a
+    // choice made through one has to reach the other.
+    const a = renderHook(() => useTheme());
+    const b = renderHook(() => useTheme());
+
+    act(() => a.result.current.setPreference("dark"));
+
+    expect(b.result.current.theme).toBe("dark");
+  });
+
+  it("toggle leaves an explicit choice behind, not 'system'", () => {
+    setMedia(DARK, false);
+    const { result } = renderHook(() => useTheme());
+    act(() => result.current.toggle());
+    expect(result.current.preference).toBe("dark");
+  });
+});
+
+describe("useIsMobile", () => {
+  const NARROW = "(max-width: 767px)";
+
+  it("answers from the media query on the first render", () => {
+    setMedia(NARROW, true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it("follows the viewport crossing the breakpoint", () => {
+    setMedia(NARROW, false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+
+    act(() => setMedia(NARROW, true));
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/lib/theme.tsx
+++ b/src/lib/theme.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 
 export type Theme = "light" | "dark";
 export type ThemePreference = "system" | "light" | "dark";
@@ -21,17 +21,32 @@ export const THEME_INIT_SCRIPT = `
 })();
 `;
 
+const SYSTEM_DARK = "(prefers-color-scheme: dark)";
+
 function systemTheme(): Theme {
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  return window.matchMedia(SYSTEM_DARK).matches ? "dark" : "light";
 }
 
 function resolve(pref: ThemePreference): Theme {
   return pref === "system" ? systemTheme() : pref;
 }
 
-function applyPreference(pref: ThemePreference) {
-  const theme = resolve(pref);
-  document.documentElement.classList.toggle("dark", theme === "dark");
+/**
+ * The stored preference, or "system" when there is none or it cannot be read.
+ *
+ * The absence of a value IS "system" — see `writePreference` — so a storage
+ * failure lands on the same answer as a first visit rather than on an error.
+ */
+function readPreference(): ThemePreference {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === "light" || stored === "dark" ? stored : "system";
+  } catch {
+    return "system";
+  }
+}
+
+function writePreference(pref: ThemePreference) {
   try {
     // "system" is the default, represented by the absence of a stored value —
     // so following the device stays the behavior across future visits.
@@ -42,41 +57,84 @@ function applyPreference(pref: ThemePreference) {
   }
 }
 
+/*
+ * There are two sources of truth here and neither of them is React: the stored
+ * preference, and what the device says. So the hooks below read them during
+ * render through `useSyncExternalStore` rather than copying them into state
+ * after mount, which is what this file used to do and what
+ * `react-hooks/set-state-in-effect` reported.
+ *
+ * What that replaces is worth naming, because it was more than one extra
+ * render. `useTheme` held three pieces of state, seeded them all in one effect,
+ * and exported a `mounted` flag purely so callers could hide theme-dependent
+ * markup until that effect had run. The flag existed to paper over the gap
+ * between the first render and the effect — and with the browser read during
+ * render, the gap it papered over is the ordinary hydration boundary that
+ * `useSyncExternalStore` already handles, by rendering the server snapshot and
+ * then re-rendering with the client's.
+ *
+ * `mounted` stays in the returned shape, because it is still the right answer
+ * to "may I draw something that differs between server and client yet", and
+ * because three call sites use it. It is just honest now rather than a state
+ * machine.
+ *
+ * The snapshots are strings on purpose. `useSyncExternalStore` compares
+ * snapshots by identity and would loop forever on a fresh object each call.
+ */
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const listener of listeners) listener();
+}
+
+function subscribe(onStoreChange: () => void) {
+  listeners.add(onStoreChange);
+  const mq = window.matchMedia(SYSTEM_DARK);
+  mq.addEventListener("change", onStoreChange);
+  // Another tab choosing a theme. The old effect never listened for this, so
+  // two open tabs disagreed until one of them was reloaded.
+  window.addEventListener("storage", onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+    mq.removeEventListener("change", onStoreChange);
+    window.removeEventListener("storage", onStoreChange);
+  };
+}
+
 /**
  * Reads and controls the active theme. The default preference is "system",
- * which tracks the device's color scheme live. Initial render assumes "light"
- * (matches SSR output); after mount it syncs to whatever the init script set,
- * so gate any theme-dependent icon on `mounted` to avoid a hydration mismatch.
+ * which tracks the device's colour scheme live.
+ *
+ * The server renders "light" and "system", matching `THEME_INIT_SCRIPT`'s
+ * fallback; the client's first snapshot is whatever the device and storage
+ * actually say. Gate theme-dependent markup on `mounted` as before.
  */
 export function useTheme() {
-  const [preference, setPreferenceState] = useState<ThemePreference>("system");
-  const [theme, setTheme] = useState<Theme>("light");
-  const [mounted, setMounted] = useState(false);
+  const preference = useSyncExternalStore(subscribe, readPreference, () => "system" as const);
+  const theme = useSyncExternalStore(
+    subscribe,
+    () => resolve(readPreference()),
+    () => "light" as const,
+  );
+  const mounted = useSyncExternalStore(
+    subscribe,
+    () => true,
+    () => false,
+  );
 
+  // Updating something outside React from React's own state, which is what an
+  // effect is for. The init script has already set this class before first
+  // paint, so on load this agrees with what is on the element and changes
+  // nothing; it earns its keep when the device flips at midnight or somebody
+  // picks a theme in another tab.
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    const pref: ThemePreference = stored === "light" || stored === "dark" ? stored : "system";
-    setPreferenceState(pref);
-    setTheme(document.documentElement.classList.contains("dark") ? "dark" : "light");
-    setMounted(true);
-
-    // While following the device, react to OS light/dark changes live.
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const onChange = () => {
-      const s = localStorage.getItem(STORAGE_KEY);
-      if (s === "light" || s === "dark") return; // explicit choice wins
-      const next = mq.matches ? "dark" : "light";
-      document.documentElement.classList.toggle("dark", next === "dark");
-      setTheme(next);
-    };
-    mq.addEventListener("change", onChange);
-    return () => mq.removeEventListener("change", onChange);
-  }, []);
+    document.documentElement.classList.toggle("dark", theme === "dark");
+  }, [theme]);
 
   const setPreference = (pref: ThemePreference) => {
-    setPreferenceState(pref);
-    applyPreference(pref);
-    setTheme(resolve(pref));
+    writePreference(pref);
+    // `storage` does not fire in the tab that wrote it.
+    notify();
   };
 
   return {


### PR DESCRIPTION
Two of the eleven sites in #68 — the two that issue calls the textbook case, where a hook exists to mirror something outside React and was doing it by rendering a wrong answer first and correcting itself.

**`useIsMobile`** rendered `false`, set state after mount, and rendered again, so a phone got one frame of the desktop layout on every mount. It also registered on a media query and then measured `window.innerWidth` — two sources for one answer, which disagree while a scrollbar is being counted. It now subscribes to the query and reads `mql.matches`.

**`useTheme`** was three pieces of state seeded in one effect, plus a `mounted` flag whose only job was to hide theme-dependent markup until that effect had run. With the browser read during render there is no gap left to hide: what `mounted` papered over is the ordinary hydration boundary, and `useSyncExternalStore` handles that itself by rendering the server snapshot and then re-rendering with the client's.

`mounted` stays in the returned shape — three call sites use it, and it is still the right answer to "may I draw something that differs between server and client yet". It is just honest now instead of a state machine, and no call site changed.

**Two things fell out that were not the point:**

- The theme now derives from the stored preference and the device, rather than from reading back the class `THEME_INIT_SCRIPT` wrote. One source of truth instead of a value round-tripping through the DOM.
- `subscribe` listens for `storage`. The old effect never did, so two open tabs disagreed about the theme until one of them was reloaded.

**Neither file had a test.** There are eleven now, and five fail against the old hooks:

```
× follows the device when nothing has been chosen
× reads the stored choice on the very first render
× agrees with a second hook in the same page
× answers from the media query on the first render
× follows the viewport crossing the breakpoint
```

jsdom implements no `matchMedia`, so the stub lives in the test file rather than in `test-setup.ts` — only these two hooks need it, and a global one would let a future test depend on media queries working without saying so.

`react-hooks/set-state-in-effect` is down from 11 warnings to 9. The nine that remain are the form-state group and two singletons, which want individual decisions about what happens to a half-typed edit when a query refetches — that is the rest of #68 and it stays open.

375 tests, clean typecheck, 0 lint errors. Mirror to covan-cloud to follow.