### PR TITLE
Read the dismissal where it lives, instead of after mount

### DIFF
--- a/src/lib/first-week-dismissed.test.tsx
+++ b/src/lib/first-week-dismissed.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { useChecklistDismissed } from "./first-week";
+
+/*
+ * `useChecklistDismissed` reads `localStorage` during render rather than copying
+ * it into state after mount (#68). These tests are about what that buys: the
+ * workspace id arriving a render late still gets read, another tab is noticed,
+ * and the flag stays per workspace.
+ *
+ * Every test uses its own workspace id. The hook keeps a module-level set of
+ * dismissals made in this tab — the fallback for when the storage write throws —
+ * and nothing exports a way to clear it, which is right for the product and
+ * means tests must not share ids.
+ */
+let n = 0;
+const nextId = () => `ws-${++n}`;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("useChecklistDismissed", () => {
+  it("is not dismissed before the workspace id has arrived", () => {
+    const { result } = renderHook(() => useChecklistDismissed(undefined));
+    expect(result.current.dismissed).toBe(false);
+  });
+
+  it("reads a flag that was already stored", () => {
+    const id = nextId();
+    localStorage.setItem(`covan:first-week-dismissed:${id}`, "1");
+    const { result } = renderHook(() => useChecklistDismissed(id));
+    expect(result.current.dismissed).toBe(true);
+  });
+
+  it("reads the flag on the render the id shows up, with no effect in between", () => {
+    // The case the old comment was about: `api.me()` answers a beat after the
+    // first render. A lazy initialiser would have run against `undefined` and
+    // never looked again; a snapshot function is called every render.
+    const id = nextId();
+    localStorage.setItem(`covan:first-week-dismissed:${id}`, "1");
+
+    const { result, rerender } = renderHook(
+      ({ workspaceId }: { workspaceId: string | undefined }) => useChecklistDismissed(workspaceId),
+      { initialProps: { workspaceId: undefined as string | undefined } },
+    );
+    expect(result.current.dismissed).toBe(false);
+
+    rerender({ workspaceId: id });
+    expect(result.current.dismissed).toBe(true);
+  });
+
+  it("dismisses, and says so without a reload", () => {
+    const id = nextId();
+    const { result } = renderHook(() => useChecklistDismissed(id));
+    expect(result.current.dismissed).toBe(false);
+
+    act(() => result.current.dismiss());
+
+    expect(result.current.dismissed).toBe(true);
+    expect(localStorage.getItem(`covan:first-week-dismissed:${id}`)).toBe("1");
+  });
+
+  it("remembers per workspace, so a second setup is still nagged about", () => {
+    const first = nextId();
+    const second = nextId();
+    localStorage.setItem(`covan:first-week-dismissed:${first}`, "1");
+
+    expect(renderHook(() => useChecklistDismissed(first)).result.current.dismissed).toBe(true);
+    expect(renderHook(() => useChecklistDismissed(second)).result.current.dismissed).toBe(false);
+  });
+
+  it("follows a dismissal made in another tab", () => {
+    // What the effect this replaces never did: two tabs disagreed until one of
+    // them was reloaded.
+    const id = nextId();
+    const { result } = renderHook(() => useChecklistDismissed(id));
+    expect(result.current.dismissed).toBe(false);
+
+    act(() => {
+      localStorage.setItem(`covan:first-week-dismissed:${id}`, "1");
+      window.dispatchEvent(new StorageEvent("storage"));
+    });
+
+    expect(result.current.dismissed).toBe(true);
+  });
+
+  it("still hides the checklist when storage refuses the write", () => {
+    // Private mode, or a full quota. Dismissing has to work for the rest of the
+    // session even though nothing can be written down for the next one.
+    const id = nextId();
+    const setItem = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new Error("QuotaExceededError");
+    };
+    try {
+      const { result } = renderHook(() => useChecklistDismissed(id));
+      act(() => result.current.dismiss());
+      expect(result.current.dismissed).toBe(true);
+    } finally {
+      Storage.prototype.setItem = setItem;
+    }
+  });
+
+  it("treats a storage read that throws as not dismissed", () => {
+    const id = nextId();
+    const getItem = Storage.prototype.getItem;
+    Storage.prototype.getItem = () => {
+      throw new Error("SecurityError");
+    };
+    try {
+      const { result } = renderHook(() => useChecklistDismissed(id));
+      expect(result.current.dismissed).toBe(false);
+    } finally {
+      Storage.prototype.getItem = getItem;
+    }
+  });
+});

