### PR TITLE
Record who uploaded a document

### DIFF
--- a/supabase/migrations/0037_who_put_this_here.sql
+++ b/supabase/migrations/0037_who_put_this_here.sql
@@ -1,0 +1,104 @@
+-- =========================================================================
+-- Who put this document here
+--
+-- `documents` knows which bundle it is in and nothing about the person who
+-- uploaded it. That is enough for access — a bundle belongs to a workspace and
+-- the workspace grants the reading — and it stops being enough at exactly one
+-- moment: somebody asks for everything they contributed to be removed.
+--
+-- `DELETE /account` deletes the workspaces nobody else is in and leaves the
+-- ones that still have members, which is the right answer for the room. It
+-- means the leaver's documents stay, readable by the team, and no query could
+-- find them even if we decided they should go. It matters most for a file
+-- dropped into a private chat: it becomes workspace knowledge the moment it is
+-- embedded, and until now nothing recorded whose file it was.
+--
+-- This column does not decide any of that. It is the fact the decision needs,
+-- and the reason to add it before the decision is made is that it cannot be
+-- backfilled. Every document that exists today has no answer and will stay
+-- null forever; the column only ever tells the truth about uploads that come
+-- after it. Each day it does not exist is another day of documents it can
+-- never speak for.
+--
+-- Nullable, and not load-bearing. It says who uploaded a thing, not whose it
+-- is — the same standing as `created_by` on workspaces, agents and bundles,
+-- and it follows their rule from 0016: the reference is `on delete set null`,
+-- so a document does not evaporate because its uploader left. Attribution
+-- survives its author by becoming anonymous, which is also what an account
+-- closure should leave behind.
+
+alter table public.documents
+  add column created_by uuid default auth.uid() references auth.users (id) on delete set null;
+
+comment on column public.documents.created_by is
+  'Who uploaded this, or null: for every document that predates this column, '
+  'and for anything written by the service role. Attribution, not ownership — '
+  'access comes from the bundle''s workspace.';
+
+-- The default is the whole mechanism, and the policy is what makes it honest.
+--
+-- Nothing in the API sends this column: `POST /bundles/:id/documents/upload`
+-- inserts through the caller's own client, so `auth.uid()` fills it in and
+-- there is no code path that could get it wrong by forgetting. But the Data API
+-- is reachable directly, and a hand-written insert can name any column it
+-- likes. Without the check below, a member could file their upload under a
+-- colleague's name — which is worse than no attribution at all, because the
+-- erasure request this column exists to answer would then delete the wrong
+-- person's documents, or miss the right one's.
+--
+-- `is null` stays allowed: the service role inserts with no `auth.uid()`, and
+-- the honest record of that is null rather than a failure.
+
+drop policy if exists "documents_insert_member" on public.documents;
+create policy "documents_insert_member"
+  on public.documents for insert
+  with check (
+    (created_by is null or created_by = auth.uid())
+    and exists (
+      select 1 from public.knowledge_bundles b
+      where b.id = documents.bundle_id and public.can_write_in_workspace(b.workspace_id)
+    )
+  );
+
+-- An update must not be able to do what the insert cannot, and this is a
+-- trigger rather than a policy for a reason worth writing down.
+--
+-- `PATCH` on a document is how a file moves between bundles
+-- (worker/src/routes/documents.ts), and any writer in the workspace may make
+-- that move — including on a document somebody else uploaded. So the obvious
+-- `with check (created_by = auth.uid())` would be wrong twice over: it would
+-- refuse a legitimate move of a colleague's file, and it still would not say
+-- what we mean. RLS's `with check` sees only the new row; "this column may not
+-- change" is a statement about both, and only a trigger can see both.
+--
+-- Without it there is a second door to the same forgery the insert check
+-- closes: upload as yourself, then rewrite `created_by` to a colleague. The
+-- erasure request this column exists to answer would then reach the wrong
+-- person's documents.
+--
+-- The service role is exempt on purpose. It is the only thing that could ever
+-- need to correct this column, and it is not reachable from a browser.
+
+-- Not `security definer`: it reads only the row in front of it and the caller's
+-- own uid, so it needs no privilege the caller does not already have. The
+-- search path is still pinned, because a function that can be reached from a
+-- request should not resolve `auth.uid` through whatever the caller set.
+create or replace function public.documents_pin_created_by()
+returns trigger
+language plpgsql
+set search_path = public, pg_catalog
+as $$
+begin
+  if auth.uid() is not null and new.created_by is distinct from old.created_by then
+    raise exception 'created_by cannot be changed'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_documents_pin_created_by on public.documents;
+create trigger trg_documents_pin_created_by
+  before update on public.documents
+  for each row
+  execute function public.documents_pin_created_by();

