### PR TITLE
Let a version prefix speak only for the directory it is unique in

### DIFF
--- a/tests/rls/preflight.test.ts
+++ b/tests/rls/preflight.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { missingMigrations, unknownToCheckout, type Ledger } from "./preflight";
+import { missingMigrations, unknownToCheckout, type Ledger, type MigrationFile } from "./preflight";
 
 /*
  * The comparison behind the preflight check in `preflight.ts`, tested without a
@@ -16,17 +16,23 @@ const ledger = (patch: Partial<{ filenames: string[]; versions: string[] }> = {}
   versions: new Set(patch.versions ?? []),
 });
 
-const FILES = ["0001_init.sql", "0002_policies.sql", "0003_api_keys.sql"];
+/** Under `supabase/migrations/` — the one directory the CLI reads. */
+const shared = (...names: string[]): MigrationFile[] => names.map((name) => ({ name, cli: true }));
+/** Under `supabase/cloud/`, which only `docker/migrate.sh` applies. */
+const hosted = (...names: string[]): MigrationFile[] => names.map((name) => ({ name, cli: false }));
+
+const FILES = shared("0001_init.sql", "0002_policies.sql", "0003_api_keys.sql");
+const NAMES = FILES.map((file) => file.name);
 
 describe("missingMigrations", () => {
   it("finds nothing when the compose ledger has every file", () => {
-    expect(missingMigrations(FILES, ledger({ filenames: FILES }))).toEqual([]);
+    expect(missingMigrations(FILES, ledger({ filenames: NAMES }))).toEqual([]);
   });
 
   it("names the files a compose stack has not applied", () => {
     // The shape of the failure this whole check exists for: the database was at
     // 0029, the repository at 0034, and `api_keys` did not exist.
-    expect(missingMigrations(FILES, ledger({ filenames: FILES.slice(0, 1) }))).toEqual([
+    expect(missingMigrations(FILES, ledger({ filenames: NAMES.slice(0, 1) }))).toEqual([
       "0002_policies.sql",
       "0003_api_keys.sql",
     ]);
@@ -55,26 +61,47 @@ describe("missingMigrations", () => {
   });
 
   it("reports everything when both ledgers are empty", () => {
-    expect(missingMigrations(FILES, ledger())).toEqual(FILES);
+    expect(missingMigrations(FILES, ledger())).toEqual(NAMES);
+  });
+
+  it("does not let a shared prefix vouch for a hosted-only file", () => {
+    // The hosted tree numbers supabase/cloud/ from 0001 of its own, so
+    // `0001_user_usage.sql` and `0001_init.sql` have the same version and are
+    // different migrations. `supabase start` never reads supabase/cloud/ at
+    // all, so its `0001` can only ever mean the shared one — and treating the
+    // prefix as an answer for both would report a database as up to date while
+    // `user_usage` did not exist.
+    const tree = [...FILES, ...hosted("0001_user_usage.sql")];
+    expect(missingMigrations(tree, ledger({ versions: ["0001", "0002", "0003"] }))).toEqual([
+      "0001_user_usage.sql",
+    ]);
+  });
+
+  it("takes the compose ledger's word for a hosted-only file", () => {
+    // The route that does apply it keys on the filename, where there is no
+    // collision — migrate.sh refuses one outright.
+    const tree = [...FILES, ...hosted("0001_user_usage.sql")];
+    expect(
+      missingMigrations(tree, ledger({ filenames: [...NAMES, "0001_user_usage.sql"] })),
+    ).toEqual([]);
   });
 });
 
 describe("unknownToCheckout", () => {
   it("says nothing when the database matches", () => {
-    expect(unknownToCheckout(FILES, ledger({ filenames: FILES }))).toEqual([]);
+    expect(unknownToCheckout(FILES, ledger({ filenames: NAMES }))).toEqual([]);
   });
 
   it("names a migration the database has and the branch does not", () => {
     expect(
-      unknownToCheckout(FILES, ledger({ filenames: [...FILES, "0004_from_another_branch.sql"] })),
+      unknownToCheckout(FILES, ledger({ filenames: [...NAMES, "0004_from_another_branch.sql"] })),
     ).toEqual(["0004_from_another_branch.sql"]);
   });
 
-  it("does not mistake a hosted-only migration for a missing one", () => {
-    // In the cloud tree `supabase/cloud/` is on disk too, so its files are in
-    // `onDisk` and must not be reported in either direction.
-    const withCloud = [...FILES, "0100_metered_usage.sql"];
-    expect(unknownToCheckout(withCloud, ledger({ filenames: withCloud }))).toEqual([]);
-    expect(missingMigrations(withCloud, ledger({ filenames: withCloud }))).toEqual([]);
+  it("does not read a hosted-only file as a stray ledger entry", () => {
+    const tree = [...FILES, ...hosted("0001_user_usage.sql")];
+    expect(
+      unknownToCheckout(tree, ledger({ filenames: [...NAMES, "0001_user_usage.sql"] })),
+    ).toEqual([]);
   });
 });

--- a/tests/rls/preflight.ts
+++ b/tests/rls/preflight.ts
@@ -36,19 +36,47 @@ import { sql, closeSql } from "./harness";
  * gets, and a deployment's own additions. The second is absent in the
  * open-source tree, which is why it is checked for rather than assumed — the
  * same file then works in both.
+ *
+ * `cli` marks the one directory `supabase start` knows about. It matters
+ * because the two ledgers key on different things, and only one of them can
+ * speak for a hosted-only file. See `versionOf`.
  */
-const MIGRATION_DIRS = ["supabase/migrations", "supabase/cloud"];
+const MIGRATION_DIRS = [
+  { path: "supabase/migrations", cli: true },
+  { path: "supabase/cloud", cli: false },
+];
 
-function migrationFilesOnDisk(): string[] {
-  const files: string[] = [];
+export type MigrationFile = {
+  name: string;
+  /** Whether a CLI stack would have applied this file, had one been used. */
+  cli: boolean;
+};
+
+function migrationFilesOnDisk(): MigrationFile[] {
+  const files: MigrationFile[] = [];
   for (const dir of MIGRATION_DIRS) {
-    if (!existsSync(dir)) continue;
-    files.push(...readdirSync(dir).filter((name) => name.endsWith(".sql")));
+    if (!existsSync(dir.path)) continue;
+    for (const name of readdirSync(dir.path)) {
+      if (name.endsWith(".sql")) files.push({ name, cli: dir.cli });
+    }
   }
-  return files.sort();
+  return files.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-/** `0034_something.sql` → `0034`. What the Supabase CLI stores as a version. */
+/**
+ * `0034_something.sql` → `0034`. What the Supabase CLI stores as a version.
+ *
+ * A prefix is only unique inside one directory. The hosted tree numbers
+ * `supabase/cloud/` from 0001 of its own, so `0001_user_usage.sql` and
+ * `0001_init.sql` share a version while being different migrations —
+ * `docker/migrate.sh` gets away with it because its ledger keys on the full
+ * filename, and it refuses a genuine filename collision outright.
+ *
+ * So a version only ever answers for a file the CLI could have applied, which
+ * is `supabase/migrations/` and nothing else. Without that restriction a CLI
+ * stack in the hosted tree would count `0001_user_usage.sql` as applied on the
+ * strength of `0001_init.sql` — and it is a file the CLI never even reads.
+ */
 function versionOf(filename: string): string {
   return filename.split("_")[0];
 }
@@ -66,10 +94,14 @@ export type Ledger = {
  * A file counts as applied if either ledger knows it, because the two stacks
  * record it differently and a developer has only ever used one of them.
  */
-export function missingMigrations(onDisk: string[], ledger: Ledger): string[] {
-  return onDisk.filter(
-    (name) => !ledger.filenames.has(name) && !ledger.versions.has(versionOf(name)),
-  );
+export function missingMigrations(onDisk: MigrationFile[], ledger: Ledger): string[] {
+  return onDisk
+    .filter(
+      (file) =>
+        !ledger.filenames.has(file.name) &&
+        !(file.cli && ledger.versions.has(versionOf(file.name))),
+    )
+    .map((file) => file.name);
 }
 
 /**
@@ -79,9 +111,9 @@ export function missingMigrations(onDisk: string[], ledger: Ledger): string[] {
  * It means the branch is older than the database, which is worth one line
  * before somebody reads a green run as a statement about this branch.
  */
-export function unknownToCheckout(onDisk: string[], ledger: Ledger): string[] {
-  const names = new Set(onDisk);
-  const versions = new Set(onDisk.map(versionOf));
+export function unknownToCheckout(onDisk: MigrationFile[], ledger: Ledger): string[] {
+  const names = new Set(onDisk.map((file) => file.name));
+  const versions = new Set(onDisk.filter((file) => file.cli).map((file) => versionOf(file.name)));
   return [
     ...[...ledger.filenames].filter((name) => !names.has(name)),
     ...[...ledger.versions].filter((version) => !versions.has(version)),
@@ -92,7 +124,7 @@ export async function setup() {
   const onDisk = migrationFilesOnDisk();
   if (onDisk.length === 0) {
     throw new Error(
-      `No .sql files under ${MIGRATION_DIRS.join(" or ")}. ` +
+      `No .sql files under ${MIGRATION_DIRS.map((dir) => dir.path).join(" or ")}. ` +
         "The suite is being run from somewhere that is not the repository root.",
     );
   }


### PR DESCRIPTION
Follow-up to #81, found while mirroring it into the hosted tree — where `supabase/cloud/` exists and this repo has nothing to catch it with.

#81 accepts a Supabase CLI version prefix as proof a migration is applied: `0034` stands for `0034_a_name.sql`. The hosted tree numbers `supabase/cloud/` from 0001 of its own, so `0001_user_usage.sql` and `0001_init.sql` share a version while being different migrations. `docker/migrate.sh` is unbothered — its ledger keys on the whole filename, and it refuses an actual filename collision outright.

So on a `supabase start` stack in the hosted tree, `0001` would have vouched for a file the CLI has never even read: `supabase/cloud/` is not a directory it looks in. The check would have reported a database as up to date while `user_usage` did not exist — which is precisely the failure #57 describes, wearing the uniform of the thing built to prevent it.

A version now only answers for a file the CLI could have applied. The on-disk list carries which directory each file came from:

```ts
const MIGRATION_DIRS = [
  { path: "supabase/migrations", cli: true },
  { path: "supabase/cloud", cli: false },
];
```

The compose ledger is untouched — it is the route that does apply `supabase/cloud/`, and it keys on the filename, where there is no collision.

**Two more tests, eleven in all.** A shared prefix must not vouch for a hosted-only file; the compose ledger must still be taken at its word for one.

Nothing here changes behaviour in this repo, where `supabase/cloud/` does not exist. It is here because the file has to stay identical in both trees, and because a check that can be silently wrong in one of them is worth less than no check.