--- a/src/lib/first-week.ts
+++ b/src/lib/first-week.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import type { Agent, ChatSession } from "./agents-store";
 
 /**
@@ -74,40 +74,82 @@ export function firstWeekRemaining(steps: FirstWeekStep[]): number {
   return steps.filter((s) => !s.done).length;
 }
 
-/**
- * Dismissal, remembered per workspace — a second workspace is a second setup,
- * and being told once about this one should not silence the next.
+/*
+ * The dismissal flag lives in `localStorage`, which is not React's to hold. So
+ * it is read during render through `useSyncExternalStore` rather than copied
+ * into state after mount, the same move `theme.tsx` makes and for the same
+ * reason (#68).
  *
- * The read is in an effect rather than a lazy initialiser because the workspace
- * id arrives from `api.me()` a beat after the first render: an initialiser
- * would run against `undefined` and never look again, so a dismissed checklist
- * would come back on every load. It also keeps the server render out of
- * `localStorage`, which does not exist there.
+ * The old comment here explained why the read could not be a lazy initialiser:
+ * the workspace id arrives from `api.me()` a beat after the first render, so an
+ * initialiser would run against `undefined` and never look again. That is still
+ * true, and it is precisely what a snapshot function handles — it is called on
+ * every render, so the render where the id shows up is the render that reads
+ * the right key. No effect required to notice.
+ *
+ * `localStorage` has no change event of its own within a tab, so `dismiss`
+ * tells the subscribers itself. `storage` covers the other tabs, which the
+ * effect this replaces never listened for: dismissing the checklist in one tab
+ * left it on screen in the next until a reload.
+ */
+const dismissListeners = new Set<() => void>();
+
+/** Dismissals this tab has made, for when the write above them fails. Storage
+    throwing used to be survivable because `dismiss` set React state first and
+    the checklist went away regardless; with the store as the only source of
+    truth, without this the button would visibly do nothing in private mode. */
+const dismissedHere = new Set<string>();
+
+function subscribeDismissed(onStoreChange: () => void) {
+  dismissListeners.add(onStoreChange);
+  window.addEventListener("storage", onStoreChange);
+  return () => {
+    dismissListeners.delete(onStoreChange);
+    window.removeEventListener("storage", onStoreChange);
+  };
+}
+
+/** The key is per workspace: a second workspace is a second setup, and being
+    told once about this one should not silence the next. */
+function dismissKey(workspaceId: string | undefined) {
+  return workspaceId ? `covan:first-week-dismissed:${workspaceId}` : null;
+}
+
+/**
+ * Whether the first-week checklist has been dismissed for this workspace.
  *
  * Storage can throw — private mode, quota — and the answer is a checklist that
- * shows up again, which is the harmless direction.
+ * shows up again, which is the harmless direction. The server snapshot is
+ * `false` for the same reason: `localStorage` does not exist there, and a
+ * checklist that appears and then disappears is better than one that never
+ * appears because we guessed.
  */
 export function useChecklistDismissed(workspaceId: string | undefined) {
-  const key = workspaceId ? `covan:first-week-dismissed:${workspaceId}` : null;
-  const [dismissed, setDismissed] = useState(false);
+  const key = dismissKey(workspaceId);
 
-  useEffect(() => {
-    if (!key) return;
-    try {
-      setDismissed(window.localStorage.getItem(key) === "1");
-    } catch {
-      setDismissed(false);
-    }
-  }, [key]);
+  const dismissed = useSyncExternalStore(
+    subscribeDismissed,
+    () => {
+      if (!key) return false;
+      if (dismissedHere.has(key)) return true;
+      try {
+        return window.localStorage.getItem(key) === "1";
+      } catch {
+        return false;
+      }
+    },
+    () => false,
+  );
 
   const dismiss = () => {
-    setDismissed(true);
     if (!key) return;
+    dismissedHere.add(key);
     try {
       window.localStorage.setItem(key, "1");
     } catch {
       /* back next reload; see above */
     }
+    for (const listener of dismissListeners) listener();
   };
 
   return { dismissed, dismiss };


### PR DESCRIPTION
Seventh of eleven in #68, and the one the issue filed under "a one-shot read of storage, not a subscription". It turns out to want a subscription after all, and the reason is a small bug.

`useChecklistDismissed` kept the flag in state and filled it in from `localStorage` in an effect. The comment it carried was right about why the read could not be a lazy initialiser:

> the workspace id arrives from `api.me()` a beat after the first render: an initialiser would run against `undefined` and never look again

Which is precisely what a snapshot function does for you — it is called on every render, so the render the id turns up in is the render that reads the right key. No effect needed to notice.

**What subscribing adds.** `storage` is now listened for, and it never was. Dismiss the checklist in one tab and it stayed on screen in the other until a reload.

**What it costs, and what pays it back.** `dismiss` used to set state first and write second, so a throw from private mode or a full quota was survivable by accident: the checklist went away for the session regardless. With the store as the only source of truth that would silently stop working, so there is a module-level set of dismissals made in this tab and the snapshot consults it. Same behaviour, on purpose rather than by luck.

**Eight tests**, in a new `first-week-dismissed.test.tsx` — the existing `first-week.test.ts` is pure and this needs `renderHook`. They cover the id arriving a render late, a dismissal from another tab, per-workspace scoping, and storage throwing on both the read and the write. Each test takes a fresh workspace id, because the in-tab set is module-level and deliberately has no reset.

383 tests pass, `tsc` clean. Remaining after this: `create-agent-dialog`, `chat`, `_authed.app:82`, `reset-password`.