### PR TITLE
Answer "what now" on the one screen that currently does not

### DIFF
--- a/src/components/first-uploads.tsx
+++ b/src/components/first-uploads.tsx
@@ -1,0 +1,65 @@
+import { SectionCard } from "@/components/section-card";
+
+/**
+ * What to put in the first bundle.
+ *
+ * A workspace with no bundles is the one screen where the product is
+ * indistinguishable from a chat window, and the honest reason is that nobody
+ * has told it anything yet. `EmptyState` is the right treatment for a list that
+ * happens to be empty; it is the wrong one here, because there is a specific
+ * answer to "what now" and printing "no bundles yet" withholds it (covan#45).
+ *
+ * The four below are not categories, they are files a team already has. Each
+ * carries the reason it earns a place, because "upload your documentation" is
+ * advice nobody can act on and "the page that says how expenses work" is.
+ *
+ * Only shown to somebody who can actually upload. A viewer looking at an empty
+ * workspace gets the plain empty state — a checklist you are not allowed to
+ * complete is worse than a blank.
+ */
+
+const FIRST_UPLOADS: Array<{ what: string; why: string }> = [
+  {
+    what: "The handbook",
+    why: "Leave, expenses, hours, who approves what. These are the questions asked out loud, by the person least willing to ask twice.",
+  },
+  {
+    what: "The tooling pages",
+    why: "Which tool for what, and who owns it. Half of a first week is finding out where things live.",
+  },
+  {
+    what: "However you do the thing you do",
+    why: "A release, a refund, a proposal, a handover. This is the knowledge that usually lives in one person's head and leaves with them.",
+  },
+  {
+    what: "The answer you have typed twice",
+    why: "If you have written it out for two different people, it is documentation that has not been filed yet.",
+  },
+];
+
+export function FirstUploads({ className }: { className?: string }) {
+  return (
+    <SectionCard className={className}>
+      <p className="font-dm text-[18px] leading-tight">Start with four files</p>
+      <p className="mt-2 max-w-prose text-sm leading-[1.45] text-muted-foreground">
+        A bundle is a group of documents any agent can read. It is worth more than the sum of the
+        files in it once it covers the questions people actually ask, so start with the ones they
+        already do.
+      </p>
+      <ul className="mt-5 space-y-3.5">
+        {FIRST_UPLOADS.map((item) => (
+          <li key={item.what} className="flex gap-3">
+            {/* Square, per the system: bullets, marks and selection markers are
+                never round. Nudged down to sit on the first line's baseline
+                rather than its box. */}
+            <span aria-hidden="true" className="mt-[7px] size-1.5 shrink-0 bg-muted-foreground" />
+            <p className="text-sm leading-[1.45]">
+              <span className="font-medium">{item.what}</span>
+              <span className="text-muted-foreground"> — {item.why}</span>
+            </p>
+          </li>
+        ))}
+      </ul>
+    </SectionCard>
+  );
+}

