### PR TITLE
Fix one of the last three, and say why the other two stay

### DIFF
--- a/src/routes/_authed.agents.$agentId.chat.tsx
+++ b/src/routes/_authed.agents.$agentId.chat.tsx
@@ -439,6 +439,15 @@ function ChatTab() {
     } catch {
       /* ignore */
     }
+    // The last of the eleven in #68, and the one that stays. The other ten were
+    // effects copying something into state that could have been read or derived
+    // instead; this one sends a message. `submit` sets state on the way — that
+    // is what the rule sees — but the state is a consequence of the send, not
+    // the point of the effect, and there is nothing to derive it from: the
+    // draft is a handoff from another route, it is deleted as it is read, and
+    // it can only go once the session is loaded and still empty. Doing it
+    // during render would send a message twice under StrictMode.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void submit(draft);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active?.id, messages.length, busy]);

--- a/src/routes/_authed.app.tsx
+++ b/src/routes/_authed.app.tsx
@@ -77,8 +77,23 @@ function Home() {
   });
 
   // The ⌘K "New agent" action deep-links here with ?new=true.
+  //
+  // One of the eleven in #68, and the second of the two that stay. It is not a
+  // copy of anything: the URL is a request, and this consumes it — opens the
+  // dialog, then takes the request back out of the address bar so closing and
+  // reopening does not reopen it. Synchronising React with the URL is what the
+  // rule's own guidance calls an effect's job.
+  //
+  // Deriving it instead — `createOpen || !!openNew`, and clearing the search
+  // param on close — was tried and is worse. The dialog would then stay open
+  // until the router's update lands, and TanStack does that in a transition,
+  // so React is free to defer it: closing the dialog would visibly lag on the
+  // ⌘K path and only on the ⌘K path. Both palette entries can also fire while
+  // already on /app, so a `useState(!!openNew)` initialiser never sees the
+  // second press.
   useEffect(() => {
     if (openNew) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setCreateOpen(true);
       navigate({ to: "/app", search: {}, replace: true });
     }

--- a/src/routes/reset-password.tsx
+++ b/src/routes/reset-password.tsx
@@ -23,18 +23,22 @@ function readUrlError(): string | null {
 function ResetPassword() {
   const [showPassword, setShowPassword] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<"checking" | "ready" | "invalid" | "done">("checking");
+  // Supabase puts a rejected link's reason in the URL fragment before this
+  // component ever renders, so it is known at mount and read here rather than
+  // announced by an effect afterwards (#68). The rest of the effect below —
+  // the auth subscription — is what an effect is for, and stays.
+  const [urlError] = useState(readUrlError);
+  const [error, setError] = useState<string | null>(urlError);
+  const [status, setStatus] = useState<"checking" | "ready" | "invalid" | "done">(
+    urlError ? "invalid" : "checking",
+  );
 
   useEffect(() => {
-    let active = true;
+    // An expired or already-used link. There is no token to wait for, so
+    // subscribing would only keep a listener alive to hear nothing.
+    if (urlError) return;
 
-    const urlError = readUrlError();
-    if (urlError) {
-      setStatus("invalid");
-      setError(urlError);
-      return;
-    }
+    let active = true;
 
     // The reset email link redirects here with a recovery token. supabase-js
     // (detectSessionInUrl, on by default) parses it and fires PASSWORD_RECOVERY,
@@ -61,7 +65,7 @@ function ResetPassword() {
       active = false;
       subscription.subscription.unsubscribe();
     };
-  }, []);
+  }, [urlError]);
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();


### PR DESCRIPTION
The tail of #68. Three effects, and only one of them was copying something it could have read.

**`reset-password` — fixed.** Supabase puts a rejected link's reason in the URL fragment before this component renders, so the effect that announced it was telling React something already true at mount. That branch is a `useState` initialiser now, and the effect returns early instead of subscribing to an auth event that cannot arrive — a dead link has no token behind it.

**`chat:442` — stays.** This effect sends the draft handed over from the composer on `/app`: read from `sessionStorage`, deleted as it is read, sent only once the session has loaded and is still empty. `submit` sets state on the way, which is what the rule sees, but the state is a consequence of sending a message rather than the point of the effect. Doing it during render would send twice under StrictMode.

**`_authed.app:82` — stays.** `?new=true` is a request from ⌘K and this consumes it: open the dialog, then take the parameter back out of the URL so closing and reopening does not reopen it. Synchronising React with the address bar is what the rule's own guidance describes an effect as being for.

The derived alternative was written and thrown away, and that is worth recording so nobody rediscovers it:

- `createOpen || !!openNew`, clearing the parameter on close, leaves the dialog open until the router's update lands. TanStack navigates inside a transition, so React is free to defer it — the result is a close that visibly lags, on the ⌘K path and only there.
- `useState(!!openNew)` never sees a second press. Both palette entries (`command-palette.tsx:102`, `app-shell.tsx:442`) can fire while already on `/app`, where nothing remounts.

Both disables name `set-state-in-effect` specifically and carry their reasoning inline, so flipping the rule to `error` will not have to argue with them.

With #78 merged this leaves zero reports. 383 tests pass, `tsc` clean.