### PR TITLE
Let the rule fail the build, now that it has nothing to report

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,21 +42,23 @@ export default tseslint.config(
       // two that did not — `static-components` and `refs` — were fixed rather
       // than silenced, because each was one site and each was a real defect.
       //
-      // This one is different, and the difference is worth writing down. It
-      // reports eleven sites, and every one of them is the same shape: read
-      // something that only exists in a browser — `matchMedia`, `localStorage`,
-      // the theme the init script chose, a form field seeded from a query that
-      // resolves a beat after first render — and put it into state after mount.
-      // The rule is right that this costs a second render, and right that
-      // `useSyncExternalStore` is the answer for most of them. It is a
-      // behavioural refactor of eleven call sites across the chat, settings,
-      // theme and onboarding surfaces, and it does not belong in the commit
-      // that upgrades the plugin: a dependency bump that quietly rewrites how
-      // the theme loads is a dependency bump nobody can review.
+      // This one arrived reporting eleven sites, which was too many to fix in
+      // the commit that upgraded the plugin — a dependency bump that quietly
+      // rewrites how the theme loads is a dependency bump nobody can review.
+      // It sat at `warn` while covan#68 worked through them, and the rule was
+      // right about nine: they read something that only exists in a browser —
+      // `matchMedia`, `localStorage`, the theme the init script chose, a form
+      // field seeded from a query — and copied it into state after mount.
+      // `useSyncExternalStore`, a `key`, and in two cases deleting the effect
+      // outright. One of them was a live bug rather than an extra render.
       //
-      // A warning, not off, so the count stays visible and a twelfth site
-      // announces itself. The eleven are enumerated in covan#68.
-      "react-hooks/set-state-in-effect": "warn",
+      // `error` now, because the two that remain are not oversights and say so
+      // where they are: `chat.tsx` sends a draft handed over from another
+      // route, and `_authed.app.tsx` consumes a `?new=true` deep link. Both
+      // carry a targeted disable and the reasoning for it. A twelfth site is
+      // now a build failure, which is the right answer — the fix is either an
+      // hour's work or a sentence explaining why it is the exception.
+      "react-hooks/set-state-in-effect": "error",
       "no-restricted-imports": [
         "error",
         {


### PR DESCRIPTION
Closes #68.

`react-hooks/set-state-in-effect` arrived with the `eslint-plugin-react-hooks` 7 upgrade reporting eleven sites, which was too many to fix inside a dependency bump. It has sat at `warn` since, with the eleven enumerated in #68.

Nine are now gone:

| site | what replaced the effect |
|---|---|
| `use-mobile`, `theme` ×2 | `useSyncExternalStore` (#74) |
| `_authed.app:180` | nothing — the fallback below it already answered (#75) |
| `_authed.settings` ×2, `agents/$agentId/settings` | `key`, so the id decides when a form resets (#76) |
| `first-week` | `useSyncExternalStore`, plus a `storage` listener it never had (#77) |
| `create-agent-dialog` | the dialog unmounting its own content (#78) |
| `reset-password` | a `useState` initialiser; the URL already said so (#79) |

Two stay, both with a targeted disable and their reasoning inline: `chat.tsx` sends a draft handed over from another route, and `_authed.app.tsx` consumes a `?new=true` deep link.

**Why `error` rather than leaving it at `warn`.** At `warn` the eleven were a number in a log nobody reads on a green build, and a twelfth would have joined them without anybody noticing — which is how it got to eleven. Now it stops CI, and the author's choice is an hour's work or a sentence explaining the exception. That is the same choice the two remaining sites made, and both wrote the sentence.

**One of the nine was a live bug**, not an extra render: `_authed.settings.tsx` seeded the workspace form from `me.workspace`, a fresh object on every refetch, and the page refetches `me` itself — so saving your display name reverted an unsaved workspace name in the field above it.

Verified with `--no-inline-config` that the rule reports two errors without the disables, so it is biting rather than passing because it has stopped looking. 0 errors, 383 tests.