### PR TITLE
Check the directory wiring against the directories

### DIFF
--- a/tests/rls/preflight.test.ts
+++ b/tests/rls/preflight.test.ts
@@ -1,6 +1,15 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
 import { describe, it, expect } from "vitest";
 
-import { missingMigrations, unknownToCheckout, type Ledger, type MigrationFile } from "./preflight";
+import {
+  migrationFilesOnDisk,
+  missingMigrations,
+  unknownToCheckout,
+  type Ledger,
+  type MigrationFile,
+} from "./preflight";
 
 /*
  * The comparison behind the preflight check in `preflight.ts`, tested without a
@@ -84,6 +93,39 @@ describe("missingMigrations", () => {
     expect(
       missingMigrations(tree, ledger({ filenames: [...NAMES, "0001_user_usage.sql"] })),
     ).toEqual([]);
+  });
+});
+
+describe("migrationFilesOnDisk", () => {
+  /*
+   * Read against the repository this is running in, so the assertions have to
+   * hold in both trees. In the open-source one `supabase/cloud/` does not
+   * exist and the second half is vacuous; in the hosted one it is the whole
+   * point, and `0001_user_usage.sql` is the file that has to come back
+   * `cli: false`.
+   */
+  const files = migrationFilesOnDisk();
+
+  it("finds the schema", () => {
+    expect(files.length).toBeGreaterThan(0);
+    expect(files.every((file) => file.name.endsWith(".sql"))).toBe(true);
+  });
+
+  it("comes back sorted, so a message names the files in the order they apply", () => {
+    expect(files.map((file) => file.name)).toEqual([...files.map((file) => file.name)].sort());
+  });
+
+  it("has no two files with the same name", () => {
+    // docker/migrate.sh refuses this outright — its ledger keys on the
+    // filename and could not tell two of them apart. Asserted here too,
+    // because this check keys on the same thing.
+    expect(new Set(files.map((file) => file.name)).size).toBe(files.length);
+  });
+
+  it("marks a file CLI-applicable exactly when it is one the CLI reads", () => {
+    for (const file of files) {
+      expect(file.cli).toBe(existsSync(join("supabase/migrations", file.name)));
+    }
   });
 });
 

--- a/tests/rls/preflight.ts
+++ b/tests/rls/preflight.ts
@@ -52,7 +52,8 @@ export type MigrationFile = {
   cli: boolean;
 };
 
-function migrationFilesOnDisk(): MigrationFile[] {
+/** Exported so a test can check the wiring against the real directories. */
+export function migrationFilesOnDisk(): MigrationFile[] {
   const files: MigrationFile[] = [];
   for (const dir of MIGRATION_DIRS) {
     if (!existsSync(dir.path)) continue;


### PR DESCRIPTION
#82 made a version prefix answer only for `supabase/migrations/`, on the strength of a `cli` flag set where the directories are listed. Nothing checked the flag was set correctly — and that is the one part of #82 that cannot be caught by reasoning about the comparison, because it is a fact about the filesystem rather than about sets.

Four tests read the real directories of whichever tree they run in.

Three hold everywhere: files are found, they come back sorted (so a failure message names them in the order they apply), and no two share a name — the rule `docker/migrate.sh` enforces outright and which this check keys on just as hard.

The fourth is the one that matters:

```ts
it("marks a file CLI-applicable exactly when it is one the CLI reads", () => {
  for (const file of files) {
    expect(file.cli).toBe(existsSync(join("supabase/migrations", file.name)));
  }
});
```

Vacuous in this repo, where `supabase/cloud/` does not exist. In the hosted tree it is the assertion that `0001_user_usage.sql` comes back `cli: false`, which is the whole of #82 — and the tree where getting it wrong would have been silent.

Written to hold in both trees rather than to be right in one, since this file has to stay identical across them.

Fifteen tests. `migrationFilesOnDisk` is exported for this and says so.