### PR TITLE
A licence page, and a security note that stopped being true

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,19 +22,30 @@ browser. Any path that leaks it is critical.
 
 ## Already known
 
-One thing in the policies looks like a finding and is a documented limitation,
-so you can save yourself the write-up: the owner branch of the select policy on
-`chat_sessions` tests `user_id = auth.uid()` with no membership condition beside
-it. A person removed from a workspace therefore keeps their own sessions from
-it — the list stops showing them, but somebody holding a session id can still
-read the transcript back. They cannot get new answers; the reply path loads the
-agent first and that read is membership-gated.
+This section used to describe a real weakness: the owner branch of the select
+policy on `chat_sessions` tested `user_id = auth.uid()` with no membership
+condition beside it, so a person removed from a workspace kept their own
+transcripts from it and could read one back by id.
 
-[What removal leaves behind](docs/team.md#what-removal-leaves-behind) covers
-this and the rest of what outlives a membership. It is a product decision that
-has not been made yet, not an oversight — reports are still welcome if you find
-a consequence of it we have not written down, and especially if you find a way
-to reach anything that was _not_ already theirs.
+**That is closed.** `0031_access_follows_membership.sql` rewrote eleven policies
+across `chat_sessions`, `messages` and `ideas` so membership is checked
+unconditionally and ownership only decides which member sees the row. A
+conversation in a workspace somebody has left is now refused however they come
+at it — the list, a bookmarked id, an open tab, or a request straight to
+PostgREST. `tests/rls/membership.test.ts` asserts it in both directions.
+
+One thing on the same shape deliberately remains, so you can save yourself the
+write-up: `routines_select_visible` keeps the plain owner branch. A departed
+member can still read their own routine rows. That is the point — the executor
+re-checks membership before every run and pauses the routine with a recorded
+reason, and that reason is the only explanation its owner will ever get. The row
+holds their own instruction; `routine_runs` records counts and status, never
+content.
+
+[What removal leaves behind](docs/team.md#what-removal-leaves-behind) covers the
+rest of what outlives a membership, and [Security](docs/security.md) is the
+whole model in one page. Reports are welcome for anything that reaches something
+which was _not_ already the reporter's.
 
 ## Self-hosted instances
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,208 @@
+# Security
+
+Two people arrive at this page. One is deciding whether to put their team's
+documents into covan.app. The other is about to run Covan on their own machines
+and wants to know what they are taking responsibility for.
+
+Most of what follows is the same answer for both, because it is a property of
+the software rather than of who is hosting it. Where the two diverge it says so.
+
+The short version: **authorization lives in Postgres, not in the API.** Almost
+every other decision here follows from that one.
+
+## Where authorization lives
+
+A request arrives with the caller's token. The API does not unpack it, decide
+what that person may see, and write a filter — it hands the token to Postgres
+and asks for the rows. Row level security policies on every table decide what
+comes back, and they gate on `auth.uid()`, which is the authenticated user as
+the _database_ understands them.
+
+The consequence worth understanding is what it does to mistakes. A route that
+forgets to scope a query by workspace is an ordinary bug in most systems and a
+data leak in all of them. Here it is only the first of those: the query returns
+nothing extra, because the filter that mattered was never in the route.
+
+[Architecture](architecture.md#authorization-is-postgres) has the long form,
+including where the two seams are and why they are where they are.
+
+## Three guards, deliberately overlapping
+
+Tenancy is the one thing that must not break quietly, so it is checked three
+different ways and no two of them share a failure mode.
+
+- **Every table is covered.** A dependency-free script walks the migrations
+  before anything is installed and fails if a `create table` in `public` is not
+  followed by `enable row level security`. It takes about a second and it
+  catches the mistake that would otherwise be invisible: a new table that nobody
+  remembered to protect.
+- **The policies are tested against a real database.** Not read, not
+  regex-matched — a Postgres, GoTrue and PostgREST stack comes up in CI,
+  migrations are applied, real users sign up and get real tokens, and the tests
+  try to reach each other's rows. A `using (...)` predicate is a program, and
+  the only honest way to test a program is to run it.
+- **The key that bypasses all of it is pinned to a list.** A static test names
+  the files allowed to call for a service-role client, and fails the build if any
+  other file does. The list is meant to shrink over time, never to grow
+  casually.
+
+## The service-role key
+
+One credential bypasses row level security entirely, and it exists because a few
+operations legitimately cross users: minting a short-lived token for an API key,
+the routine engine waking up when nobody is signed in, cleaning up storage when
+an account is closed.
+
+It lives only in the API's runtime. It is never sent to a browser, never
+embedded in the client bundle, and every file that touches it is on the
+allowlist above. **If you are self-hosting, this is the one secret whose leak is
+unrecoverable** — anybody holding it can read every row of every workspace.
+
+## Who can do what
+
+Three roles, and they answer two different questions.
+
+| Role | Their own things | The workspace's things |
+| ------ | ----------------- | ----------------------- |
+| Admin | Read and write | Read and write, plus invite, remove and change roles |
+| Member | Read and write | Read and write |
+| Viewer | Read and write | Read only |
+
+The rule underneath it: **shared things need a member, your own things need only
+membership.** A viewer still has their own sessions, their own messages, their
+own ideas and their own routines, and can chat with every agent in the
+workspace — what they cannot do is change something everybody else depends on.
+
+That distinction is one database function, named by all thirteen write policies
+on the five shared tables, rather than thirteen copies of the same predicate.
+Copies are how one of them ends up different.
+
+## What a conversation is
+
+A session is private to the person who opened it. Not private by convention or
+by a check in the API — private because the policy says so, which is why a
+colleague cannot read it by guessing a URL.
+
+Sharing one makes it readable by the workspace, and that is the only way it
+becomes readable. There is no administrator view of everybody's chats.
+
+Access follows membership. When somebody leaves a workspace, or is removed from
+it, their sessions in that workspace stop being reachable — from the list, from
+a bookmarked id, from an open tab, from a request made straight to the database.
+Nothing is destroyed, and re-inviting them brings all of it back.
+
+That behaviour is newer than the product and it was a deliberate decision rather
+than a bug fix. [What removal leaves behind](team.md#what-removal-leaves-behind)
+covers the whole of it, including the two things that survive on purpose.
+
+## API keys
+
+A key is not a second permission system. It looks the key up, mints a
+sixty-second token for the person who owns it, and makes the request as them —
+so every policy that applies to you applies to your script, and a viewer's key
+can read and not write because a viewer can read and not write.
+
+Three things a key cannot do, each by explicit refusal: create another key,
+revoke a key, or close the account. All three exist so that a leaked key cannot
+entrench itself, cannot lock you out of revoking it, and cannot destroy the
+account and the evidence in one call.
+
+A key belongs to a person, not to a workspace. When their access ends, their
+keys stop working at the same moment. [The API](api.md) has the rest.
+
+## Secrets, and what happens when they are wrong
+
+An operator holds four things that matter: the Supabase service-role key, the
+OpenAI key, the key that encrypts delivery-channel secrets, and the database
+password.
+
+Delivery-channel secrets — a Slack webhook URL, for instance — are encrypted
+with AES-GCM before they are stored, using a key held only by the API. The
+database on its own does not yield them.
+
+The Node build refuses to start rather than run in a state that looks fine and
+is not:
+
+- Any required variable missing, and it says all of them at once rather than one
+  per restart.
+- The published example values still in place while the app is served anywhere
+  other than localhost. Those values are in a public repository and they _work_,
+  which is the dangerous part — a demo key that verifies is worse than one that
+  does not.
+- An encryption key that is not base64 of 16, 24 or 32 bytes, checked at boot
+  instead of at the moment somebody first saves a webhook.
+
+The Worker build takes its configuration from the platform and runs none of
+these checks, because a deployment cannot start failing on a secret it has held
+all along.
+
+## In transit and at rest
+
+TLS everywhere, in and out. Uploaded files and the database are encrypted at
+rest by whoever provides them — which is your choice when you self-host, and is
+[named for covan.app on the subprocessor page](https://covan.app/subprocessors).
+
+Passwords are never stored. Authentication is Supabase Auth, and what the
+database holds is a hash.
+
+## Rate limits and the ceiling above them
+
+Every endpoint that spends money — a completion, a transcription — is rate
+limited per account rather than per address, because after authentication there
+is an account, and a per-address limit punishes a shared office for one person's
+runaway loop.
+
+Above the per-minute limit sits the monthly allowance, and the two are not
+substitutes: an allowance bounds the bill, a rate limit bounds how fast it is
+reached. A self-hosted install ships no allowance at all, which is correct — it
+is your OpenAI key and your ceiling to set.
+
+## What Covan does not have
+
+Stated here rather than left to be discovered, because for some readers one of
+these is the end of the evaluation.
+
+- **No single sign-on.** No SAML, no OIDC, no SCIM provisioning. Accounts are
+  email and password.
+- **No audit log.** There is no per-action trail an administrator can export.
+- **No certification.** covan.app has no SOC 2 and no ISO 27001, and no external
+  party has audited any of the above. What is offered instead is that the code
+  is published and the claims on this page can be checked rather than believed.
+- **No two-factor authentication** on Covan accounts today.
+
+## Reporting a vulnerability
+
+Privately, to the address in the repository's
+[security policy](https://github.com/covan-ai/covan/security/policy), never as a
+public issue. You get an acknowledgement within seventy-two hours.
+
+Findings that let one workspace read or write another workspace's data are the
+highest severity there is and are treated that way. Nothing bad happens to
+anybody who reports in good faith.
+
+## If you run it yourself
+
+You are the operator, which means the parts above about "who is responsible" all
+resolve to you. The short list:
+
+1. **Keep the service-role key off the client.** It belongs in the API's
+   environment and nowhere else. Nothing named `VITE_` is a secret — those are
+   compiled into the bundle every visitor downloads.
+2. **Regenerate every example value** before the stack is reachable from
+   anything but your own machine. The boot check catches this, and it is better
+   not to rely on it.
+3. **Set `ALLOWED_ORIGIN` to your own origin.** It is what stops another site
+   from making authenticated requests on a visitor's behalf.
+4. **Back up the database, and restore one.** A dump nobody has restored is a
+   file, not a backup. covan.app's own job restores every nightly dump into a
+   throwaway Postgres and compares row counts before keeping it — worth copying.
+5. **Keep the encryption key.** Lose the one that encrypts delivery-channel
+   secrets and every stored webhook becomes undecryptable noise.
+6. **Decide where the model calls go.** Completions and embeddings can each be
+   pointed at any OpenAI-compatible endpoint, independently — which is the whole
+   answer for anyone who cannot send document text to the United States. See
+   [Self-hosting](self-hosting.md).
+
+[Taking it with you](export.md) is the other half of this page: the security
+property that matters most in the long run is being able to leave with
+everything, and that is a feature rather than a promise.

--- a/docs/team.md
+++ b/docs/team.md
@@ -460,9 +460,13 @@ to leave un-owned.
 
 ## Deleting a person
 
-There is no route for this either, and the same operator path applies. The schema
-draws one line through it, and it is worth knowing which side a thing falls on.
-Six columns record who _made_ something — the `created_by` on workspaces, agents,
+Unlike a workspace, this one has a door. **Settings → Close account** calls
+`DELETE /account`, and it is immediate rather than a request somebody processes.
+The operator path below still exists and still works, and what follows describes
+both, because the schema is what decides most of it either way.
+
+The schema draws one line through it, and it is worth knowing which side a thing
+falls on. Six columns record who _made_ something — the `created_by` on workspaces, agents,
 bundles and ideas, and both of the who-did-this columns on invitations. All six
 null out. A workspace does not evaporate because the person who opened it left,
 and a shared agent does not vanish because its author closed their account; the
@@ -477,11 +481,24 @@ One case is refused, and it is refused on purpose.
 
 **The last admin of a surviving workspace.** Somebody who is the only admin of a
 workspace that still exists cannot be deleted, because the cascade into
-`workspace_members` meets the guard. Whether that should promote the oldest
-remaining member, block until the role is handed over, or take the workspace with
-it is a product question that has not been answered, and answering it in the
-schema would be answering it by accident. Deleting or handing over the workspace
-first is the way through.
+`workspace_members` meets the guard. Hand the role over first; the route names
+the workspace when it refuses, so there is nothing to go looking for.
+
+The trigger's reach is wider than that sentence suggests, and it is why closing
+an account is not one `delete`. It never asks how many members are left, and
+everybody starts as the sole admin of a workspace of their own — so left alone
+it would refuse _every_ account closure there will ever be, including one from
+somebody who never invited anybody. `planWorkspaces` in
+`worker/src/routes/account.ts` tells the two cases apart before the delete runs:
+a workspace with other people in it blocks and is named, and a workspace with
+nobody else in it is deleted along with the account. There is no role to hand
+over in the second case and nobody to hand it to, and keeping it would leave a
+room no living person can enter, still holding the agents and documents of
+somebody who asked to be forgotten.
+
+That is the product question this section used to say was unanswered. It was
+answered by building the route, and the answer is the same one
+[Leaving](#leaving) already gave: block until the role is handed over.
 
 What a departing account leaves behind, in somebody else's session, is its
 words without its name. `messages.sender_id` nulls on delete

--- a/src/components/legal-layout.tsx
+++ b/src/components/legal-layout.tsx
@@ -1,29 +1,36 @@
 import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { BrandMark } from "@/components/brand-mark";
-import { PageContainer, Headline } from "@/components/page-container";
+import { PageContainer, Headline, type PageWidth } from "@/components/page-container";
 
 /**
  * The frame for a document somebody has to be able to read before they have an
  * account — so no AppShell, whose sidebar assumes a session and a workspace.
  *
  * `form` width rather than `list`: these are paragraphs, and a measure that
- * suits a table of members is too wide to read prose in.
+ * suits a table of members is too wide to read prose in. `width` exists for the
+ * exception — a legal page whose substance is a table rather than prose, where
+ * the reading measure is the wrong constraint. Prose stays at `form`.
  */
 export function LegalLayout({
   title,
   updated,
+  width = "form",
   children,
 }: {
   title: string;
   /** When the text last changed. Written as prose, e.g. "August 2026". */
   updated: string;
+  /** Prose measure by default; widen only for a page that is genuinely tabular. */
+  width?: PageWidth;
   children: ReactNode;
 }) {
+  const header = width === "form" ? "max-w-2xl" : "max-w-4xl";
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <header className="border-b border-border">
-        <div className="mx-auto flex h-16 max-w-2xl items-center justify-between px-5 lg:px-8">
+        <div className={`mx-auto flex h-16 items-center justify-between px-5 lg:px-8 ${header}`}>
           <Link to="/" className="flex items-center gap-2.5">
             <BrandMark />
             <span className="font-dm text-lg font-semibold leading-none tracking-[-0.02em]">
@@ -39,7 +46,7 @@ export function LegalLayout({
         </div>
       </header>
 
-      <PageContainer width="form">
+      <PageContainer width={width}>
         <Headline as="h1">{title}</Headline>
         <p className="mt-3 text-sm text-muted-foreground">Last updated {updated}</p>
         <div className="mt-12 space-y-10">{children}</div>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
+import { Route as LicenseRouteImport } from './routes/license'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as SignInRouteImport } from './routes/sign-in'
@@ -43,6 +44,11 @@ const AuthedRoute = AuthedRouteImport.update({
 const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
   id: '/forgot-password',
   path: '/forgot-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LicenseRoute = LicenseRouteImport.update({
+  id: '/license',
+  path: '/license',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PrivacyRoute = PrivacyRouteImport.update({
@@ -145,6 +151,7 @@ const AuthedAgentsAgentIdRoutinesRoutineIdRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/forgot-password': typeof ForgotPasswordRoute
+  '/license': typeof LicenseRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
   '/sign-in': typeof SignInRoute
@@ -167,6 +174,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/forgot-password': typeof ForgotPasswordRoute
+  '/license': typeof LicenseRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
   '/sign-in': typeof SignInRoute
@@ -190,6 +198,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/_authed': typeof AuthedRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
+  '/license': typeof LicenseRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
   '/sign-in': typeof SignInRoute
@@ -214,6 +223,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/forgot-password'
+    | '/license'
     | '/privacy'
     | '/reset-password'
     | '/sign-in'
@@ -236,6 +246,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/forgot-password'
+    | '/license'
     | '/privacy'
     | '/reset-password'
     | '/sign-in'
@@ -258,6 +269,7 @@ export interface FileRouteTypes {
     | '/'
     | '/_authed'
     | '/forgot-password'
+    | '/license'
     | '/privacy'
     | '/reset-password'
     | '/sign-in'
@@ -282,6 +294,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthedRoute: typeof AuthedRouteWithChildren
   ForgotPasswordRoute: typeof ForgotPasswordRoute
+  LicenseRoute: typeof LicenseRoute
   PrivacyRoute: typeof PrivacyRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
   SignInRoute: typeof SignInRoute
@@ -310,6 +323,13 @@ declare module '@tanstack/react-router' {
       path: '/forgot-password'
       fullPath: '/forgot-password'
       preLoaderRoute: typeof ForgotPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/license': {
+      id: '/license'
+      path: '/license'
+      fullPath: '/license'
+      preLoaderRoute: typeof LicenseRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/privacy': {
@@ -490,6 +510,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthedRoute: AuthedRouteWithChildren,
   ForgotPasswordRoute: ForgotPasswordRoute,
+  LicenseRoute: LicenseRoute,
   PrivacyRoute: PrivacyRoute,
   ResetPasswordRoute: ResetPasswordRoute,
   SignInRoute: SignInRoute,

--- a/src/routes/license.tsx
+++ b/src/routes/license.tsx
@@ -1,0 +1,186 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { LegalLayout, LegalSection, LegalList, LegalItem } from "@/components/legal-layout";
+
+/**
+ * What the licence lets you do, in the build where the licence is the whole
+ * agreement.
+ *
+ * The repository has carried the AGPL's full text since the first commit, and
+ * `/terms` has summarised it in three bullets since there was a terms page at
+ * all. Neither answers the question somebody actually arrives with, which is
+ * not "what does the AGPL say" but "am I allowed to do the specific thing I am
+ * about to do" — run a modified copy for my own company, offer it to my
+ * customers, call it something else, build it into a product I sell.
+ *
+ * The hosted repository has a page at this path too and it says more, because
+ * it also has to explain what is *not* published. Here there is no such
+ * boundary to draw: this tree is the offer. That difference is the reason the
+ * two are not the same file, and it is the same reason `/terms` differs — see
+ * the header there.
+ *
+ * The one thing to keep exact: this page must never describe the hosted
+ * service's plans, prices or promises. A self-hoster reading it is not a
+ * customer, and a sentence about what covan.app includes is a sentence that
+ * goes stale here first.
+ */
+export const Route = createFileRoute("/license")({
+  component: LicensePage,
+  head: () => ({
+    meta: [
+      { title: "Licence — Covan" },
+      {
+        name: "description",
+        content:
+          "Covan is AGPL-3.0. What you may do with it, the one obligation, the name, and when you need a different licence.",
+      },
+    ],
+  }),
+});
+
+const REPO = "https://github.com/covan-ai/covan";
+
+function LicensePage() {
+  return (
+    <LegalLayout title="Licence" updated="September 2026">
+      <p className="text-[15px] leading-[1.55] text-muted-foreground">
+        Covan is open source under the{" "}
+        <a
+          href="https://www.gnu.org/licenses/agpl-3.0.html"
+          target="_blank"
+          rel="noreferrer"
+          className="text-foreground underline underline-offset-4"
+        >
+          GNU Affero General Public License, version 3
+        </a>
+        . The full text ships in this repository as{" "}
+        <code className="rounded-sm bg-muted px-1 py-0.5 font-mono text-[13px]">LICENSE</code> and
+        it is the authority; everything on this page is a summary and loses to it wherever the two
+        differ.
+      </p>
+
+      <LegalSection title="What you may do">
+        <LegalList>
+          <LegalItem>
+            Run it, read it, change it and host it yourself — including commercially, including
+            inside a company, including for as many people as you like — without asking anyone and
+            without paying anyone.
+          </LegalItem>
+          <LegalItem>
+            Keep your changes to yourself, as long as you are running it for your own organisation.
+            Internal use triggers nothing at all, however heavily modified your copy is.
+          </LegalItem>
+          <LegalItem>
+            Fork it. Every feature is here — there is no separate build, no licence key and nothing
+            that checks in with anyone — so a fork is a working product rather than a demo of one.
+          </LegalItem>
+        </LegalList>
+      </LegalSection>
+
+      <LegalSection title="The one obligation">
+        <p>
+          If you modify Covan and then offer it to other people over a network — a hosted version
+          for your customers, a service built on a changed copy — you have to make your changes
+          available to those users under the same licence. That is section 13, and it is the only
+          condition that distinguishes the AGPL from an ordinary GPL.
+        </p>
+        <p>
+          Running an unmodified copy for your own team does not trigger it. Neither does modifying a
+          copy that only your own organisation uses. It is a rule about redistributing a service,
+          not a rule about using one.
+        </p>
+        <p>
+          The practical form of it is a link. If you run a modified Covan for other people, give
+          those people a way to get the source of the version they are using.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="The name">
+        <p>
+          The licence covers the code, not the name. <em>Covan</em>, the wordmark and the logo are
+          not granted by the AGPL.
+        </p>
+        <p>
+          What you may always do without asking: say truthfully that your thing is built on Covan,
+          is a fork of Covan, or is compatible with it. What you may not do is call it Covan, or use
+          the mark in a way that suggests the project runs it or endorses it. If you want to do
+          something in between, ask — the answer is usually yes and it is quicker than guessing.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="When you need a different licence">
+        <p>
+          The AGPL is the right licence for almost everybody reading this. It stops being the right
+          one in a narrow case: you want to build Covan into a proprietary product that you offer to
+          other people over a network, and you do not want to publish your changes.
+        </p>
+        <p>
+          A commercial licence exists for that. It is possible because every contribution arrives
+          with a grant permitting release under the AGPL or another licence — see{" "}
+          <code className="rounded-sm bg-muted px-1 py-0.5 font-mono text-[13px]">
+            CONTRIBUTING.md
+          </code>{" "}
+          — so the rights are the maintainer's to give. Write to{" "}
+          <a
+            href="mailto:efe@covan.app"
+            className="text-foreground underline underline-offset-4 hover:no-underline"
+          >
+            efe@covan.app
+          </a>{" "}
+          and describe what you are building.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="What you contribute">
+        <p>
+          A pull request comes with that same grant, which is what keeps a commercial licence
+          possible without going back to every contributor. You keep the copyright in what you
+          wrote; what you give is permission to release it under this licence or another one.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="No warranty">
+        <p>
+          The software is provided as is, without warranty of any kind, and the authors are not
+          liable for what happens when you run it. That is sections 15 and 16 of the licence and it
+          is not a formality: Covan sends your documents to a language model and shows you what
+          comes back, and a language model can be confidently wrong. Answers are a starting point,
+          not a decision.
+        </p>
+        <p>
+          Running it makes you the operator, which is a role with obligations of its own toward the
+          people whose data is in it. What that involves is set out on the{" "}
+          <Link to="/privacy" className="text-foreground underline underline-offset-4">
+            privacy page
+          </Link>{" "}
+          and in the security notes that ship with the repository.
+        </p>
+      </LegalSection>
+
+      <LegalSection title="Other people's code">
+        <p>
+          Covan depends on a lot of open source, each package under its own licence, and those are
+          unaffected by this one. The dependency list is in the repository, so a compliance review
+          can be done from{" "}
+          <a
+            href={REPO}
+            target="_blank"
+            rel="noreferrer"
+            className="text-foreground underline underline-offset-4"
+          >
+            the source
+          </a>{" "}
+          rather than from a form somebody filled in.
+        </p>
+        <p>
+          <Link to="/terms" className="text-foreground underline underline-offset-4">
+            Terms
+          </Link>{" "}
+          ·{" "}
+          <Link to="/privacy" className="text-foreground underline underline-offset-4">
+            Privacy
+          </Link>
+        </p>
+      </LegalSection>
+    </LegalLayout>
+  );
+}

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -167,6 +167,10 @@ function PrivacyPage() {
         <p>
           <Link to="/terms" className="text-foreground underline underline-offset-4">
             Terms
+          </Link>{" "}
+          ·{" "}
+          <Link to="/license" className="text-foreground underline underline-offset-4">
+            Licence
           </Link>
         </p>
       </LegalSection>

--- a/src/routes/routes.test.ts
+++ b/src/routes/routes.test.ts
@@ -53,6 +53,19 @@ describe("route files", () => {
   // person passes through exactly once. This walks the source rather than
   // rendering Settings, because the regression to catch is a deletion, and a
   // deleted link fails no render test.
+  // The licence page has no resolver in front of it — `lib/legal.ts` exists so
+  // an operator can redirect Terms and Privacy at documents of their own, and
+  // nobody redirects a licence. So the only thing holding /license reachable is
+  // that two other pages link to it, and the regression is a deletion, which no
+  // render test would catch.
+  it("reaches the licence page from both of the pages that name it", () => {
+    expect(routeFiles()).toContain("license.tsx");
+
+    for (const page of ["terms.tsx", "privacy.tsx"]) {
+      expect(readFileSync(`${ROUTES_DIR}${page}`, "utf8"), page).toContain('to="/license"');
+    }
+  });
+
   it("links to both documents from somewhere inside the signed-in app", () => {
     const authed = routeFiles()
       .filter((f) => f.startsWith("_authed"))

--- a/src/routes/terms.tsx
+++ b/src/routes/terms.tsx
@@ -61,7 +61,12 @@ function TermsPage() {
             The full text ships in the repository as{" "}
             <code className="rounded-sm bg-muted px-1 py-0.5 font-mono text-[13px]">LICENSE</code>,
             and it is the authority — this summary is a convenience and loses to it wherever the two
-            differ.
+            differ. The{" "}
+            <Link to="/license" className="text-foreground underline underline-offset-4">
+              licence page
+            </Link>{" "}
+            answers the questions the text does not put in one place: the name, contributions, and
+            when you would need a different licence.
           </LegalItem>
         </LegalList>
       </LegalSection>
@@ -104,6 +109,10 @@ function TermsPage() {
         <p>
           <Link to="/privacy" className="text-foreground underline underline-offset-4">
             Privacy
+          </Link>{" "}
+          ·{" "}
+          <Link to="/license" className="text-foreground underline underline-offset-4">
+            Licence
           </Link>
         </p>
       </LegalSection>


### PR DESCRIPTION
The open build's half of the legal work done for the hosted one in covan-cloud#150.

### `/license`, new

The AGPL text has shipped here since the first commit and `/terms` has summarised it in three bullets for as long as there has been a terms page. Neither answers what somebody actually arrives with: not "what does the AGPL say" but **"am I allowed to do the thing I am about to do"** — run a modified copy internally, offer it to my customers, call it something else, build it into a product I sell. The page is organised by those questions, plus the name, contributions, and the commercial licence `CONTRIBUTING.md`'s grant makes possible.

It is deliberately **not** the hosted tree's copy of this page. That one also has to explain what is *not* published; here the tree is the offer and there is no boundary to draw. Same reason `/terms` differs between the two, and the header says so, so it does not read as drift later. Declared in `check-sync.sh`.

### `SECURITY.md` was telling researchers something untrue

It said the owner branch of the select policy on `chat_sessions` let a removed member read their transcripts back by session id, and invited people not to write it up. **`0031_access_follows_membership.sql` closed that in August** across eleven policies, and `docs/team.md` has described the current behaviour all along — the security policy was the copy nobody reran.

That is the worse direction for this particular mistake: a stale "already known" section tells a reporter to skip a finding. It now says what remains open instead — `routines_select_visible`, deliberately — and why.

### `docs/security.md`, new and shared

Where authorization lives, the three overlapping tenancy guards, what the service-role key is and where it is allowed, the three things an API key cannot do, what the Node build refuses to start with, what Covan does not have (no SSO, no audit log, no certification, no 2FA), and a six-item checklist for anyone running it.

Byte-identical with covan-cloud. Everything specific to covan.app — regions, backups, subprocessors — deliberately stays out and lives on that site's own pages, which is what keeps the file shareable.

### Guards

`routes.test.ts` gains a check that `/license` exists and that both pages naming it still link to it: it has no resolver in front of it, so two links are the only thing holding it reachable, and the regression is a deletion. 400 tests pass; `check-sync.sh` reports **in sync** against covan-cloud's matching branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)