### PR TITLE
Record whether anything the team wrote was close to the question

### DIFF
--- a/supabase/migrations/0039_whether_anything_came_close.sql
+++ b/supabase/migrations/0039_whether_anything_came_close.sql
@@ -1,0 +1,68 @@
+-- =========================================================================
+-- Whether anything the team wrote was close to the question
+--
+-- covan#44 wants to report what a team asked that its own written knowledge
+-- does not cover, so somebody can see what to write down next. The issue
+-- assumed the signal was already recorded: "when a question falls below the
+-- similarity floor, that is a recorded fact". It is neither recorded nor,
+-- on its own, the fact it sounds like.
+--
+-- Nothing is written down. `messages.sources` (0005) names the documents that
+-- grounded a reply, but there are two ways to arrive at a grounded reply and
+-- the column cannot tell them apart. `worker/src/routes/chat.ts` first asks
+-- `match_chunks` for passages above `RAG_MIN_SIMILARITY`; if none clears it, a
+-- fallback grounds the answer on whole documents instead, newest first, under
+-- the same character budget. Both paths fill `sources`. So a reply with
+-- sources may mean "a passage matched" or "nothing matched and we sent the
+-- newest files anyway", and only the first means the question was covered.
+--
+-- Hence one column recording which of the three happened:
+--
+--   'chunks'    at least one passage cleared the floor — the question was
+--               covered by something written for it
+--   'documents' nothing cleared the floor; the fallback grounded the reply on
+--               whole documents. The answer may still be right, and often is
+--               for "summarise the file" questions, but no passage in the
+--               team's knowledge was a close match for what was asked
+--   'none'      nothing grounded it. The agent has no usable documents at all,
+--               which is a setup problem rather than a coverage one, and the
+--               report will want to say so differently
+--
+-- The distinction matters for what the report is allowed to claim. "Questions
+-- we could not answer" would be false — the fallback answers most of them.
+-- "Questions nothing written was close to" is true, and is the one a founder
+-- can act on.
+--
+-- Null is the honest value for every row written before today, and for every
+-- user message. It is not a fourth state; it means nobody recorded one.
+-- =========================================================================
+
+alter table public.messages
+  add column grounding text;
+
+-- Two conditions in one constraint, because they are one rule: this column
+-- describes how an assistant reply was grounded, so only an assistant row may
+-- carry it, and only with a value the reader will recognise.
+--
+-- The role half is not decoration. `messages_insert_user_self` (0009) and
+-- `messages_update_owner` (0031) both pin a member to `role = 'user'`, so a
+-- member can only ever write their own question — and without this constraint
+-- they could stamp a grounding on it and quietly become the source of a number
+-- the report is built from.
+alter table public.messages
+  add constraint messages_grounding_valid check (
+    grounding is null
+    or (role = 'assistant' and grounding in ('chunks', 'documents', 'none'))
+  );
+
+-- The report reads "assistant replies in this workspace, over a window, where
+-- nothing came close". Sessions carry the workspace and the timestamp lives on
+-- the message, so the useful index is the one that lets a scan start from the
+-- grounding rather than from every message ever sent.
+--
+-- Partial, because the rows worth reporting on are a minority and always will
+-- be: an index over all of `messages` would be mostly `'chunks'` and mostly
+-- read past.
+create index if not exists messages_grounding_missed_idx
+  on public.messages (session_id, created_at)
+  where grounding in ('documents', 'none');

