### PR TITLE
Remount a form when what it edits changes, instead of refilling it

### DIFF
--- a/src/routes/_authed.agents.$agentId.settings.tsx
+++ b/src/routes/_authed.agents.$agentId.settings.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
-import { useAgentsStore } from "@/lib/agents-store";
+import { useState } from "react";
+import { useAgentsStore, type Agent } from "@/lib/agents-store";
 import {
   PageContainer,
   PageHeader,
@@ -50,32 +50,32 @@ export const Route = createFileRoute("/_authed/agents/$agentId/settings")({
  */
 function SettingsTab() {
   const { agentId } = Route.useParams();
-  const { agents, updateAgent, deleteAgent, canWrite } = useAgentsStore();
-  const navigate = useNavigate();
+  const { agents } = useAgentsStore();
   const agent = agents.find((a) => a.id === agentId)!;
+
+  // Switching to a different agent remounts the form, which is the only event
+  // that should discard a half-typed edit.
+  //
+  // This replaces an effect that copied the five fields into state whenever
+  // `agent.id` changed, with a disable for the exhaustive-deps rule and a
+  // paragraph explaining that adding the other five dependencies would be a
+  // bug — any refresh of the store (the write-back from `save`, another tab, a
+  // realtime update) would have run it again and thrown away what you had
+  // typed. All of that reasoning survives; `key` is just the spelling of it
+  // React can enforce, and it does not need an effect, a disable, or a comment
+  // asking the next person not to "fix" the dependency array. #68.
+  return <AgentSettingsForm key={agent.id} agent={agent} />;
+}
+
+function AgentSettingsForm({ agent }: { agent: Agent }) {
+  const { updateAgent, deleteAgent, canWrite } = useAgentsStore();
+  const navigate = useNavigate();
 
   const [name, setName] = useState(agent.name);
   const [emoji, setEmoji] = useState(agent.emoji);
   const [model, setModel] = useState(agent.model);
   const [persona, setPersona] = useState(agent.persona);
   const [mode, setMode] = useState(agent.mode);
-
-  // Refill the form when you switch to a *different* agent, and only then.
-  //
-  // The lint rule wants agent.name, .emoji, .model, .persona and .mode in here
-  // too, and adding them would be a bug: this effect writes to the same state
-  // the inputs are bound to, so any refresh of the store — the write-back from
-  // `save`, another tab, a realtime update — would run it again and throw away
-  // whatever you had typed since. The identity of the agent is the only thing
-  // that should reset the form.
-  useEffect(() => {
-    setName(agent.name);
-    setEmoji(agent.emoji);
-    setModel(agent.model);
-    setPersona(agent.persona);
-    setMode(agent.mode);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agent.id]);
 
   const save = () => {
     updateAgent(agent.id, { name: name.trim() || agent.name, emoji, model, persona, mode });

--- a/src/routes/_authed.settings.tsx
+++ b/src/routes/_authed.settings.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { AppShell } from "@/components/app-shell";
 import { PageContainer, PageHeader, SectionHeading } from "@/components/page-container";
 import { SectionCard } from "@/components/section-card";
@@ -16,7 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
-import { api, ApiError } from "@/lib/api-client";
+import { api, ApiError, type Me, type Workspace } from "@/lib/api-client";
 import { isAdminRole } from "@/lib/roles";
 import { privacyLink, termsLink } from "@/lib/legal";
 import { LegalAnchor } from "@/components/legal-anchor";
@@ -31,34 +31,101 @@ export const Route = createFileRoute("/_authed/settings")({
   }),
 });
 
-function SettingsPage() {
+/**
+ * Both forms on this page are seeded from `me` at mount and never again. The
+ * effects that used to do the seeding are gone (#68), and the identity of the
+ * thing being edited — passed as `key` by the caller — is what discards a
+ * half-typed edit. That is the whole rule, and it is the one
+ * `agents.$agentId.settings.tsx` already followed.
+ *
+ * It matters here more than most places, because this page invalidates `me`
+ * itself: saving your display name refetches it so the sidebar agrees, and the
+ * workspace form's old effect depended on `me.workspace` — a fresh object on
+ * every refetch. So saving one form wiped whatever you had typed in the other.
+ * Keying on the id cannot make that mistake; there is nothing to re-run.
+ *
+ * The cost, stated plainly: a workspace renamed in another tab does not appear
+ * in these inputs until something remounts them. An input you are typing in is
+ * exactly where a background write should not land.
+ */
+function WorkspaceForm({
+  workspace,
+  isAdmin,
+}: {
+  workspace: Workspace | undefined;
+  isAdmin: boolean;
+}) {
   const queryClient = useQueryClient();
-  const { data: me } = useQuery({ queryKey: ["me"], queryFn: () => api.me() });
-
-  // Defaults to true while `me` loads, so the form does not visibly lock and
-  // then unlock on every cold load — mirrors the same choice in agents-store.
-  const isAdmin = me ? isAdminRole(me.members.find((m) => m.id === me.user.id)?.role) : true;
-
-  const [name, setName] = useState("");
-  const [slug, setSlug] = useState("");
+  const [name, setName] = useState(workspace?.name ?? "");
+  const [slug, setSlug] = useState(workspace?.slug ?? "");
   const [saving, setSaving] = useState(false);
 
-  const [profileName, setProfileName] = useState("");
+  const dirty = !!workspace && (name !== workspace.name || slug !== workspace.slug);
+
+  const handleSave = async () => {
+    if (!workspace || !name.trim() || !slug.trim()) return;
+    setSaving(true);
+    try {
+      await api.workspace.update({ name, slug });
+      toast.success("Changes saved");
+      await queryClient.invalidateQueries({ queryKey: ["me"] });
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : "Failed to save changes";
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const reset = () => {
+    if (!workspace) return;
+    setName(workspace.name);
+    setSlug(workspace.slug);
+  };
+
+  return (
+    <SectionCard className="mt-6 space-y-5">
+      <fieldset disabled={!isAdmin} className="contents">
+        <div className="space-y-2">
+          <Label htmlFor="ws-name">Name</Label>
+          <Input id="ws-name" value={name} onChange={(e) => setName(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="ws-slug">Slug</Label>
+          <Input
+            id="ws-slug"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            className="font-mono text-sm"
+          />
+          <p className="text-xs text-muted-foreground">
+            Short identifier used in links. Lowercase letters, numbers and dashes.
+          </p>
+        </div>
+      </fieldset>
+      {isAdmin ? (
+        <div className="flex items-center justify-end gap-2 border-t border-hairline pt-4">
+          {dirty ? (
+            <Button variant="ghost" onClick={reset} disabled={saving}>
+              Discard
+            </Button>
+          ) : null}
+          <Button onClick={handleSave} disabled={saving || !dirty || !name.trim() || !slug.trim()}>
+            {saving ? "Saving…" : "Save changes"}
+          </Button>
+        </div>
+      ) : null}
+    </SectionCard>
+  );
+}
+
+/** Your own display name. Same rule as `WorkspaceForm` above, same reason. */
+function ProfileForm({ user }: { user: Me["user"] | undefined }) {
+  const queryClient = useQueryClient();
+  const [profileName, setProfileName] = useState(user?.name ?? "");
   const [savingProfile, setSavingProfile] = useState(false);
 
-  useEffect(() => {
-    if (me?.workspace) {
-      setName(me.workspace.name);
-      setSlug(me.workspace.slug);
-    }
-  }, [me?.workspace]);
-
-  useEffect(() => {
-    setProfileName(me?.user.name ?? "");
-  }, [me?.user.name]);
-
-  const dirty = !!me && (name !== me.workspace.name || slug !== me.workspace.slug);
-  const profileDirty = !!me && profileName.trim() !== (me.user.name ?? "");
+  const profileDirty = !!user && profileName.trim() !== (user.name ?? "");
 
   const handleSaveProfile = async () => {
     if (!profileName.trim()) return;
@@ -77,26 +144,61 @@ function SettingsPage() {
     }
   };
 
-  const handleSave = async () => {
-    if (!me || !name.trim() || !slug.trim()) return;
-    setSaving(true);
-    try {
-      await api.workspace.update({ name, slug });
-      toast.success("Changes saved");
-      await queryClient.invalidateQueries({ queryKey: ["me"] });
-    } catch (err) {
-      const message = err instanceof ApiError ? err.message : "Failed to save changes";
-      toast.error(message);
-    } finally {
-      setSaving(false);
-    }
-  };
+  return (
+    <SectionCard className="mt-6 space-y-5">
+      <div className="flex items-center gap-4">
+        <UserAvatar name={user?.name} url={user?.avatarUrl} className="h-11 w-11 text-xs" />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[13px] text-muted-foreground">{user?.email ?? "…"}</div>
+        </div>
+      </div>
 
-  const reset = () => {
-    if (!me) return;
-    setName(me.workspace.name);
-    setSlug(me.workspace.slug);
-  };
+      <div className="space-y-2">
+        <Label htmlFor="profile-name">Display name</Label>
+        <Input
+          id="profile-name"
+          value={profileName}
+          onChange={(e) => setProfileName(e.target.value)}
+          maxLength={80}
+        />
+        <p className="text-xs text-muted-foreground">
+          What the rest of the workspace sees — on shared sessions, in the member list, next to
+          anything you send.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 border-t border-hairline pt-4">
+        {profileDirty ? (
+          <Button
+            variant="ghost"
+            onClick={() => setProfileName(user?.name ?? "")}
+            disabled={savingProfile}
+          >
+            Discard
+          </Button>
+        ) : null}
+        <Button
+          onClick={handleSaveProfile}
+          disabled={savingProfile || !profileDirty || !profileName.trim()}
+        >
+          {savingProfile ? "Saving…" : "Save name"}
+        </Button>
+      </div>
+
+      <p className="border-t border-hairline pt-4 text-xs text-muted-foreground">
+        Your photo still comes from the account you signed in with. Sign out from the menu at the
+        bottom of the sidebar.
+      </p>
+    </SectionCard>
+  );
+}
+
+function SettingsPage() {
+  const { data: me } = useQuery({ queryKey: ["me"], queryFn: () => api.me() });
+
+  // Defaults to true while `me` loads, so the form does not visibly lock and
+  // then unlock on every cold load — mirrors the same choice in agents-store.
+  const isAdmin = me ? isAdminRole(me.members.find((m) => m.id === me.user.id)?.role) : true;
 
   return (
     <AppShell>
@@ -116,96 +218,20 @@ function SettingsPage() {
               always refused this write, and PATCH /workspace answers 403 — but
               the form was rendered to everyone, so a member could fill it in,
               press Save and be told they had done something wrong. */}
-          <SectionCard className="mt-6 space-y-5">
-            <fieldset disabled={!isAdmin} className="contents">
-              <div className="space-y-2">
-                <Label htmlFor="ws-name">Name</Label>
-                <Input id="ws-name" value={name} onChange={(e) => setName(e.target.value)} />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="ws-slug">Slug</Label>
-                <Input
-                  id="ws-slug"
-                  value={slug}
-                  onChange={(e) => setSlug(e.target.value)}
-                  className="font-mono text-sm"
-                />
-                <p className="text-xs text-muted-foreground">
-                  Short identifier used in links. Lowercase letters, numbers and dashes.
-                </p>
-              </div>
-            </fieldset>
-            {isAdmin ? (
-              <div className="flex items-center justify-end gap-2 border-t border-hairline pt-4">
-                {dirty ? (
-                  <Button variant="ghost" onClick={reset} disabled={saving}>
-                    Discard
-                  </Button>
-                ) : null}
-                <Button
-                  onClick={handleSave}
-                  disabled={saving || !dirty || !name.trim() || !slug.trim()}
-                >
-                  {saving ? "Saving…" : "Save changes"}
-                </Button>
-              </div>
-            ) : null}
-          </SectionCard>
+          {/* `key` is the seeding. "pending" while `me` loads, then the id: the
+              change from one to the other is the mount that fills the inputs
+              in, and switching workspaces is the only other thing that can
+              move it. */}
+          <WorkspaceForm
+            key={me?.workspace.id ?? "pending"}
+            workspace={me?.workspace}
+            isAdmin={isAdmin}
+          />
         </section>
 
         <section className="mt-16">
           <SectionHeading title="Your account" />
-          <SectionCard className="mt-6 space-y-5">
-            <div className="flex items-center gap-4">
-              <UserAvatar
-                name={me?.user.name}
-                url={me?.user.avatarUrl}
-                className="h-11 w-11 text-xs"
-              />
-              <div className="min-w-0 flex-1">
-                <div className="truncate text-[13px] text-muted-foreground">
-                  {me?.user.email ?? "…"}
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="profile-name">Display name</Label>
-              <Input
-                id="profile-name"
-                value={profileName}
-                onChange={(e) => setProfileName(e.target.value)}
-                maxLength={80}
-              />
-              <p className="text-xs text-muted-foreground">
-                What the rest of the workspace sees — on shared sessions, in the member list, next
-                to anything you send.
-              </p>
-            </div>
-
-            <div className="flex items-center justify-end gap-2 border-t border-hairline pt-4">
-              {profileDirty ? (
-                <Button
-                  variant="ghost"
-                  onClick={() => setProfileName(me?.user.name ?? "")}
-                  disabled={savingProfile}
-                >
-                  Discard
-                </Button>
-              ) : null}
-              <Button
-                onClick={handleSaveProfile}
-                disabled={savingProfile || !profileDirty || !profileName.trim()}
-              >
-                {savingProfile ? "Saving…" : "Save name"}
-              </Button>
-            </div>
-
-            <p className="border-t border-hairline pt-4 text-xs text-muted-foreground">
-              Your photo still comes from the account you signed in with. Sign out from the menu at
-              the bottom of the sidebar.
-            </p>
-          </SectionCard>
+          <ProfileForm key={me?.user.id ?? "pending"} user={me?.user} />
         </section>
 
         <PreferencesSection me={me} />


### PR DESCRIPTION
Three sites from #68 — `_authed.settings.tsx` ×2 and `agents.\$agentId.settings.tsx` — and the group the issue called the least mechanical, because they were answering one question three different ways: when does a form discard what you have typed?

**`agents/$agentId/settings` already had the answer**, in a comment that had to argue with the linter to keep it:

> The lint rule wants agent.name, .emoji, .model, .persona and .mode in here too, and adding them would be a bug: this effect writes to the same state the inputs are bound to […] The identity of the agent is the only thing that should reset the form.

That reasoning is right and it survives intact. What changes is that `key` says it in a way React enforces, so there is no dependency array for a future reader to helpfully complete.

**`settings` had the same shape and a worse dependency**, and this one is a live bug rather than an extra render:

```ts
useEffect(() => {
  if (me?.workspace) { setName(me.workspace.name); setSlug(me.workspace.slug); }
}, [me?.workspace]);        // an object — new on every refetch of `me`
```

The page refetches `me` itself: saving your display name invalidates it so the sidebar, the member list and the header agree. So typing a new workspace name, then saving your profile name below it, reverted the workspace field under the cursor. The sibling effect keyed on `me.user.name` — a string — so it only fired when the value actually changed, which is why it was quieter rather than better.

**All three now use `key`.** `WorkspaceForm` and `ProfileForm` come out of `settings` as two small components, each mounted under the id of the thing it edits; the agent form moves behind a four-line route component doing the same. Seeding is `useState(agent.name)` — an initialiser, used as one.

While `me` loads the key is `"pending"`, so the change to a real id is the mount that fills the inputs in. The loading state renders exactly as before.

The trade, restated so it is on the record: a workspace renamed in another tab does not reach these inputs until something remounts them. An input somebody is typing in is where a background write should not land.

Six of eleven done. Remaining: `create-agent-dialog`, `first-week`, `chat`, `_authed.app:82`, `reset-password`. 375 tests pass, `tsc` clean.