### PR TITLE
Say which documents the answers are standing on

### DIFF
--- a/src/components/revisit-panel.test.tsx
+++ b/src/components/revisit-panel.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// The factory is hoisted above every top-level binding in this file, so the
+// mock has to create the spy itself and the test reaches it back through the
+// module. A `const` declared here would not exist yet when the factory runs.
+vi.mock("@/lib/api-client", () => ({ api: { bundles: { citations: vi.fn() } } }));
+
+import { api } from "@/lib/api-client";
+import { RevisitPanel } from "./revisit-panel";
+
+const citations = api.bundles.citations as unknown as ReturnType<typeof vi.fn>;
+
+const DAY = 24 * 60 * 60 * 1000;
+const daysAgo = (n: number) => Date.now() - n * DAY;
+
+const doc = (id: string, name: string, days: number) => ({ id, name, createdAt: daysAgo(days) });
+
+function renderPanel(documents: ReturnType<typeof doc>[]) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <RevisitPanel documents={documents} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  citations.mockReset();
+});
+
+describe("RevisitPanel", () => {
+  it("names the documents worth going back to, worst first", async () => {
+    citations.mockResolvedValue({
+      since: Date.UTC(2026, 7, 24),
+      counts: { onboarding: 41, pricing: 12 },
+    });
+    renderPanel([doc("onboarding", "onboarding.pdf", 280), doc("pricing", "pricing-v2.md", 210)]);
+
+    await waitFor(() => expect(screen.getByText("Worth revisiting")).toBeInTheDocument());
+
+    const names = screen.getAllByRole("listitem").map((li) => li.textContent);
+    expect(names[0]).toContain("onboarding.pdf");
+    expect(names[0]).toContain("41 answers");
+    expect(names[1]).toContain("pricing-v2.md");
+  });
+
+  it("says nothing at all when nothing qualifies", async () => {
+    // No heading, no empty state, no "0 documents need attention". A panel that
+    // is always on screen stops being read, and this one has to be read on the
+    // days it appears.
+    citations.mockResolvedValue({ since: Date.UTC(2026, 7, 24), counts: { fresh: 90 } });
+    renderPanel([doc("fresh", "written-last-week.md", 3)]);
+
+    await waitFor(() => expect(citations).toHaveBeenCalled());
+    expect(screen.queryByText("Worth revisiting")).not.toBeInTheDocument();
+  });
+
+  it("stays quiet for an old document nothing asks about", async () => {
+    citations.mockResolvedValue({ since: Date.UTC(2026, 7, 24), counts: {} });
+    renderPanel([doc("ancient", "someone-else-problem.md", 900)]);
+
+    await waitFor(() => expect(citations).toHaveBeenCalled());
+    expect(screen.queryByText("Worth revisiting")).not.toBeInTheDocument();
+  });
+
+  it("says what the count is and is not", async () => {
+    // A number invites more trust than it has earned. A citation means the
+    // document was searched and admitted, not that a word of it reached the
+    // model — the context budget cuts documents that are still cited.
+    citations.mockResolvedValue({ since: Date.UTC(2026, 7, 24), counts: { old: 5 } });
+    renderPanel([doc("old", "stale.md", 400)]);
+
+    await waitFor(() => expect(screen.getByText("Worth revisiting")).toBeInTheDocument());
+    expect(screen.getByText(/cited a document, not of answers it changed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Counting answers since Aug 24, 2026/)).toBeInTheDocument();
+  });
+
+  it("leaves the window out rather than inventing one", async () => {
+    // `since` is null when no reply has ever been countable. Printing a date
+    // there would be a claim about data that does not exist.
+    citations.mockResolvedValue({ since: null, counts: { old: 5 } });
+    renderPanel([doc("old", "stale.md", 400)]);
+
+    await waitFor(() => expect(screen.getByText("Worth revisiting")).toBeInTheDocument());
+    expect(screen.queryByText(/Counting answers since/)).not.toBeInTheDocument();
+  });
+
+  it("shows nothing while the count is still on its way", () => {
+    citations.mockReturnValue(new Promise(() => {}));
+    renderPanel([doc("old", "stale.md", 400)]);
+
+    // Not a skeleton. An empty region that later fills with a warning is fine;
+    // a warning-shaped skeleton that resolves to nothing is a false alarm.
+    expect(screen.queryByText("Worth revisiting")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/revisit-panel.tsx
+++ b/src/components/revisit-panel.tsx
@@ -1,0 +1,90 @@
+import { useQuery } from "@tanstack/react-query";
+import { TriangleAlert } from "lucide-react";
+
+import { api } from "@/lib/api-client";
+import {
+  documentsWorthRevisiting,
+  countedSince,
+  type CountedDocument,
+} from "@/lib/stale-documents";
+import { STALE_AFTER_DAYS } from "@/lib/relative-time";
+import { cn } from "@/lib/utils";
+
+/**
+ * The documents this agent reads that are old enough to doubt and used enough
+ * to matter, worst first.
+ *
+ * The source chip already puts an age under an answer, which catches the
+ * problem one reply at a time and only for whoever is reading. This is the
+ * other half: the question "which of our documents is quietly wrong in the most
+ * places" cannot be answered one chip at a time.
+ *
+ * Renders nothing when there is nothing — no heading, no empty state, no "0
+ * documents need attention". A panel that is always there stops being read, and
+ * this one is worth reading on the days it appears.
+ *
+ * The counts come from every conversation in the workspace including the
+ * private ones, which is the only way the number means "how much does this team
+ * lean on it" rather than "how much do *I*". Nothing but the number crosses:
+ * not who asked, not what they asked. See 0038.
+ */
+export function RevisitPanel({
+  documents,
+  className,
+}: {
+  documents: CountedDocument[];
+  className?: string;
+}) {
+  const { data } = useQuery({
+    queryKey: ["bundle-citations"],
+    queryFn: () => api.bundles.citations(),
+    // The answer changes as conversations happen, not as this tab is opened,
+    // and nothing here is urgent enough to refetch on every focus.
+    staleTime: 5 * 60_000,
+  });
+
+  if (!data) return null;
+
+  const worst = documentsWorthRevisiting(documents, data.counts);
+  if (worst.length === 0) return null;
+
+  const window = countedSince(data.since);
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-amber-500/40 bg-amber-500/5 px-5 py-4 text-sm",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2 font-medium text-amber-700 dark:text-amber-400">
+        <TriangleAlert className="h-4 w-4 shrink-0" aria-hidden />
+        Worth revisiting
+      </div>
+      <p className="mt-1 text-xs leading-[1.5] text-muted-foreground">
+        Older than {STALE_AFTER_DAYS} days, and answers are still being built on them.
+      </p>
+      <ul className="mt-3 space-y-1.5">
+        {worst.map((doc) => (
+          <li key={doc.id} className="flex items-baseline gap-2">
+            <span className="min-w-0 flex-1 truncate">{doc.name}</span>
+            <span className="shrink-0 text-xs text-muted-foreground">{doc.age}</span>
+            <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+              {doc.citations} {doc.citations === 1 ? "answer" : "answers"}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-3 border-t border-amber-500/20 pt-2.5 text-xs leading-[1.5] text-muted-foreground">
+        {/* Both halves of the caveat, because a number invites more trust than
+            it has earned. A citation means the document was searched and
+            admitted, not that a word of it reached the model — the context
+            budget cuts documents that are still cited (docs/knowledge.md). And
+            the count starts where citations started carrying ids, not at the
+            beginning of the workspace. */}
+        A count of answers that cited a document, not of answers it changed.
+        {window ? ` ${window}` : null}
+      </p>
+    </div>
+  );
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -66,6 +66,17 @@ export type Bundle = {
   createdAt: number;
 };
 
+export type DocumentCitations = {
+  /**
+   * The oldest reply that could be counted, as a timestamp — or null when there
+   * is none. Not "when we started counting": it is read from the data, so it
+   * moves as old conversations are deleted and stays honest either way.
+   */
+  since: number | null;
+  /** Document id to the number of answers citing it. A document with none is absent. */
+  counts: Record<string, number>;
+};
+
 export type IdeaSuggestion = { title: string; detail: string | null };
 
 // Defined in api-error.ts and re-exported here, so every call site keeps its
@@ -257,6 +268,17 @@ export const api = {
   },
   bundles: {
     list: (): Promise<Bundle[]> => request("GET", "/bundles"),
+    /**
+     * How many answers cite each document in the workspace, and how far back
+     * the counting reaches.
+     *
+     * `since` is not decoration. Replies written before citations carried ids
+     * cannot be matched to a document at all, so every count is over a window —
+     * showing the numbers without saying which window turns a sample into a
+     * census. `null` means nothing has been counted yet, which is a different
+     * screen from every document scoring zero.
+     */
+    citations: (): Promise<DocumentCitations> => request("GET", "/bundles/citations"),
     create: (name: string, description?: string): Promise<Bundle> =>
       request("POST", "/bundles", { name, description }),
     remove: (id: string): Promise<{ ok: true }> => request("DELETE", `/bundles/${id}`),

--- a/src/lib/stale-documents.test.ts
+++ b/src/lib/stale-documents.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+
+import { documentsWorthRevisiting, countedSince } from "./stale-documents";
+import { STALE_AFTER_DAYS } from "./relative-time";
+
+const NOW = Date.UTC(2026, 8, 1);
+const DAY = 24 * 60 * 60 * 1000;
+const daysAgo = (n: number) => NOW - n * DAY;
+
+const doc = (id: string, days: number, name = id) => ({ id, name, createdAt: daysAgo(days) });
+
+describe("documentsWorthRevisiting", () => {
+  it("wants both facts, not either one", () => {
+    // The pair is the whole idea. Old-and-unused is nobody's problem; used-and-
+    // recent is the product working.
+    const documents = [doc("old-unused", 400), doc("recent-busy", 3)];
+    expect(
+      documentsWorthRevisiting(documents, { "old-unused": 0, "recent-busy": 90 }, NOW),
+    ).toEqual([]);
+  });
+
+  it("lists a document that is both old and leaned on", () => {
+    const result = documentsWorthRevisiting([doc("onboarding", 280)], { onboarding: 41 }, NOW);
+    expect(result).toEqual([
+      { id: "onboarding", name: "onboarding", citations: 41, age: "9 months ago" },
+    ]);
+  });
+
+  it("orders by how many answers stand on it, not by age", () => {
+    // The ordering the issue asks for. Age decides whether a document is a
+    // candidate; the count decides which one to fix first.
+    const documents = [doc("ancient", 900), doc("merely-old", 200)];
+    const result = documentsWorthRevisiting(documents, { ancient: 1, "merely-old": 60 }, NOW);
+    expect(result.map((r) => r.id)).toEqual(["merely-old", "ancient"]);
+  });
+
+  it("breaks a tie by name, so the list does not shuffle between renders", () => {
+    const documents = [doc("b", 200), doc("a", 300)];
+    const result = documentsWorthRevisiting(documents, { a: 5, b: 5 }, NOW);
+    expect(result.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("does not count a document the day before it is old enough to doubt", () => {
+    const documents = [
+      doc("day-before", STALE_AFTER_DAYS - 1),
+      doc("on-the-day", STALE_AFTER_DAYS),
+    ];
+    const result = documentsWorthRevisiting(documents, { "day-before": 99, "on-the-day": 1 }, NOW);
+    expect(result.map((r) => r.id)).toEqual(["on-the-day"]);
+  });
+
+  it("treats a document nothing has counted as uncounted, not as zero-risk", () => {
+    // A missing key and an explicit zero mean the same thing here — no answer
+    // stands on it *within the window*. Neither is evidence the document is
+    // fine, which is why the caption saying what the window is ships with it.
+    const documents = [doc("missing", 400), doc("explicit", 400)];
+    expect(documentsWorthRevisiting(documents, { explicit: 0 }, NOW)).toEqual([]);
+  });
+
+  it("says nothing at all when there is nothing to say", () => {
+    expect(documentsWorthRevisiting([], {}, NOW)).toEqual([]);
+  });
+});
+
+describe("countedSince", () => {
+  it("names the date the numbers start at", () => {
+    expect(countedSince(Date.UTC(2026, 7, 24))).toBe("Counting answers since Aug 24, 2026.");
+  });
+
+  it("says nothing when nothing has been counted", () => {
+    // Different from every document scoring zero, and the interface has to be
+    // able to tell those apart: one is "no answers cite these", the other is
+    // "no answer has been countable yet".
+    expect(countedSince(null)).toBeNull();
+  });
+});

--- a/src/lib/stale-documents.ts
+++ b/src/lib/stale-documents.ts
@@ -1,0 +1,80 @@
+import { documentAge, STALE_AFTER_DAYS } from "./relative-time";
+
+/**
+ * Which documents are worth going back to, and in what order.
+ *
+ * The two facts on their own are not useful. A document that is nine months old
+ * and grounds no answers is nobody's problem — it sits in a bundle and nothing
+ * asks it anything. A document that grounds forty answers and was uploaded last
+ * week is working exactly as intended. It is the pair that matters, and the
+ * interface had no way to show a pair.
+ *
+ * So: old enough to doubt, and used enough to matter. Both, or it does not
+ * appear here.
+ *
+ * Ordered by how many answers stand on it, not by age. Age decides whether a
+ * document is a candidate; the count decides which candidate to fix first,
+ * because that is the one whose staleness has reached the most people. An
+ * ordering by age would put a two-year-old document with one citation above a
+ * ten-month-old one with sixty, which is the opposite of useful.
+ */
+export type Revisitable = {
+  id: string;
+  name: string;
+  /** How many answers cite it, over the window the caller reports. */
+  citations: number;
+  /** "9 months ago". */
+  age: string;
+};
+
+export type CountedDocument = {
+  id: string;
+  name: string;
+  createdAt: number;
+};
+
+export function documentsWorthRevisiting(
+  documents: CountedDocument[],
+  counts: Record<string, number>,
+  now: number = Date.now(),
+): Revisitable[] {
+  return documents
+    .map((doc) => ({ doc, age: documentAge(doc.createdAt, now), citations: counts[doc.id] ?? 0 }))
+    .filter(({ age, citations }) => age.stale && citations > 0)
+    .map(({ doc, age, citations }) => ({
+      id: doc.id,
+      name: doc.name,
+      citations,
+      age: age.label,
+    }))
+    .sort(
+      (a, b) =>
+        // Citations first. The name is the tie-break rather than the id, so the
+        // order is stable and reads as a list somebody arranged — two documents
+        // cited the same number of times would otherwise swap places between
+        // renders for no reason a reader could see.
+        b.citations - a.citations || a.name.localeCompare(b.name),
+    );
+}
+
+/**
+ * One sentence saying what the numbers cover, or null when they cover nothing.
+ *
+ * Every count is over a window: replies written before citations carried a
+ * document id cannot be matched to one at all, so the earliest countable reply
+ * is where the numbers begin. Printing "41 answers" without this reads as a
+ * total and is a sample — and the gap is largest for exactly the documents this
+ * feature is about, the old ones that were being cited long before anything was
+ * recording which.
+ */
+export function countedSince(since: number | null): string | null {
+  if (since === null) return null;
+  // A date rather than an age. "9 months ago" is the right unit for a document,
+  // where the question is how much could have changed; this is a boundary, and
+  // a boundary that drifts every time the page is opened is not one a reader
+  // can check anything against.
+  const on = new Intl.DateTimeFormat("en", { day: "numeric", month: "short", year: "numeric" });
+  return `Counting answers since ${on.format(new Date(since))}.`;
+}
+
+export { STALE_AFTER_DAYS };

--- a/src/routes/_authed.agents.$agentId.knowledge.test.tsx
+++ b/src/routes/_authed.agents.$agentId.knowledge.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type React from "react";
 
 vi.mock("@tanstack/react-router", () => ({
@@ -9,7 +10,15 @@ vi.mock("@tanstack/react-router", () => ({
   }),
 }));
 
-vi.mock("@/lib/api-client", () => ({ api: { documents: { download: vi.fn() } } }));
+// `bundles.citations` is here because the tab now renders RevisitPanel, which
+// asks for it. Answering with nothing to revisit keeps these two tests about
+// what they were about — the panel has its own file.
+vi.mock("@/lib/api-client", () => ({
+  api: {
+    documents: { download: vi.fn() },
+    bundles: { citations: vi.fn().mockResolvedValue({ since: null, counts: {} }) },
+  },
+}));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 const store = {
@@ -40,7 +49,12 @@ async function renderTab(canWrite: boolean) {
   store.canWrite = canWrite;
   const { Route } = await import("./_authed.agents.$agentId.knowledge");
   const Component = (Route as unknown as { component: () => React.ReactElement }).component;
-  render(<Component />);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <Component />
+    </QueryClientProvider>,
+  );
 }
 
 describe("the Knowledge tab", () => {

--- a/src/routes/_authed.agents.$agentId.knowledge.tsx
+++ b/src/routes/_authed.agents.$agentId.knowledge.tsx
@@ -5,6 +5,7 @@ import { api } from "@/lib/api-client";
 import { PageContainer, PageHeader, SectionHeading } from "@/components/page-container";
 import { Chip, EmptyState } from "@/components/section-card";
 import { DocsLink } from "@/components/docs-link";
+import { RevisitPanel } from "@/components/revisit-panel";
 import { Switch } from "@/components/ui/switch";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -351,6 +352,10 @@ function KnowledgeTab() {
               : undefined
           }
         />
+        {/* Above the list rather than inside it. Sorting the file list by
+            staleness would move a document somebody is looking for, so the
+            ranked answer gets its own place and the list stays a list. */}
+        <RevisitPanel documents={agent.documents} className="mt-3" />
         {agent.documents.length === 0 ? (
           <EmptyState
             className="mt-3"

--- a/supabase/migrations/0038_how_many_answers_stand_on_this.sql
+++ b/supabase/migrations/0038_how_many_answers_stand_on_this.sql
@@ -1,0 +1,117 @@
+-- =========================================================================
+-- How many answers stand on this document
+--
+-- 0005 stored which documents grounded a reply; #54 started storing their ids
+-- alongside the names, so a citation is a link rather than a string. This is
+-- what the link was for: a document that is nine months old and behind forty
+-- answers is a different problem from a document that is nine months old and
+-- behind none, and the interface could not tell them apart.
+--
+-- The count has to cross private sessions, and that is the whole reason this is
+-- a function rather than a view.
+--
+-- Chats are private by default (0008). A member reading `messages` through RLS
+-- sees their own sessions and the shared ones, so a count assembled in the
+-- client would be a count of *that person's* answers — different for everybody
+-- looking at the same document, and near zero for somebody who has just joined.
+-- "Which documents does this team lean on" is not a question any one member can
+-- answer from what they are allowed to read.
+--
+-- So the function reads across the workspace and returns a number, and nothing
+-- else. Not who asked, not what they asked, not which session, not when. The
+-- most it discloses is that a document the whole workspace can already read has
+-- been used n times — which is the same trade #44 makes for unanswered
+-- questions, and worth naming rather than assuming.
+--
+-- Membership is still checked, per bundle, inside the function. `security
+-- definer` turns RLS off for the body; it does not make the caller anybody
+-- else, so `auth.uid()` is still them and `is_workspace_member` still answers
+-- honestly. A bundle in a workspace the caller is not in contributes nothing.
+
+-- Containment (`@>`) is the operator the count uses, and jsonb_path_ops is the
+-- smaller, faster GIN opclass for exactly that operator — it indexes values
+-- rather than keys, which is all `@> [{"id": ...}]` needs.
+--
+-- Without this the count is a sequential scan of every message in the database
+-- per document. That is survivable at today's sizes and is not survivable at
+-- the size this feature becomes useful at, which is the wrong way round.
+create index if not exists messages_sources_gin
+  on public.messages using gin (sources jsonb_path_ops);
+
+/**
+ * Citations per document, for documents in the given bundles.
+ *
+ * Returns a row per document that has at least one citation. A document with
+ * none is absent rather than zero — the caller already knows which documents it
+ * asked about, and a missing row is the same answer in fewer bytes.
+ */
+create or replace function public.document_citation_counts(p_bundle_ids uuid[])
+returns table (document_id uuid, citations bigint)
+language sql
+security definer
+stable
+set search_path = pg_catalog, public
+as $$
+  select d.id, count(*)
+  from public.documents d
+  join public.knowledge_bundles b on b.id = d.bundle_id
+  join public.messages m
+    -- `d.id::text`: ids are stored as JSON strings, and jsonb equality is typed
+    -- — `{"id": "<uuid>"}` never matches a uuid literal, it matches a string.
+    on m.sources @> jsonb_build_array(jsonb_build_object('id', d.id::text))
+  join public.chat_sessions s on s.id = m.session_id
+  where d.bundle_id = any(p_bundle_ids)
+    -- The reply and the document have to belong to the same room. A document id
+    -- is unique, so a citation from elsewhere should be impossible — this says
+    -- so out loud, and lets the planner start from the workspace.
+    and s.workspace_id = b.workspace_id
+    and public.is_workspace_member(b.workspace_id)
+  group by d.id;
+$$;
+
+/**
+ * The oldest reply whose citations carry ids, for one workspace.
+ *
+ * Every count above is a count over a window, and the window is not "all of
+ * history": replies written before #54 cite by name alone and cannot be
+ * matched to a document at all. A list that does not say so reads as a census
+ * and is a sample — a document uploaded two years ago and heavily used until
+ * spring would show a smaller number than one uploaded last week.
+ *
+ * Rather than hard-code the date the ids started, this asks the data. It is the
+ * first reply that could have been counted, which is exactly the sentence the
+ * interface needs to print. Null means none yet: a workspace with no counted
+ * replies at all, where the honest thing to show is nothing rather than zeroes.
+ */
+create or replace function public.citations_counted_since(p_workspace_id uuid)
+returns timestamptz
+language sql
+security definer
+stable
+set search_path = pg_catalog, public
+as $$
+  select min(m.created_at)
+  from public.messages m
+  join public.chat_sessions s on s.id = m.session_id
+  where s.workspace_id = p_workspace_id
+    and public.is_workspace_member(p_workspace_id)
+    -- An element carrying a real id. Spelled out rather than written as a
+    -- jsonpath filter, because three shapes have to come out false and only one
+    -- true: `sources` null at all, the pre-#54 `[{"name": …}]`, and the
+    -- `{"id": null, "name": …}` that chat.ts still writes when retrieval
+    -- matched a document it could not identify. Only a string id counts.
+    and jsonb_typeof(m.sources) = 'array'
+    and exists (
+      select 1
+      from jsonb_array_elements(m.sources) e
+      where jsonb_typeof(e -> 'id') = 'string'
+    );
+$$;
+
+-- `authenticated` only. Neither function is useful to a signed-out caller and
+-- both read across sessions, so `anon` has no business holding them even with
+-- the membership check inside.
+revoke all on function public.document_citation_counts(uuid[]) from public, anon;
+revoke all on function public.citations_counted_since(uuid) from public, anon;
+grant execute on function public.document_citation_counts(uuid[]) to authenticated, service_role;
+grant execute on function public.citations_counted_since(uuid) to authenticated, service_role;

--- a/tests/rls/document-citations.test.ts
+++ b/tests/rls/document-citations.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Counting the answers that stand on a document, across conversations the
+ * counter cannot read.
+ *
+ * This is the one place in the product where a member learns something from a
+ * private session, and the whole design is in what does and does not come back:
+ * a number per document, and nothing else. So these tests are as much about the
+ * ceiling as the floor — the count has to cross a colleague's private chat
+ * (or it answers a personal question rather than a team one), and it has to
+ * stop there.
+ *
+ * `security definer` turns RLS off inside the function body. It does not make
+ * the caller somebody else, so `auth.uid()` is still them and the membership
+ * check still means something — which is what the non-member cases here are
+ * for. A definer function that forgot its own check would pass every other test
+ * in this file.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeSql,
+  createTestUser,
+  destroyTestUsers,
+  serviceClient,
+  type TestUser,
+} from "./harness";
+import { seedWorkspace, type Seeded } from "./fixtures";
+
+let owner: TestUser;
+let colleague: TestUser;
+let outsider: TestUser;
+let seeded: Seeded;
+let secondDocumentId: string;
+
+/** A reply in `user`'s own private session, citing the given documents. */
+async function replyCiting(user: TestUser, documentIds: string[]) {
+  const { data: session, error: sessionErr } = await user.db
+    .from("chat_sessions")
+    .insert({
+      agent_id: seeded.agentId,
+      user_id: user.id,
+      workspace_id: user.workspaceId,
+      visibility: "private",
+    })
+    .select("id")
+    .single();
+  if (sessionErr || !session) throw new Error(`could not seed a session: ${sessionErr?.message}`);
+
+  const { error } = await user.db.from("messages").insert({
+    session_id: session.id,
+    role: "assistant",
+    content: "An answer.",
+    sources: documentIds.map((id) => ({ id, name: "seeded.txt" })),
+  });
+  if (error) throw new Error(`could not seed a message: ${error.message}`);
+}
+
+beforeAll(async () => {
+  owner = await createTestUser("citations-owner");
+  colleague = await createTestUser("citations-colleague");
+  outsider = await createTestUser("citations-outsider");
+  seeded = await seedWorkspace(owner);
+
+  const { error: memberErr } = await serviceClient()
+    .from("workspace_members")
+    .insert({ workspace_id: owner.workspaceId, user_id: colleague.id, role: "member" });
+  if (memberErr) throw new Error(`could not seed the membership: ${memberErr.message}`);
+
+  const { data: doc, error: docErr } = await owner.db
+    .from("documents")
+    .insert({ bundle_id: seeded.bundleId, name: "second.txt" })
+    .select("id")
+    .single();
+  if (docErr || !doc) throw new Error(`could not seed a second document: ${docErr?.message}`);
+  secondDocumentId = doc.id as string;
+
+  // Two replies on the seeded document, one of them in the colleague's own
+  // private session; one reply on the second document.
+  await replyCiting(owner, [seeded.documentId]);
+  await replyCiting(colleague, [seeded.documentId]);
+  await replyCiting(owner, [secondDocumentId]);
+});
+
+afterAll(async () => {
+  await destroyTestUsers();
+  await closeSql();
+});
+
+async function counts(user: TestUser, bundleIds: string[] = [seeded.bundleId]) {
+  const { data, error } = await user.db.rpc("document_citation_counts", {
+    p_bundle_ids: bundleIds,
+  });
+  return {
+    error,
+    map: Object.fromEntries(
+      ((data ?? []) as Array<{ document_id: string; citations: number }>).map((r) => [
+        r.document_id,
+        Number(r.citations),
+      ]),
+    ),
+  };
+}
+
+describe("document_citation_counts", () => {
+  it("counts a colleague's private conversation, which is the whole point", async () => {
+    // The owner cannot read the colleague's session at all. If the count did
+    // not cross it this would be 1, and the number would mean "answers I have
+    // seen" rather than "answers this team has had".
+    const { error, map } = await counts(owner);
+    expect(error).toBeNull();
+    expect(map[seeded.documentId]).toBe(2);
+  });
+
+  it("gives the colleague the same answer as the owner", async () => {
+    // A ranking that differs by who is looking is not a ranking of documents.
+    const { map } = await counts(colleague);
+    expect(map[seeded.documentId]).toBe(2);
+  });
+
+  it("still cannot read the session behind the number", async () => {
+    // The ceiling. The count crosses; nothing else does.
+    const { data } = await owner.db.from("chat_sessions").select("id").eq("user_id", colleague.id);
+    expect(data ?? []).toEqual([]);
+  });
+
+  it("counts each document separately", async () => {
+    const { map } = await counts(owner);
+    expect(map[secondDocumentId]).toBe(1);
+  });
+
+  it("leaves an uncited document out rather than reporting a zero", async () => {
+    const { data: doc } = await owner.db
+      .from("documents")
+      .insert({ bundle_id: seeded.bundleId, name: "nobody-asks.txt" })
+      .select("id")
+      .single();
+    const { map } = await counts(owner);
+    expect(map[doc!.id as string]).toBeUndefined();
+  });
+
+  it("tells a non-member nothing", async () => {
+    // The membership check inside the function. `security definer` has already
+    // turned RLS off by the time it runs, so this is the only thing standing
+    // between an outsider and a workspace's numbers.
+    const { error, map } = await counts(outsider);
+    expect(error).toBeNull();
+    expect(map).toEqual({});
+  });
+
+  it("ignores a bundle the caller is not in, while answering for one they are", async () => {
+    // A caller who names both their own bundle and somebody else's gets their
+    // own answer and no hint about the other.
+    const { data: bundle } = await outsider.db
+      .from("knowledge_bundles")
+      .insert({ workspace_id: outsider.workspaceId, name: "Not yours", created_by: outsider.id })
+      .select("id")
+      .single();
+    const { map } = await counts(owner, [seeded.bundleId, bundle!.id as string]);
+    expect(map[seeded.documentId]).toBe(2);
+    expect(Object.keys(map)).toHaveLength(2);
+  });
+
+  it("does not count a citation that carries a name and no id", async () => {
+    // Every reply written before #54 looks like this. They are uncountable
+    // rather than zero, which is what the window caption exists to say.
+    const { data: doc } = await owner.db
+      .from("documents")
+      .insert({ bundle_id: seeded.bundleId, name: "cited-by-name-only.txt" })
+      .select("id")
+      .single();
+
+    const { data: session } = await owner.db
+      .from("chat_sessions")
+      .insert({
+        agent_id: seeded.agentId,
+        user_id: owner.id,
+        workspace_id: owner.workspaceId,
+        visibility: "private",
+      })
+      .select("id")
+      .single();
+    await owner.db.from("messages").insert({
+      session_id: session!.id,
+      role: "assistant",
+      content: "An older answer.",
+      sources: [{ name: "cited-by-name-only.txt" }],
+    });
+
+    const { map } = await counts(owner);
+    expect(map[doc!.id as string]).toBeUndefined();
+  });
+});
+
+describe("citations_counted_since", () => {
+  it("reports the oldest reply that could be counted", async () => {
+    const { data, error } = await owner.db.rpc("citations_counted_since", {
+      p_workspace_id: owner.workspaceId,
+    });
+    expect(error).toBeNull();
+    expect(typeof data).toBe("string");
+    expect(Number.isNaN(Date.parse(data as string))).toBe(false);
+  });
+
+  it("tells a non-member nothing", async () => {
+    const { data, error } = await outsider.db.rpc("citations_counted_since", {
+      p_workspace_id: owner.workspaceId,
+    });
+    expect(error).toBeNull();
+    expect(data).toBeNull();
+  });
+
+  it("is null for a workspace whose replies carry no ids", async () => {
+    // The screen this distinguishes: "nothing has been countable yet" is not
+    // "every document scored zero".
+    const { data } = await outsider.db.rpc("citations_counted_since", {
+      p_workspace_id: outsider.workspaceId,
+    });
+    expect(data).toBeNull();
+  });
+});

--- a/tests/rls/document-citations.test.ts
+++ b/tests/rls/document-citations.test.ts
@@ -46,12 +46,18 @@ async function replyCiting(user: TestUser, documentIds: string[]) {
     .single();
   if (sessionErr || !session) throw new Error(`could not seed a session: ${sessionErr?.message}`);
 
-  const { error } = await user.db.from("messages").insert({
-    session_id: session.id,
-    role: "assistant",
-    content: "An answer.",
-    sources: documentIds.map((id) => ({ id, name: "seeded.txt" })),
-  });
+  // The session is the user's own, inserted as them. The reply is not: 0031
+  // pins a user's insert to `role = 'user'`, so an assistant message is
+  // written by the service role — which is exactly how the chat route writes
+  // one, and the only rows this count ever looks at.
+  const { error } = await serviceClient()
+    .from("messages")
+    .insert({
+      session_id: session.id,
+      role: "assistant",
+      content: "An answer.",
+      sources: documentIds.map((id) => ({ id, name: "seeded.txt" })),
+    });
   if (error) throw new Error(`could not seed a message: ${error.message}`);
 }
 
@@ -179,12 +185,14 @@ describe("document_citation_counts", () => {
       })
       .select("id")
       .single();
-    await owner.db.from("messages").insert({
-      session_id: session!.id,
-      role: "assistant",
-      content: "An older answer.",
-      sources: [{ name: "cited-by-name-only.txt" }],
-    });
+    await serviceClient()
+      .from("messages")
+      .insert({
+        session_id: session!.id,
+        role: "assistant",
+        content: "An older answer.",
+        sources: [{ name: "cited-by-name-only.txt" }],
+      });
 
     const { map } = await counts(owner);
     expect(map[doc!.id as string]).toBeUndefined();

--- a/tests/rls/document-citations.test.ts
+++ b/tests/rls/document-citations.test.ts
@@ -36,10 +36,15 @@ let secondDocumentId: string;
 async function replyCiting(user: TestUser, documentIds: string[]) {
   const { data: session, error: sessionErr } = await user.db
     .from("chat_sessions")
+    // `owner.workspaceId`, not the caller's — 0028 requires the session's
+    // workspace to be the agent's, and the colleague's own workspace is the one
+    // their signup made, not the one they were invited into. Every conversation
+    // here happens in the room the agent lives in, which is also the only shape
+    // the count is ever asked about.
     .insert({
       agent_id: seeded.agentId,
       user_id: user.id,
-      workspace_id: user.workspaceId,
+      workspace_id: owner.workspaceId,
       visibility: "private",
     })
     .select("id")

--- a/worker/src/routes/bundles.test.ts
+++ b/worker/src/routes/bundles.test.ts
@@ -242,3 +242,132 @@ describe("POST /bundles/:id/documents/upload — files with no readable text", (
     expect(res.status).not.toBe(422);
   });
 });
+
+/*
+ * GET /bundles/citations
+ *
+ * The route's own job is small — resolve the workspace, hand its bundle ids to
+ * two RPCs, and shape what comes back. The counting itself is in 0038 and is
+ * tested against a real database in tests/rls/. What is worth pinning here is
+ * the shaping, because every mistake in it is silent: a bigint arriving as a
+ * string sorts as text, and a missing `since` reads as "counted from the
+ * beginning" rather than "counted from nowhere".
+ */
+function citationsDb(options: {
+  bundleIds?: string[];
+  counts?: Array<{ document_id: string; citations: number | string }>;
+  since?: string | null;
+  bundleError?: boolean;
+  rpcError?: boolean;
+}) {
+  const calls: { rpc: Array<[string, Record<string, unknown>]> } = { rpc: [] };
+  const db = {
+    from(table: string) {
+      if (table === "profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: { active_workspace_id: "ws-1" }, error: null }),
+            }),
+          }),
+        };
+      }
+      // `getActiveWorkspaceId` confirms the active workspace is still one the
+      // caller belongs to before it trusts the profile.
+      if (table === "workspace_members") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                maybeSingle: async () => ({ data: { workspace_id: "ws-1" }, error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "knowledge_bundles") {
+        return {
+          select: () => ({
+            eq: async () => ({
+              data: options.bundleError
+                ? null
+                : (options.bundleIds ?? ["bundle-1"]).map((id) => ({ id })),
+              error: options.bundleError ? { message: "boom" } : null,
+            }),
+          }),
+        };
+      }
+      throw new Error(`citationsDb: unexpected table "${table}"`);
+    },
+    async rpc(name: string, args: Record<string, unknown>) {
+      calls.rpc.push([name, args]);
+      if (options.rpcError) return { data: null, error: { message: "boom" } };
+      if (name === "document_citation_counts") return { data: options.counts ?? [], error: null };
+      return { data: options.since ?? null, error: null };
+    },
+  };
+  return { db, calls };
+}
+
+describe("GET /bundles/citations", () => {
+  it("counts against every bundle in the workspace, not only the ones on one agent", async () => {
+    const { db, calls } = citationsDb({ bundleIds: ["b1", "b2"] });
+    const res = await appWithDb(db).request("/bundles/citations");
+
+    expect(res.status).toBe(200);
+    const counting = calls.rpc.find(([name]) => name === "document_citation_counts");
+    expect(counting?.[1]).toEqual({ p_bundle_ids: ["b1", "b2"] });
+  });
+
+  it("turns a bigint count into a number, whichever way PostgREST sends it", async () => {
+    // Counts are bigint. PostgREST sends small ones as JSON numbers and large
+    // ones as strings, and a string would sort as text — "9" above "41".
+    const { db } = citationsDb({
+      counts: [
+        { document_id: "d1", citations: "41" },
+        { document_id: "d2", citations: 9 },
+      ],
+    });
+    const res = await appWithDb(db).request("/bundles/citations");
+    const body = (await res.json()) as { counts: Record<string, number> };
+
+    expect(body.counts).toEqual({ d1: 41, d2: 9 });
+    expect(typeof body.counts.d1).toBe("number");
+  });
+
+  it("reports the window as a timestamp", async () => {
+    const { db } = citationsDb({ since: "2026-08-24T09:15:00.000Z" });
+    const res = await appWithDb(db).request("/bundles/citations");
+    const body = (await res.json()) as { since: number | null };
+
+    expect(body.since).toBe(Date.parse("2026-08-24T09:15:00.000Z"));
+  });
+
+  it("says null rather than a date when nothing has ever been countable", async () => {
+    // Not zero, and not the epoch. "No reply has carried a document id yet" is
+    // a different screen from "the count starts in 1970".
+    const { db } = citationsDb({ since: null });
+    const res = await appWithDb(db).request("/bundles/citations");
+    const body = (await res.json()) as { since: number | null };
+
+    expect(body.since).toBeNull();
+  });
+
+  it("asks nothing of the database when the workspace has no bundles", async () => {
+    const { db, calls } = citationsDb({ bundleIds: [] });
+    const res = await appWithDb(db).request("/bundles/citations");
+
+    expect(await res.json()).toEqual({ since: null, counts: {} });
+    expect(calls.rpc).toHaveLength(0);
+  });
+
+  it("fails loudly rather than reporting an empty count", async () => {
+    // The failure mode worth avoiding: an error swallowed into `{}` would draw
+    // a panel saying nothing needs revisiting, which is a claim rather than an
+    // absence of one.
+    const { db } = citationsDb({ rpcError: true });
+    const res = await appWithDb(db).request("/bundles/citations");
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/worker/src/routes/bundles.ts
+++ b/worker/src/routes/bundles.ts
@@ -62,6 +62,55 @@ bundles.get("/bundles", async (c) => {
   return c.json((data ?? []).map(mapBundle));
 });
 
+// GET /bundles/citations — how many answers cite each document, workspace-wide.
+//
+// Two calls rather than one because they answer two different questions, and
+// the second one is the caveat on the first: `since` is the oldest reply that
+// could be counted at all. Replies written before ids were stored cite by name
+// alone (#54), so every number here is over a window and the interface has to
+// be able to say which. Sending the counts without it would print a census and
+// mean a sample.
+//
+// Both are RPCs into `security definer` functions because the count has to
+// cross private sessions — see 0038. What comes back is a number per document
+// and a timestamp; who asked and what they asked stay where they are.
+bundles.get("/bundles/citations", async (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+
+  const workspaceId = await getActiveWorkspaceId(db, user.id);
+  if (!workspaceId) return c.json({ since: null, counts: {} });
+
+  const { data: bundleRows, error: bundleError } = await db
+    .from("knowledge_bundles")
+    .select("id")
+    .eq("workspace_id", workspaceId);
+  if (bundleError) return c.json({ error: "failed to load bundles" }, 500);
+
+  const bundleIds = (bundleRows ?? []).map((b) => b.id as string);
+  if (bundleIds.length === 0) return c.json({ since: null, counts: {} });
+
+  const [counted, sinceResult] = await Promise.all([
+    db.rpc("document_citation_counts", { p_bundle_ids: bundleIds }),
+    db.rpc("citations_counted_since", { p_workspace_id: workspaceId }),
+  ]);
+
+  if (counted.error || sinceResult.error) {
+    return c.json({ error: "failed to count citations" }, 500);
+  }
+
+  const counts: Record<string, number> = {};
+  for (const row of (counted.data ?? []) as Array<{ document_id: string; citations: number }>) {
+    // Postgres counts are bigint, which PostgREST sends as a JSON number here
+    // and as a string once it exceeds 2^53. Coerced rather than trusted: a
+    // string would sort as text, and "9" would outrank "41".
+    counts[row.document_id] = Number(row.citations);
+  }
+
+  const since = (sinceResult.data as string | null) ?? null;
+  return c.json({ since: since ? Date.parse(since) : null, counts });
+});
+
 // POST /bundles
 bundles.post("/bundles", async (c) => {
   const db = c.get("db");


### PR DESCRIPTION
Closes #43. #54 shipped part 1 — an age under every citation. That catches the problem one reply at a time, and only for whoever happens to be reading it. Part 2 is the question a chip cannot answer: **which of our documents is quietly wrong in the most places.**

**Only the pair is useful.** A document nine months old that grounds nothing is nobody's problem — it sits in a bundle and nothing asks it anything. One that grounds forty answers and was uploaded last week is the product working. So: old enough to doubt *and* used enough to matter, ordered by the count. Age decides whether a document is a candidate; the count decides which candidate has reached the most people. Ordering by age would put a two-year-old document with one citation above a ten-month-old one with sixty.

**Why it is a  function.** Chats are private by default (0008), so a count assembled through RLS is a count of *the reader's own* answers — different for everybody looking at the same document, near zero for somebody who just joined. "Which documents does this team lean on" is not a question any one member can answer from what they are allowed to read.

The function reads across the workspace and returns a number, and nothing else. Not who asked, not what, not which session, not when. The most it discloses is that a document the whole workspace can already read has been used n times — the same trade #44 makes, and written into 0038 rather than left implicit.

Membership is still checked inside, per bundle. Definer turns RLS off for the body; it does not make the caller somebody else, so `auth.uid()` is still them. **Two of the eleven RLS tests are an outsider getting nothing**, because a definer function that forgot its own check would pass every other test in the file — as would one that leaked, so there is also a test that the owner still cannot read the session behind the number.

**A second function reports the window.** Replies written before #54 cite by name and cannot be matched to a document, so every count is over a period rather than over all of history — and the gap is largest for exactly the documents this feature is about. It is read from the data (the oldest countable reply) rather than hard-coded, so it stays true as old conversations are deleted. `null` means nothing has been countable yet, which is a different screen from every document scoring zero.

**The panel renders nothing when nothing qualifies.** No heading, no empty state, no "0 documents need attention". A panel that is always on screen stops being read, and this one is worth reading on the days it appears. It sits *above* the file list rather than reordering it — sorting the list by staleness would move a document somebody was looking for.

**Both halves of the caveat ship with the number**, because a count invites more trust than it has earned. `docs/knowledge.md` is explicit that a chip means a document was searched and admitted, not that a word of it reached the model — the 4000-character budget cuts documents that are still cited. So the panel says "a count of answers that cited a document, not of answers it changed", and then says since when.

**A GIN index on `messages.sources`** (`jsonb_path_ops`, the smaller opclass for the containment operator the count uses). Without it the count is a sequential scan of every message per document: survivable today, not survivable at the size this feature becomes useful at, which is the wrong way round.

399 frontend tests, 695 worker tests, 11 new RLS tests. Docker is not running here, so 0038 is applied for the first time by CI's Row level security job.