--- a/tests/rls/message-grounding.test.ts
+++ b/tests/rls/message-grounding.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Who may say how an answer was grounded.
+ *
+ * `messages.grounding` (0039) exists so covan#44 can report what a team asked
+ * that nothing it wrote was close to. That makes it a number-shaped column: it
+ * is not read back in the chat screen, it is counted, and a count is only worth
+ * printing if the rows behind it were written by the one party that knows.
+ *
+ * That party is the reply path, which runs as the service role. A member writes
+ * their own question and nothing else — 0009 and 0031 pin their insert and
+ * their update to `role = 'user'` — so the interesting question is not whether
+ * they can rewrite an assistant row (they cannot, and that is tested below for
+ * the record) but whether they can stamp a grounding on the one row they *are*
+ * allowed to write. Without the role half of the constraint they could, and the
+ * report would be counting rows its own subjects had filled in.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeSql,
+  createTestUser,
+  destroyTestUsers,
+  serviceClient,
+  type TestUser,
+} from "./harness";
+import { seedWorkspace, type Seeded } from "./fixtures";
+
+let owner: TestUser;
+let seeded: Seeded;
+let sessionId: string;
+
+/** A private session of the owner's, in the workspace the agent lives in. */
+async function seedSession(): Promise<string> {
+  const { data, error } = await owner.db
+    .from("chat_sessions")
+    .insert({
+      agent_id: seeded.agentId,
+      user_id: owner.id,
+      workspace_id: owner.workspaceId,
+      visibility: "private",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`could not seed a session: ${error?.message}`);
+  return data.id as string;
+}
+
+beforeAll(async () => {
+  owner = await createTestUser("grounding-owner");
+  seeded = await seedWorkspace(owner);
+  sessionId = await seedSession();
+});
+
+afterAll(async () => {
+  await destroyTestUsers();
+  await closeSql();
+});
+
+describe("messages.grounding, written by the reply path", () => {
+  it.each(["chunks", "documents", "none"] as const)(
+    "accepts %s on an assistant reply from the service role",
+    async (value) => {
+      const { data, error } = await serviceClient()
+        .from("messages")
+        .insert({
+          session_id: sessionId,
+          role: "assistant",
+          content: `Grounded via ${value}.`,
+          grounding: value,
+        })
+        .select("grounding")
+        .single();
+
+      expect(error).toBeNull();
+      expect(data?.grounding).toBe(value);
+    },
+  );
+
+  it("refuses a value the report would not recognise", async () => {
+    // A fourth state invented at the call site is worse than a missing one: it
+    // would be silently excluded from both halves of every count, and nothing
+    // would say so.
+    const { error } = await serviceClient().from("messages").insert({
+      session_id: sessionId,
+      role: "assistant",
+      content: "Grounded somehow.",
+      grounding: "partial",
+    });
+
+    expect(error).not.toBeNull();
+  });
+
+  it("allows null, which is what every reply written before 0039 has", async () => {
+    const { data, error } = await serviceClient()
+      .from("messages")
+      .insert({ session_id: sessionId, role: "assistant", content: "An older answer." })
+      .select("grounding")
+      .single();
+
+    expect(error).toBeNull();
+    expect(data?.grounding).toBeNull();
+  });
+});
+
+describe("messages.grounding, from a member", () => {
+  it("lets them write their own question, as always", async () => {
+    const { error } = await owner.db.from("messages").insert({
+      session_id: sessionId,
+      role: "user",
+      sender_id: owner.id,
+      content: "What is the parental leave policy?",
+    });
+
+    expect(error).toBeNull();
+  });
+
+  it("refuses a grounding on that question", async () => {
+    // The row is theirs and the insert is otherwise allowed, so RLS has no
+    // objection — the constraint is the only thing standing here. Take the role
+    // half out of 0039 and this insert succeeds, which is how a member becomes
+    // an author of the report's inputs.
+    const { error } = await owner.db.from("messages").insert({
+      session_id: sessionId,
+      role: "user",
+      sender_id: owner.id,
+      content: "What is the parental leave policy?",
+      grounding: "chunks",
+    });
+
+    expect(error).not.toBeNull();
+  });
+
+  it("cannot change the grounding on an assistant reply", async () => {
+    const { data: reply, error: insertError } = await serviceClient()
+      .from("messages")
+      .insert({
+        session_id: sessionId,
+        role: "assistant",
+        content: "Nothing written was close to that.",
+        grounding: "none",
+      })
+      .select("id")
+      .single();
+    if (insertError || !reply) throw new Error(`could not seed a reply: ${insertError?.message}`);
+
+    // `messages_update_owner` (0031) matches only `role = 'user'` rows, so this
+    // update finds nothing rather than failing loudly. Postgres reports no
+    // error for an update that matched no rows, which is why the assertion is
+    // on the stored value and not on the error.
+    await owner.db.from("messages").update({ grounding: "chunks" }).eq("id", reply.id);
+
+    const { data: after } = await serviceClient()
+      .from("messages")
+      .select("grounding")
+      .eq("id", reply.id)
+      .single();
+
+    expect(after?.grounding).toBe("none");
+  });
+});

--- a/worker/src/routes/chat.ts
+++ b/worker/src/routes/chat.ts
@@ -124,6 +124,18 @@ chat.post("/chat/stream", async (c) => {
   // the persisted history so that prefix stays byte-identical across turns and
   // OpenAI's automatic prompt cache can discount the bulk of the input.
   let ragBlock = "";
+  /**
+   * Which of the two grounding paths below produced `ragBlock`, persisted with
+   * the reply (0039) because `sources` cannot tell them apart — both paths fill
+   * it, and only the first means a passage the team wrote was close to what was
+   * asked. covan#44 reports on the difference.
+   *
+   * Starts at `"none"` and is narrowed on the way down, so every exit — an
+   * agent with no documents, a retrieval that threw, a fallback that found
+   * nothing with content — lands on the truthful value without needing its own
+   * assignment.
+   */
+  let grounding: "chunks" | "documents" | "none" = "none";
   // Embedding the question costs tokens too. Carried to the end of the turn and
   // recorded with the completion's, so one reply means one counter write.
   let embeddingTokens = 0;
@@ -186,6 +198,7 @@ chat.post("/chat/stream", async (c) => {
             typed.map((m) => ({ documentName: m.document_name, content: m.content })),
           );
           if (ragBlock) {
+            grounding = "chunks";
             for (const m of typed) addSource(m.document_id ?? null, m.document_name);
           }
         }
@@ -216,6 +229,7 @@ chat.post("/chat/stream", async (c) => {
         withContent.map((d) => ({ documentName: d.name, content: d.content as string })),
       );
       if (ragBlock) {
+        grounding = "documents";
         for (const d of withContent) addSource(d.id ?? null, d.name);
       }
     }
@@ -312,6 +326,7 @@ chat.post("/chat/stream", async (c) => {
             content: text,
             sender_id: null,
             sources: sources.size > 0 ? [...sources.values()] : null,
+            grounding,
             prompt_tokens: opts.promptTokens,
             completion_tokens: opts.completionTokens,
             cached_tokens: opts.cachedTokens,


### PR DESCRIPTION
## What problem does this solve?

First half of #44 — and it starts by correcting that issue.

#44 says a question falling below the similarity floor "is a recorded fact". It is not recorded, and on its own it is not the fact it sounds like.

**Nothing writes it down.** `messages.sources` names the documents behind a reply but cannot say how they got there, because `worker/src/routes/chat.ts` has two ways to ground an answer and both fill it:

1. `match_chunks` for passages above `RAG_MIN_SIMILARITY`
2. if none clears the floor, a fallback grounds the reply on **whole documents**, newest first, under the same character budget

So a reply with sources means either *a passage matched* or *nothing matched and we sent the newest files anyway* — and only the first says the question was covered.

That distinction decides whether the report can be honest. "Questions we could not answer" would be **false**: the fallback answers most of them, often well, because "summarise the handbook" is exactly the shape that embeds close to nothing. "Questions nothing written was close to" is true, and is the one a founder can act on.

### The column

| value | meaning |
|---|---|
| `chunks` | a passage cleared the floor — something written for this question |
| `documents` | only the fallback grounded it; no passage was a close match |
| `none` | nothing grounded it — the agent has no usable documents, a setup problem rather than a coverage one |

`null` is every row written before today and every user message. Not a fourth state — it means nobody recorded one.

### The constraint's role half is load-bearing

A member may write their own question and nothing else (0009, 0031). Without `role = 'assistant'` in the check they could stamp a grounding on it, and the report would be counting rows its own subjects had filled in. `tests/rls/message-grounding.test.ts` is seven cases and that is the one it exists for; the rest pin the three accepted values, refuse a fourth, allow null, and show that an assistant row's grounding survives a member's update attempt.

The index is partial: the rows worth reporting on are a minority and always will be, so an index over all of `messages` would be mostly `chunks` and mostly read past.

### Not in this PR

Nothing reads the column yet. The aggregation with its minimum-distinct-users floor, and the clustering that turns questions into topics without printing any of them, are the next two pieces.

## Checks

- [x] The commands above pass

```
lint             0 errors, 3 warnings (pre-existing)
typecheck        clean (root and worker)
check:rls        ✓ all 20 tables created under 1 directory enable RLS
test             399 passed
worker test      695 passed
```

## If you touched the database

- [x] A **new** migration, `0039_whether_anything_came_close.sql`
- [x] No new table; the column sits on `messages`, whose RLS is unchanged, and `bun run test:rls` covers it in CI

> **Sequencing note for the hosted mirror.** covan-cloud deploys on merge while migrations are applied by hand, so the mirror of this PR must not land until 0039 has been run against production — the reply path would otherwise write a column that does not exist and no assistant message would persist. This repository does not deploy, so merging here is safe and the mirror waits.
