### PR TITLE
Refuse to run the RLS suite against a database that is behind

### DIFF
--- a/tests/rls/preflight.test.ts
+++ b/tests/rls/preflight.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+
+import { missingMigrations, unknownToCheckout, type Ledger } from "./preflight";
+
+/*
+ * The comparison behind the preflight check in `preflight.ts`, tested without a
+ * database. The check itself runs as `globalSetup`, where it cannot be asserted
+ * on — a `globalSetup` that throws takes the run with it, which is the point of
+ * it. This covers the part that decides whether it throws.
+ *
+ * It lives in tests/rls/ rather than src/ because that is where the code is.
+ * It needs no database of its own; the suite around it already has one.
+ */
+const ledger = (patch: Partial<{ filenames: string[]; versions: string[] }> = {}): Ledger => ({
+  filenames: new Set(patch.filenames ?? []),
+  versions: new Set(patch.versions ?? []),
+});
+
+const FILES = ["0001_init.sql", "0002_policies.sql", "0003_api_keys.sql"];
+
+describe("missingMigrations", () => {
+  it("finds nothing when the compose ledger has every file", () => {
+    expect(missingMigrations(FILES, ledger({ filenames: FILES }))).toEqual([]);
+  });
+
+  it("names the files a compose stack has not applied", () => {
+    // The shape of the failure this whole check exists for: the database was at
+    // 0029, the repository at 0034, and `api_keys` did not exist.
+    expect(missingMigrations(FILES, ledger({ filenames: FILES.slice(0, 1) }))).toEqual([
+      "0002_policies.sql",
+      "0003_api_keys.sql",
+    ]);
+  });
+
+  it("accepts the CLI's version prefixes as applied", () => {
+    // `supabase start` records `0001`, not `0001_init.sql`. Matching only on
+    // filenames would report every migration as missing on a stack that has
+    // them all — a check that fails where nothing is wrong is worse than none.
+    expect(missingMigrations(FILES, ledger({ versions: ["0001", "0002", "0003"] }))).toEqual([]);
+  });
+
+  it("names what the CLI is missing, by prefix", () => {
+    expect(missingMigrations(FILES, ledger({ versions: ["0001", "0002"] }))).toEqual([
+      "0003_api_keys.sql",
+    ]);
+  });
+
+  it("takes either ledger as an answer", () => {
+    // Nothing stops a database from having both tables — a compose stack that
+    // was once pointed at by the CLI, or the reverse. A file applied by either
+    // route is applied.
+    expect(
+      missingMigrations(FILES, ledger({ filenames: ["0003_api_keys.sql"], versions: ["0001"] })),
+    ).toEqual(["0002_policies.sql"]);
+  });
+
+  it("reports everything when both ledgers are empty", () => {
+    expect(missingMigrations(FILES, ledger())).toEqual(FILES);
+  });
+});
+
+describe("unknownToCheckout", () => {
+  it("says nothing when the database matches", () => {
+    expect(unknownToCheckout(FILES, ledger({ filenames: FILES }))).toEqual([]);
+  });
+
+  it("names a migration the database has and the branch does not", () => {
+    expect(
+      unknownToCheckout(FILES, ledger({ filenames: [...FILES, "0004_from_another_branch.sql"] })),
+    ).toEqual(["0004_from_another_branch.sql"]);
+  });
+
+  it("does not mistake a hosted-only migration for a missing one", () => {
+    // In the cloud tree `supabase/cloud/` is on disk too, so its files are in
+    // `onDisk` and must not be reported in either direction.
+    const withCloud = [...FILES, "0100_metered_usage.sql"];
+    expect(unknownToCheckout(withCloud, ledger({ filenames: withCloud }))).toEqual([]);
+    expect(missingMigrations(withCloud, ledger({ filenames: withCloud }))).toEqual([]);
+  });
+});