--- a/src/lib/agent-meta.test.ts
+++ b/src/lib/agent-meta.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { EMOJIS, MODELS, PERSONA_TEMPLATES } from "./agent-meta";
+
+/**
+ * Two invariants that nothing else would catch, because both fail silently.
+ *
+ * A template's emoji and model are pre-filled into `Select` controls whose
+ * options are `EMOJIS` and `MODELS`. A value outside either list is not an
+ * error — the control simply renders empty, on the create dialog and then again
+ * on that agent's settings tab forever after. There is no thrown exception and
+ * no failing request; the picker is just blank, which reads as a rendering bug
+ * rather than a typo four files away.
+ *
+ * These are cheap to state and the alternative is finding out from a user.
+ */
+
+describe("persona templates", () => {
+  it.each(PERSONA_TEMPLATES)("$id offers an emoji the pickers can show", ({ emoji }) => {
+    expect(EMOJIS).toContain(emoji);
+  });
+
+  it.each(PERSONA_TEMPLATES)("$id offers a model the pickers can show", ({ model }) => {
+    expect(MODELS).toContain(model);
+  });
+
+  it("has no two templates sharing an id", () => {
+    // The dialog finds the picked template by id and toggles on it. Two rows
+    // with one id means the second is unreachable and the first cannot be
+    // deselected without appearing to select the other.
+    const ids = PERSONA_TEMPLATES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/src/lib/agent-meta.ts
+++ b/src/lib/agent-meta.ts
@@ -2,7 +2,13 @@
 // per-model badge accents, and starter persona templates. Previously these
 // lists were duplicated across create-agent-dialog and the configuration tab.
 
-export const EMOJIS = ["🎓", "🚀", "🧑‍💻", "📊", "🧠", "✍️", "🎨", "🔬", "⚖️", "💬"] as const;
+// Every emoji a template uses has to be on this list, and not for tidiness: the
+// create dialog and the agent settings tab both render it as the option set of
+// a `Select`. A template carrying an emoji that is not here pre-fills a value
+// with no matching item, so the picker shows a blank — on the new agent, and
+// again every time somebody opens its settings afterwards.
+// `agent-meta.test.ts` pins that.
+export const EMOJIS = ["🎓", "🚀", "🧑‍💻", "📊", "🧠", "✍️", "🎨", "🔬", "⚖️", "💬", "🧭"] as const;
 
 export const MODELS = ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini"] as const;
 
@@ -62,6 +68,29 @@ export const PERSONA_TEMPLATES: PersonaTemplate[] = [
     model: "gpt-4o",
     persona:
       "You are a skilled content writer who matches the team's brand voice. Draft clear, engaging copy grounded in our docs. Offer a couple of variations when useful, keep it tight, and flag anything that needs a fact-check.",
+  },
+  {
+    // The week somebody joins is the clearest first job a team has for
+    // something that has read everything: the same questions get asked out
+    // loud, and the cost of nobody having written things down is visible that
+    // week and invisible every other one (covan#45).
+    //
+    // `gpt-4o-mini` on purpose, and it is the only template below the top tier
+    // besides Support. A new joiner asks many small questions whose answers are
+    // already in the documents; the work is retrieval and plain phrasing, not
+    // reasoning, and the cheaper model is the one that survives a busy first
+    // week without the cost being noticed.
+    //
+    // The persona's second half is the part that matters. An onboarding agent
+    // that fills a gap with a plausible answer is worse than no agent at all,
+    // because the person asking has no way to know it is wrong and every reason
+    // to repeat it.
+    id: "onboarding",
+    label: "Onboarding Guide",
+    emoji: "🧭",
+    model: "gpt-4o-mini",
+    persona:
+      "You are the colleague a new joiner can ask anything, however small. Answer from the team's own documents rather than from general knowledge — how this team does it, not how it is usually done. Keep replies short and point to the next thing worth reading. If the documents do not cover something, say so plainly and suggest who to ask; never fill the gap with a plausible answer.",
   },
   {
     id: "analyst",

--- a/src/routes/_authed.agents.$agentId.knowledge.test.tsx
+++ b/src/routes/_authed.agents.$agentId.knowledge.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type React from "react";
@@ -45,6 +45,18 @@ const store = {
 
 vi.mock("@/lib/agents-store", () => ({ useAgentsStore: () => store }));
 
+/** Puts the workspace back to one bundle with one document in it. */
+function withKnowledge() {
+  store.bundles = [{ id: "bundle-1", name: "GTM knowledge", description: null, documentCount: 1 }];
+  store.agents[0].bundleIds = ["bundle-1"];
+}
+
+/** A workspace nobody has uploaded anything to yet. */
+function withNothing() {
+  store.bundles = [];
+  store.agents[0].bundleIds = [];
+}
+
 async function renderTab(canWrite: boolean) {
   store.canWrite = canWrite;
   const { Route } = await import("./_authed.agents.$agentId.knowledge");
@@ -58,6 +70,7 @@ async function renderTab(canWrite: boolean) {
 }
 
 describe("the Knowledge tab", () => {
+  beforeEach(withKnowledge);
   // The read-only notice promises a viewer "can read every bundle attached to
   // this agent and everything in it". The document list used to sit inside the
   // `canWrite` branch alongside the upload form, so a viewer read the promise
@@ -77,5 +90,30 @@ describe("the Knowledge tab", () => {
     expect(screen.getByText("pitch-deck.pdf")).toBeInTheDocument();
     expect(screen.getByLabelText(/remove pitch-deck\.pdf/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/reindex pitch-deck\.pdf/i)).toBeInTheDocument();
+  });
+});
+
+// covan#45: an empty workspace is the one screen where the product looks like a
+// chat window, and the reason is that nobody has told it anything yet. "No
+// bundles yet" is true and useless — there is a specific answer to "what now".
+describe("a workspace with nothing in it", () => {
+  beforeEach(withNothing);
+
+  it("tells a member what to upload first, instead of that there is nothing", async () => {
+    await renderTab(true);
+
+    expect(screen.getByText("Start with four files")).toBeInTheDocument();
+    expect(screen.getByText("The handbook")).toBeInTheDocument();
+    expect(screen.getByText("The answer you have typed twice")).toBeInTheDocument();
+    expect(screen.queryByText("No bundles yet")).not.toBeInTheDocument();
+  });
+
+  it("gives a viewer the plain empty state, because they cannot act on the list", async () => {
+    // A checklist you are not allowed to complete is worse than a blank: it
+    // reads as your job until you try, and the upload control is not there.
+    await renderTab(false);
+
+    expect(screen.getByText("No bundles yet")).toBeInTheDocument();
+    expect(screen.queryByText("Start with four files")).not.toBeInTheDocument();
   });
 });

--- a/src/routes/_authed.agents.$agentId.knowledge.tsx
+++ b/src/routes/_authed.agents.$agentId.knowledge.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useAgentsStore } from "@/lib/agents-store";
 import { api } from "@/lib/api-client";
 import { PageContainer, PageHeader, SectionHeading } from "@/components/page-container";
+import { FirstUploads } from "@/components/first-uploads";
 import { Chip, EmptyState } from "@/components/section-card";
 import { DocsLink } from "@/components/docs-link";
 import { RevisitPanel } from "@/components/revisit-panel";
@@ -168,11 +169,15 @@ function KnowledgeTab() {
           meta={bundles.length > 0 ? `${bundles.length} available` : undefined}
         />
         {bundles.length === 0 ? (
-          <EmptyState
-            className="mt-3"
-            title="No bundles yet"
-            description="Create one below, then drop documents into it. Bundles are reusable across every agent."
-          />
+          canWrite ? (
+            <FirstUploads className="mt-3" />
+          ) : (
+            <EmptyState
+              className="mt-3"
+              title="No bundles yet"
+              description="Nothing has been uploaded to this workspace. A member can create a bundle and drop documents into it."
+            />
+          )
         ) : (
           <div className="mt-3 divide-y divide-hairline overflow-hidden rounded-xl border border-border bg-surface">
             {bundles.map((b) => {


### PR DESCRIPTION
## What problem does this solve?

Two thirds of #45, which calls itself packaging rather than capability and is right — nothing here is new machinery.

### The empty workspace

A workspace with no bundles is the one screen where this product is indistinguishable from a chat window, and the honest reason is that nobody has told it anything yet. It said **"No bundles yet"**: true, and useless. There is a specific answer to *what now* and the screen was withholding it.

Four files now, each with the reason it earns a place, because "upload your documentation" is advice nobody can act on and "the page that says how expenses work" is:

- **The handbook** — leave, expenses, hours, who approves what
- **The tooling pages** — which tool for what, and who owns it
- **However you do the thing you do** — a release, a refund, a handover
- **The answer you have typed twice** — if you have written it out for two people, it is documentation that has not been filed yet

The last is the one worth keeping: it is the cheapest item on the list to find.

Only for somebody who can upload. A viewer keeps the empty state, reworded to say whose job it is — a checklist you are not allowed to complete reads as yours until you try and find no control.

### The Onboarding Guide template

The week somebody joins is the clearest first job a team has for something that has read everything: the same questions get asked out loud, and the cost of nobody having written things down is visible that week and invisible every other one.

`gpt-4o-mini`, because the work is retrieval and plain phrasing rather than reasoning. The half of the persona that matters is the last sentence — an onboarding agent that fills a gap with a plausible answer is worse than no agent at all, since the person asking has no way to know it is wrong and every reason to repeat it.

### It turned up a live trap

The template's emoji was not in `EMOJIS`, and that list is the option set of a `Select` on **both** the create dialog and the agent settings tab. A template carrying an emoji off the list pre-fills a value with no matching item, so the picker renders blank — on the new agent, and again every time anybody opens its settings afterwards. No error, no failed request; just an empty control that reads as a rendering bug rather than a typo four files away.

`src/lib/agent-meta.test.ts` pins it: every template's emoji is in `EMOJIS`, every template's model is in `MODELS`, and no two templates share an id (the dialog finds the picked one by id, so a duplicate makes the second unreachable).

### Not in this PR

The issue's third piece, a first-week routine, is missing on purpose. Routines have no template mechanism, so building one is new machinery rather than packaging — the one thing this issue said it was not. Worth its own issue if it is wanted.

## Checks

- [x] The commands above pass

```
lint        0 errors, 3 warnings (pre-existing)
typecheck   clean
check:rls   ✓ all 20 tables created under 1 directory enable RLS
test        416 passed (was 399; 17 new)
build       ✓
```

## If you touched UI

- [x] It follows `DESIGN.md` — `SectionCard` for the surface (border and a surface step, no shadow), DM Sans for the title and Geist for the body, square bullets per "squares, not circles", and no amber added
