### PR TITLE
Let the fallback be the default, instead of copying it into state

### DIFF
--- a/src/routes/_authed.app.tsx
+++ b/src/routes/_authed.app.tsx
@@ -175,10 +175,14 @@ function HomeComposer({
     () => agents.find((a) => favorites.includes(a.id)) ?? agents[0],
     [agents, favorites],
   );
-  const [agentId, setAgentId] = useState<string | undefined>(defaultAgent?.id);
-  useEffect(() => {
-    if (!agentId && defaultAgent) setAgentId(defaultAgent.id);
-  }, [agentId, defaultAgent]);
+  // Holds a pick, and only a pick. `undefined` is not "not loaded yet" — it is
+  // "nobody has chosen", which is the state this composer opens in and the one
+  // the line below already knows what to do with. Seeding it from defaultAgent
+  // (in the initialiser, or in an effect once the agents arrive) would say the
+  // same thing twice and let the two copies disagree: an agent that is deleted
+  // leaves its id behind here, where `?? defaultAgent` recovers and a stored id
+  // does not. Everything the dropdown renders reads `selected`, never this.
+  const [agentId, setAgentId] = useState<string | undefined>(undefined);
 
   const selected = agents.find((a) => a.id === agentId) ?? defaultAgent;
 


### PR DESCRIPTION
First of the nine sites left in #68, and the only one where the fix is a deletion.

The composer on `/app` kept an `agentId` in state and an effect to fill it in:

```ts
const [agentId, setAgentId] = useState<string | undefined>(defaultAgent?.id);
useEffect(() => {
  if (!agentId && defaultAgent) setAgentId(defaultAgent.id);
}, [agentId, defaultAgent]);

const selected = agents.find((a) => a.id === agentId) ?? defaultAgent;
```

The last line already answers the question the effect was asking. Nothing reads `agentId` directly — the trigger, the label and `launch()` all go through `selected` — so the empty case was covered before the effect ran, and all it bought was a second render.

Both the effect and the seeded initialiser are gone. `agentId` now means one thing: what the user picked. `undefined` is "nobody has chosen", not "the agents have not loaded".

Worth saying why the two spellings were not equivalent. With the id seeded, an agent deleted in another tab leaves its id behind in state and the dropdown label goes blank; without it, `?? defaultAgent` picks the next one up. The redundant copy was the one that could be wrong.

`_authed.app.tsx:82` — the `?new=true` deep link — is still there. It is a navigation side effect rather than form state and wants its own decision.

375 tests pass, `tsc` clean, and the rule now reports one site in this file instead of two.