--- a/tests/rls/preflight.ts
+++ b/tests/rls/preflight.ts
@@ -1,0 +1,157 @@
+/**
+ * Refuses to run the RLS suite against a database that is behind the checkout.
+ *
+ * The compose stack applies `supabase/migrations/` once, at `docker compose up`.
+ * Pull new migrations and the containers keep serving the old schema — and the
+ * suite then reports policy failures for policies that were never installed.
+ * That is the worst shape a red suite can take: it blames the code for the
+ * environment, and the danger is not the confusion, it is somebody "fixing" a
+ * policy that was correct.
+ *
+ * So this runs once, before any test file, and turns a dozen misleading
+ * failures into one sentence naming the missing files. It is `globalSetup`
+ * rather than a test on purpose: CI builds a fresh database every run and would
+ * never trip it, and a test that only ever passes in CI is protecting CI rather
+ * than the laptop where the problem actually happens.
+ *
+ * Two ledgers, because there are two supported ways to have a database here and
+ * they do not record the same thing:
+ *
+ *   covan_meta.migrations                   docker/migrate.sh — filenames
+ *   supabase_migrations.schema_migrations   the Supabase CLI — version prefixes
+ *
+ * `resolveConfig` in harness.ts accepts either stack, so this has to as well; a
+ * check that only understood the compose ledger would fail every `supabase
+ * start` run with a message about migrations that are, in fact, applied.
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+
+import { sql, closeSql } from "./harness";
+
+/**
+ * The directories the stack applies, in the order it applies them.
+ *
+ * These are `docker/migrate.sh`'s two default mounts: the schema everybody
+ * gets, and a deployment's own additions. The second is absent in the
+ * open-source tree, which is why it is checked for rather than assumed — the
+ * same file then works in both.
+ */
+const MIGRATION_DIRS = ["supabase/migrations", "supabase/cloud"];
+
+function migrationFilesOnDisk(): string[] {
+  const files: string[] = [];
+  for (const dir of MIGRATION_DIRS) {
+    if (!existsSync(dir)) continue;
+    files.push(...readdirSync(dir).filter((name) => name.endsWith(".sql")));
+  }
+  return files.sort();
+}
+
+/** `0034_something.sql` → `0034`. What the Supabase CLI stores as a version. */
+function versionOf(filename: string): string {
+  return filename.split("_")[0];
+}
+
+export type Ledger = {
+  /** Filenames, from `covan_meta.migrations`. Empty if that table is absent. */
+  filenames: Set<string>;
+  /** Version prefixes, from the CLI's table. Empty if that table is absent. */
+  versions: Set<string>;
+};
+
+/**
+ * Files on disk that neither ledger accounts for — the database is behind.
+ *
+ * A file counts as applied if either ledger knows it, because the two stacks
+ * record it differently and a developer has only ever used one of them.
+ */
+export function missingMigrations(onDisk: string[], ledger: Ledger): string[] {
+  return onDisk.filter(
+    (name) => !ledger.filenames.has(name) && !ledger.versions.has(versionOf(name)),
+  );
+}
+
+/**
+ * Ledger entries with no file behind them — the checkout is behind.
+ *
+ * Not an error: every policy under test is installed, so the suite is sound.
+ * It means the branch is older than the database, which is worth one line
+ * before somebody reads a green run as a statement about this branch.
+ */
+export function unknownToCheckout(onDisk: string[], ledger: Ledger): string[] {
+  const names = new Set(onDisk);
+  const versions = new Set(onDisk.map(versionOf));
+  return [
+    ...[...ledger.filenames].filter((name) => !names.has(name)),
+    ...[...ledger.versions].filter((version) => !versions.has(version)),
+  ].sort();
+}
+
+export async function setup() {
+  const onDisk = migrationFilesOnDisk();
+  if (onDisk.length === 0) {
+    throw new Error(
+      `No .sql files under ${MIGRATION_DIRS.join(" or ")}. ` +
+        "The suite is being run from somewhere that is not the repository root.",
+    );
+  }
+
+  const db = sql();
+  try {
+    // `to_regclass` answers null instead of raising, so a stack with neither
+    // ledger is a message rather than a stack trace.
+    const [present] = await db<{ compose: boolean; cli: boolean }[]>`
+      select to_regclass('covan_meta.migrations') is not null as compose,
+             to_regclass('supabase_migrations.schema_migrations') is not null as cli
+    `;
+
+    if (!present.compose && !present.cli) {
+      throw new Error(
+        "This database has no migration ledger, so nothing has been applied to it.\n" +
+          "  Compose stack:  docker compose up migrate\n" +
+          "  Supabase CLI:   supabase start",
+      );
+    }
+
+    const ledger: Ledger = { filenames: new Set(), versions: new Set() };
+    if (present.compose) {
+      const rows = await db<{ filename: string }[]>`select filename from covan_meta.migrations`;
+      for (const row of rows) ledger.filenames.add(row.filename);
+    }
+    // Version prefixes, kept in their own set: the CLI records `0034`, not
+    // `0034_a_name.sql`, and matching a bare number against filenames would
+    // count nothing.
+    if (present.cli) {
+      const rows = await db<
+        { version: string }[]
+      >`select version from supabase_migrations.schema_migrations`;
+      for (const row of rows) ledger.versions.add(row.version);
+    }
+
+    const missing = missingMigrations(onDisk, ledger);
+
+    if (missing.length > 0) {
+      const how = present.compose ? "docker compose up migrate" : "supabase migration up";
+      throw new Error(
+        `The database is behind this checkout by ${missing.length} migration${
+          missing.length === 1 ? "" : "s"
+        }.\n\n` +
+          missing.map((name) => `  ${name}`).join("\n") +
+          `\n\nEvery policy those files install is missing, so the suite would report ` +
+          `them as regressions in code that is fine. Apply them first:\n\n  ${how}\n`,
+      );
+    }
+
+    const unknown = unknownToCheckout(onDisk, ledger);
+    if (unknown.length > 0) {
+      console.warn(
+        `\nThis database has ${unknown.length} migration(s) this checkout does not: ` +
+          `${unknown.sort().join(", ")}.\n` +
+          `The schema is ahead of the branch. Nothing here will fail because of it.\n`,
+      );
+    }
+  } finally {
+    await closeSql();
+  }
+}