--- a/tests/rls/document-attribution.test.ts
+++ b/tests/rls/document-attribution.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Who uploaded a document, and who cannot claim somebody else did.
+ *
+ * `documents.created_by` (0037) exists so an erasure request has something to
+ * find. That makes it different from the other `created_by` columns, which are
+ * decoration: this one will be read to decide what gets deleted, so a wrong
+ * value is worse than no value — it either reaches a colleague's documents or
+ * misses the asker's.
+ *
+ * Nothing in the API sends the column. The default is `auth.uid()` and the
+ * upload route inserts through the caller's own client, so the honest path
+ * cannot get it wrong by forgetting. These tests are about the dishonest one:
+ * the Data API is reachable directly, and a hand-written insert or update can
+ * name any column it likes.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeSql,
+  createTestUser,
+  destroyTestUsers,
+  serviceClient,
+  type TestUser,
+} from "./harness";
+import { seedWorkspace, type Seeded } from "./fixtures";
+
+let owner: TestUser;
+let colleague: TestUser;
+let seeded: Seeded;
+
+beforeAll(async () => {
+  owner = await createTestUser("attribution-owner");
+  colleague = await createTestUser("attribution-colleague");
+  seeded = await seedWorkspace(owner);
+
+  const { error } = await serviceClient()
+    .from("workspace_members")
+    .insert({ workspace_id: owner.workspaceId, user_id: colleague.id, role: "member" });
+  if (error) throw new Error(`could not seed the membership: ${error.message}`);
+});
+
+afterAll(async () => {
+  await destroyTestUsers();
+  await closeSql();
+});
+
+/** A document inserted the way the upload route inserts one: without the column. */
+async function upload(user: TestUser, name: string) {
+  const { data, error } = await user.db
+    .from("documents")
+    .insert({ bundle_id: seeded.bundleId, name })
+    .select("id,created_by")
+    .single();
+  return { data, error };
+}
+
+describe("documents.created_by", () => {
+  it("records the uploader without being told to", async () => {
+    const { data, error } = await upload(owner, "the-default-fills-it-in.txt");
+    expect(error).toBeNull();
+    expect(data?.created_by).toBe(owner.id);
+  });
+
+  it("records the colleague when the colleague uploads", async () => {
+    // Same bundle, same workspace. Attribution is per upload, not per bundle.
+    const { data, error } = await upload(colleague, "not-the-owners.txt");
+    expect(error).toBeNull();
+    expect(data?.created_by).toBe(colleague.id);
+  });
+
+  it("lets an insert say what the default would have said anyway", async () => {
+    const { data, error } = await owner.db
+      .from("documents")
+      .insert({ bundle_id: seeded.bundleId, name: "explicit-and-true.txt", created_by: owner.id })
+      .select("created_by")
+      .single();
+    expect(error).toBeNull();
+    expect(data?.created_by).toBe(owner.id);
+  });
+
+  it("refuses an upload filed under somebody else's name", async () => {
+    // The forgery the policy exists for. Both of these are workspace members
+    // with every right to upload here — the question is only whose it is.
+    const { error } = await colleague.db
+      .from("documents")
+      .insert({
+        bundle_id: seeded.bundleId,
+        name: "filed-under-the-owner.txt",
+        created_by: owner.id,
+      })
+      .select("id")
+      .single();
+    expect(error).not.toBeNull();
+  });
+
+  it("allows an explicit null, which is what the service role writes", async () => {
+    const { data, error } = await serviceClient()
+      .from("documents")
+      .insert({ bundle_id: seeded.bundleId, name: "no-uid-behind-it.txt" })
+      .select("created_by")
+      .single();
+    expect(error).toBeNull();
+    expect(data?.created_by).toBeNull();
+  });
+});
+
+describe("documents.created_by is not editable", () => {
+  it("still lets a colleague move somebody else's document", async () => {
+    // The reason this is a trigger and not a `with check`. Moving a file
+    // between bundles is a workspace-member's right, including for a file
+    // they did not upload — and `with check (created_by = auth.uid())` would
+    // have refused exactly this while claiming to prevent forgery.
+    const { data: doc } = await upload(owner, "the-owners-to-move.txt");
+    const { data: bundle, error: bundleErr } = await owner.db
+      .from("knowledge_bundles")
+      .insert({ workspace_id: owner.workspaceId, name: "Somewhere else", created_by: owner.id })
+      .select("id")
+      .single();
+    if (bundleErr || !bundle)
+      throw new Error(`could not seed a second bundle: ${bundleErr?.message}`);
+
+    const { data: moved, error } = await colleague.db
+      .from("documents")
+      .update({ bundle_id: bundle.id })
+      .eq("id", doc!.id)
+      .select("bundle_id,created_by")
+      .single();
+
+    expect(error).toBeNull();
+    expect(moved?.bundle_id).toBe(bundle.id);
+    // And it is still the owner's upload afterwards.
+    expect(moved?.created_by).toBe(owner.id);
+  });
+
+  it("refuses to reassign an upload to somebody else", async () => {
+    const { data: doc } = await upload(colleague, "mine-until-i-say-otherwise.txt");
+    const { error } = await colleague.db
+      .from("documents")
+      .update({ created_by: owner.id })
+      .eq("id", doc!.id)
+      .select("id")
+      .single();
+    expect(error).not.toBeNull();
+  });
+
+  it("refuses to claim somebody else's upload as your own", async () => {
+    // The other direction, and the one that would quietly enlarge what an
+    // erasure request deletes.
+    const { data: doc } = await upload(owner, "not-yours-to-claim.txt");
+    const { error } = await colleague.db
+      .from("documents")
+      .update({ created_by: colleague.id })
+      .eq("id", doc!.id)
+      .select("id")
+      .single();
+    expect(error).not.toBeNull();
+  });
+
+  it("refuses to erase the attribution", async () => {
+    const { data: doc } = await upload(owner, "cannot-be-anonymised.txt");
+    const { error } = await owner.db
+      .from("documents")
+      .update({ created_by: null })
+      .eq("id", doc!.id)
+      .select("id")
+      .single();
+    expect(error).not.toBeNull();
+  });
+});
+
+describe("a document outlives its uploader", () => {
+  it("keeps the row and drops the name", async () => {
+    // 0016's rule, which this column follows: attribution says who made a
+    // thing, not whose it is. A workspace with other people in it keeps the
+    // document; only the name goes.
+    const leaver = await createTestUser("attribution-leaver");
+    const { error: memberErr } = await serviceClient()
+      .from("workspace_members")
+      .insert({ workspace_id: owner.workspaceId, user_id: leaver.id, role: "member" });
+    if (memberErr) throw new Error(`could not seed the membership: ${memberErr.message}`);
+
+    const { data: doc, error: uploadErr } = await upload(leaver, "left-behind.txt");
+    expect(uploadErr).toBeNull();
+    expect(doc?.created_by).toBe(leaver.id);
+
+    // Their own workspace goes first, by hand. `destroyTestUsers` finds a test
+    // user's workspaces through `created_by`, and this test is about that
+    // column becoming null — so once the user is gone the workspace would no
+    // longer be findable, and it would outlive the run.
+    const { error: wsErr } = await serviceClient()
+      .from("workspaces")
+      .delete()
+      .eq("id", leaver.workspaceId);
+    expect(wsErr).toBeNull();
+
+    const { error: deleteErr } = await serviceClient().auth.admin.deleteUser(leaver.id);
+    expect(deleteErr).toBeNull();
+
+    const { data: after, error } = await owner.db
+      .from("documents")
+      .select("id,created_by")
+      .eq("id", doc!.id)
+      .single();
+    expect(error).toBeNull();
+    expect(after?.id).toBe(doc!.id);
+    expect(after?.created_by).toBeNull();
+  });
+});

