### PR TITLE
Say that a file stays, and how to ask for the other answer

### DIFF
--- a/src/components/close-account-section.test.tsx
+++ b/src/components/close-account-section.test.tsx
@@ -53,6 +53,15 @@ describe("CloseAccountSection", () => {
     expect(screen.getByText(/keep running without you/i)).toBeInTheDocument();
   });
 
+  it("says to ask before closing, on the screen where the decision is made", async () => {
+    render(<CloseAccountSection email={EMAIL} />);
+    // A file that stays is only an acceptable answer if there is a way to ask
+    // for the other one, and the asking has to happen first: closing the
+    // account is what removes the record of who uploaded what (covan#56). A
+    // page somebody would have to already be reading is not where that goes.
+    expect(screen.getByText(/ask before you close/i)).toBeInTheDocument();
+  });
+
   it("refuses to enable the button until the address is typed exactly", async () => {
     render(<CloseAccountSection email={EMAIL} />);
     await openDialog();

--- a/src/components/close-account-section.tsx
+++ b/src/components/close-account-section.tsx
@@ -89,6 +89,19 @@ export function CloseAccountSection({ email }: { email?: string | null }) {
           what you wrote there stays, because it belongs to the workspace rather than to you; your
           name simply comes off it.
         </p>
+        {/* The way out of the paragraph above, and it has to be here rather than
+            only on /privacy — this is the screen where somebody decides, and a
+            page they would have to already be reading is not where you put the
+            one thing that has to happen first. Deliberately not a button: a
+            document that has been indexed is what other people's answers are
+            grounded on, and "delete the 14 files you uploaded" on the way out
+            is a way to damage a team. Asking puts a person in the loop, which
+            is the right amount of friction for something irreversible that
+            affects somebody other than the asker. See covan#56. */}
+        <p className="text-sm leading-[1.5] text-muted-foreground">
+          If you want a file you uploaded removed rather than anonymous, ask before you close, not
+          after — once the account is gone there is nothing left to tell which files were yours.
+        </p>
 
         <div className="border-t border-hairline pt-4">
           <AlertDialog open={open} onOpenChange={reset}>

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -132,6 +132,14 @@ function PrivacyPage() {
           case that is refused is being its last admin — hand the role over first.
         </p>
         <p>
+          A file you uploaded is part of what stays, and it is worth being exact about why. The
+          moment it was indexed it became the workspace's knowledge: other people's answers are
+          grounded on it and cite it by name, so removing it on your way out would quietly change
+          what their agents know. It is anonymised rather than deleted. If you would rather it were
+          deleted, ask before you close the account and not after — a document records who uploaded
+          it, and closing the account is what takes that away.
+        </p>
+        <p>
           There is no separate button for deleting a shared workspace. You can leave one, and an
           admin can remove someone from one, but dismantling a room other people are in is not
           something one person does from this interface.


### PR DESCRIPTION
Closes #56. #84 added the column; this answers the question it deliberately left open.

**A document survives its uploader.** It becomes the workspace's knowledge the moment it is indexed — other people's answers are grounded on it and cite it by name — so removing it on the way out changes what a team's agents know without telling them. That is a worse default than incomplete erasure, and unlike incomplete erasure it is not something the person leaving is in a position to weigh.

**No button, for the same reason.** "Also delete the 14 documents you uploaded" is honest and is also a way to damage a team on your way out, offered at the moment somebody is least inclined to think about the room they are leaving. Asking puts a person in the loop, which is the right friction for something irreversible that lands on somebody else.

**Two sentences, and the placement is the argument.** The closing screen already said what stays; what it did not say is that there is another answer available and that it has to be asked for *first*:

> If you want a file you uploaded removed rather than anonymous, ask before you close, not after — once the account is gone there is nothing left to tell which files were yours.

That is load-bearing, and it is on the screen where the decision happens rather than on `/privacy`, which somebody would already have to be reading. `created_by` is `on delete set null`, so closing the account is precisely what takes the record away — the same shape as the analytics paragraph already on that page, and the same advice.

`/privacy` gets the longer form, including why the file stays at all.

**Neither sentence over-promises.** 0037 cannot be backfilled, so documents uploaded before it carry no uploader. "There is nothing left to tell which files were yours" is true after closure and was already true for those — the wording does not claim a record that may not exist.

The third question in the issue — dangling citations — does not arise under this answer: nothing is deleted, so nothing is left cited and gone.

384 tests, one new: the closing screen says to ask first.