--- a/vitest.rls.config.ts
+++ b/vitest.rls.config.ts
@@ -12,6 +12,11 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["tests/rls/**/*.test.ts"],
+    // Reads the migration ledger before the first test file and refuses to run
+    // against a database that is behind the checkout. `globalSetup`, not a
+    // test: a stale schema makes the whole suite lie, so the right answer is
+    // one sentence instead of a dozen failures blaming the policies.
+    globalSetup: ["tests/rls/preflight.ts"],
     environment: "node",
     globals: true,
     testTimeout: 30_000,


### PR DESCRIPTION
Closes #57.

The compose stack applies `supabase/migrations/` once, at `docker compose up`. Pull new migrations and the containers keep serving the old schema — and the suite then reports fourteen policy failures across five files for policies that were never installed. A red suite that blames the code for the environment, and the real cost is the temptation to "fix" a policy that was correct.

A `globalSetup` now reads the migration ledger before the first test file and refuses to run, naming the missing filenames and the command that applies them:

```
The database is behind this checkout by 5 migrations.

  0030_….sql
  0031_….sql
  …

Every policy those files install is missing, so the suite would report them as
regressions in code that is fine. Apply them first:

  docker compose up migrate
```

`globalSetup` rather than a test, for the reason the issue gives: CI builds a fresh database every run and would never trip it, and a test that only ever passes in CI is protecting CI rather than the laptop where this actually happens.

**One correction to the issue, and it matters.** It says the Supabase CLI stack "reads the same ledger, so it should just work". It does not. `supabase start` records into `supabase_migrations.schema_migrations` keyed on the version prefix (`0034`), while `docker/migrate.sh` writes `covan_meta.migrations` keyed on the filename (`0034_a_name.sql`). `resolveConfig` accepts either stack, so a check that only understood the compose ledger would have failed every `supabase start` run with a message about migrations that were, in fact, applied — the exact failure mode this issue is about, pointed the other way. Both tables are read; a file applied by either route counts.

`to_regclass` for both, so a database with neither ledger gets a sentence naming both ways to fix it rather than a stack trace.

**Also reported, as a warning and not a failure:** ledger entries with no file behind them. The schema is ahead of the branch, every policy under test is installed, and the suite is sound — but a green run is then not a statement about this branch, which is worth one line.

**Nine tests** for the comparison, which is the part that can be wrong: compose-only, CLI-only, both at once, neither, and the hosted-only `supabase/cloud/` files that must not be reported in either direction. They need no database of their own.

Docker is not running on this machine, so the live SQL is not something I could exercise locally — CI's Row level security job runs the compose stack, applies migrations and then the suite, so a wrong query there fails this PR rather than merging quietly.