--- a/worker/src/lib/export/sql.test.ts
+++ b/worker/src/lib/export/sql.test.ts
@@ -62,6 +62,25 @@ describe("the people", () => {
     expect(sql).toContain(":'owner'");
   });
 
+  it("includes an uploader, which is a column that did not exist when this was written", () => {
+    // `USER_COLUMNS` matches on the column name, so `documents.created_by`
+    // (0037) was handled the moment it shipped and nothing had to be added
+    // here. Asserted rather than assumed: it is a foreign key to `auth.users`,
+    // and a restore that carried the old id would fail on it — after the
+    // workspace and the bundles had already been written.
+    const { sql } = renderSql(
+      base({
+        knowledge_bundles: [{ id: "b1", workspace_id: "w1", name: "Docs", created_at: "t" }],
+        documents: [
+          { id: "d1", bundle_id: "b1", name: "note.txt", created_by: "u9", created_at: "t" },
+        ],
+      }),
+    );
+
+    expect(sql).toContain("insert into public.documents");
+    expect(sql).not.toContain("'u9'");
+  });
+
   it("collapse to exactly one membership row, as an admin", () => {
     // Five members all becoming one account would be five inserts of the same
     // primary key: four swallowed by `on conflict do nothing` and the survivor


### PR DESCRIPTION
Part of #56 — the column, and nothing that depends on the three product questions the issue asks. Those stay open.

`documents` knew which bundle it was in and nothing about who put it there. That is enough for access, since a bundle belongs to a workspace and the workspace grants the reading. It stops being enough at one moment: somebody asks for everything they contributed to be removed, and no query could find it.

**Why this ships before the decisions.** The column cannot be backfilled. Every document that exists today has no answer and will keep none; it only ever tells the truth about uploads that come after it. A week spent deciding is a week of documents it can never speak for — so the fact is worth having under any of the answers, and none of the answers is here.

**Three things make it trustworthy rather than decorative.**

The default is `auth.uid()`, and `POST /bundles/:id/documents/upload` inserts through the caller's own client. Nothing in the API sends the column, so no call site added later can forget it. (The issue expected two upload paths — there is one; a chat upload goes through the same endpoint.)

The insert policy pins it to the caller. The Data API is reachable directly and a hand-written insert can name any column it likes; an upload filed under a colleague's name is worse than no attribution, because the erasure request this exists for would then reach the wrong person's documents.

A trigger stops it changing afterwards, closing the same door from the update side. It is a trigger rather than a `with check` for a reason worth stating: "this column may not change" is a claim about two rows and `with check` sees one. Written as a policy, `created_by = auth.uid()` would also have refused a legitimate move of a colleague's file between bundles — something any workspace member may do. There is a test for exactly that.

`on delete set null`, following 0016: attribution says who made a thing, not whose it is, and a document does not evaporate because its uploader left.

**Nine RLS tests**: the default fills in, an explicit-and-true value is fine, a forged one is refused, the service role's null is allowed, all three ways of editing it are refused, a colleague can still move somebody else's document and it stays theirs afterwards, and a deleted account leaves the row with a null.

**The export needed no change**, which is worth an assertion rather than a shrug. `USER_COLUMNS` in `worker/src/lib/export/sql.ts` matches on column name, so `documents.created_by` collapsed to the restoring account the moment it existed. One test proves it: it is a foreign key to `auth.users`, and a restore carrying the old id would fail *after* the workspace and bundles had been written.

Docker is not running here, so the migration itself is applied for the first time by CI's Row level security job, which brings up the compose stack and runs the suite against it.

689 worker tests pass; `tsc` clean in both trees.