### PR TITLE
Deletion you can undo, and a record of who did it

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -168,6 +168,11 @@ including this one — see [Your team](team.md).
 | `GET /documents/:id/download`                    | The original file     |
 | `POST /documents/:id/reindex`                    | Re-chunk and re-embed |
 
+Deleting a bundle or a document marks it rather than destroying it: it stops
+being visible and stops grounding answers immediately, and `GET /trash` can
+bring it back for thirty days. `403` means the caller is a viewer; `404` means
+it is already gone or was never visible. Same for `DELETE /agents/:id`.
+
 ### Routines
 
 |                                                |                                  |
@@ -192,6 +197,9 @@ including this one — see [Your team](team.md).
 | `GET`/`POST`/`DELETE /invitations`                           | Invite and revoke. Admin.                                                                                      |
 | `GET /invitations/incoming` · `POST /invitations/:id/accept` | Yours to accept                                                                                                |
 | `GET /workspaces/:id/export`                                 | The whole workspace as one zip — [Taking it with you](export.md)                                               |
+| `GET /trash`                                                 | Agents, bundles and documents deleted in the last 30 days. Refused to a viewer, rather than answered empty.    |
+| `POST /trash/:kind/:id/restore`                              | `kind` is the word `/trash` gave back. 400 means restore the parent first, and says which.                     |
+| `GET /events`                                                | Who deleted, restored, invited, removed or changed a role. Admin — anyone else gets an empty page.             |
 | `DELETE /account`                                            | Close your own account. Session only. Refused while you are the last admin of a workspace others are still in. |
 
 ### Usage and keys

--- a/docs/team.md
+++ b/docs/team.md
@@ -142,11 +142,16 @@ is a membership check plus `role <> 'viewer'`. So a member can create an agent,
 rewrite another agent's persona, change its model, upload to any bundle, detach
 a bundle, and delete any agent, bundle or document in the workspace, with no
 approval anywhere in the path. That is deliberate — the product's claim is that
-a team trains one agent together — but it is worth knowing how large it is: the
-cascades mean deleting an agent takes every session anybody ever had with it,
-every message in those sessions and every routine pointed at it, and deleting a
-bundle takes its documents and their embeddings. None of it is recoverable from
-inside the product. A `viewer` is refused all of it.
+a team trains one agent together — but it is worth knowing how large it is:
+deleting an agent takes every session anybody ever had with it, every message in
+those sessions and every routine pointed at it, and deleting a bundle takes its
+documents and their embeddings. A `viewer` is refused all of it.
+
+Until `0039` none of that was recoverable from inside the product, and this page
+said so. [Deleting, and taking it back](#deleting-and-taking-it-back) is the
+change: those three deletions now wait thirty days, and
+[the record of who did it](#the-record-of-who-did-it) says whose decision it was
+either way.
 
 **Everything that is yours** asks only whether you are a member: your own
 sessions, messages, brainstorm ideas, routines, delivery channels, favourites
@@ -306,6 +311,115 @@ a spent allowance — is also yours alone, a row in `notification_preferences` w
 your user id as its primary key. A missing row means everything is on, which is
 why turning a notice off is an update rather than a delete.
 
+## Deleting, and taking it back
+
+Three things wait rather than go: an **agent**, a **knowledge bundle** and a
+**document**. Each carries `deleted_at`, `deleted_by` and `deleted_via`, and
+deleting one is `soft_delete_agent()`, `soft_delete_bundle()` or
+`soft_delete_document()` rather than a `DELETE`. Thirty days later a sweeper on
+the API Worker deletes the row for real, and the foreign keys do what they
+always did.
+
+**`deleted_via` is what makes a restore exact.** Foreign keys cascade on a real
+delete and do nothing at all on a soft one, so a marked agent would otherwise
+leave its sessions and routines on screen pointing at something gone. Deleting
+an agent therefore also marks its `chat_sessions` and `routines` with
+`deleted_via = <agent id>`; deleting a bundle marks its documents the same way.
+Restoring X clears X and exactly the rows carrying `deleted_via = X` — so a
+document you deleted on its own does _not_ come back when its bundle is
+restored, and restoring a document into a still-deleted bundle is refused with
+a message naming which button to press first.
+
+Bundles are untouched when an agent is deleted. A bundle is workspace-level and
+may be attached to several agents, so this is unchanged from before: the
+`agent_bundles` link goes, the bundle stays, including the per-agent
+`covan:chat-uploads:<agentId>` bundle.
+
+### Deleted means invisible, to everybody
+
+Every select policy on those tables gained `deleted_at is null`, with **no**
+branch admitting the people who could restore it. That was written the other way
+first. The obvious shape — `deleted_at is null or can_write_in_workspace(...)` —
+lets a trash screen read the rows through the ordinary policy, and its cost is
+that every other SELECT in the codebase becomes wrong unless it also says
+`.is("deleted_at", null)`, because a member is exactly who runs the agent list,
+the bundle page, retrieval and export. That is thirty call sites today and an
+unbounded number forever, and the failure mode is showing deleted things rather
+than erroring, so nothing catches it.
+
+Two policies needed more than the clause, and both are where a deletion would
+otherwise have been cosmetic:
+
+- **`document_chunks`.** The chunks hold the document's text, and their policy
+  asked only about workspace membership — so a deleted document's contents
+  stayed readable straight from PostgREST by any member. They now require the
+  parent document to be alive, for everyone, with no exception for the person
+  who could restore it.
+- **`session_is_visible`** (`0031`) gained `cs.deleted_at is null`. Because
+  `messages` and `ideas` name that function and nothing else, one line hides a
+  deleted agent's entire conversation history.
+
+`match_chunks` asks twice — that the document is alive _and_ that the bundle the
+chunk is filed under is alive. Retrieval scope lives on `document_chunks.bundle_id`
+rather than on the document row, which is what makes moving a document between
+bundles a re-pointing of its chunks (`0024`), so a chunk can name a bundle its
+document has left. Without this an agent goes on quoting a file somebody
+deleted, which is the worst way the feature can fail: it looks like the deletion
+did nothing.
+
+### The trash
+
+Settings → **Recently deleted**, for anyone who can write. It reads
+`workspace_trash()` — `security definer`, checking `can_write_in_workspace` for
+itself and raising `42501`, the arrangement `workspace_usage_all` already uses —
+because the policies above hide the rows from the ordinary path. A viewer gets
+an error rather than an empty list, since an empty list would tell them there
+was nothing to recover.
+
+It lists only rows with `deleted_via is null`: decisions somebody made, not
+their consequences. A bundle of two hundred documents is one entry.
+
+**A deleted bundle still costs storage.** Its chunks are still rows and its
+files are still objects until the sweeper reaches them. Against Supabase's
+500 MB that is a real number, and it is the price of the window. It is also why
+`DELETE /documents/:id` no longer removes the stored object: a restored document
+that came back as a row pointing at a missing file would be worse than either
+outcome alone. The sweeper does both, in the order account closure already
+uses — collect the keys, delete the rows, then delete the objects — because
+afterwards there is nothing left to enumerate the keys by.
+
+## The record of who did it
+
+`workspace_events` holds twelve actions: the six deletions and restores above,
+`member.role_changed`, `member.removed`, `member.left`, `member.joined`, and
+invitations created and revoked. Team → **Activity** shows it, and
+`workspace_events_select_admin` means only an admin can read it.
+
+**Nothing writes to it through the API.** The rows come from `security definer`
+triggers on the tables the events are about, and the table has no insert policy
+for anybody — nor an INSERT grant. An audit log the API writes can be skipped by
+anything that does not go through the API, and PostgREST, reachable with the
+anon key in the browser bundle, does not. A trigger cannot be routed around.
+
+Three details decide whether it is readable:
+
+- **`subject_label` stores the name as it was.** Thirty days after a deletion the
+  sweeper takes the row and `subject_id` points nowhere; a log that can only say
+  "an agent was deleted" is not a log.
+- **Cascaded marks emit nothing.** The trigger fires only when `deleted_via is
+null`, so deleting that bundle of two hundred documents writes one event.
+- **`member.removed` and `member.left` are the same DELETE**, told apart by
+  whether `auth.uid()` is the row's own `user_id`. Being removed and choosing to
+  go are different events to everyone involved.
+
+The membership trigger stands aside when the workspace itself is being deleted —
+the same exception `trg_prevent_last_admin` makes, and for the same reason.
+
+Not a change feed: editing an agent's persona is not here. Twelve deliberate
+actions produce tens of rows a month in a busy ten-person workspace, so no
+retention policy is written; a sweeper that deletes audit history is something
+to add on purpose.
+
 ## Removing a member
 
 Only an admin can remove somebody: the delete policy on `workspace_members` is
@@ -438,15 +552,22 @@ delivery records; and the delivery channels filed under that workspace.
 
 One thing the application does not do, and an operator should know it. The
 cascade is a database cascade, and the uploaded files themselves live in object
-storage under the key on each `documents` row. Deleting a single document removes
-its object; deleting a bundle, an agent or a workspace deletes the rows that
-named those keys and nothing in Covan touches the store. Whether those objects
-are then cleaned up is a question about the storage itself — a lifecycle rule on
-the bucket, or a sweep somebody runs — not one this codebase answers. If it is
-the latter, collect the keys before the rows go, because afterwards there is
-nothing left to enumerate them by.
+storage under the key on each `documents` row. Deleting a _workspace_ deletes the
+rows that named those keys and nothing in Covan touches the store. Whether those
+objects are then cleaned up is a question about the storage itself — a lifecycle
+rule on the bucket, or a sweep somebody runs — not one this codebase answers. If
+it is the latter, collect the keys before the rows go, because afterwards there
+is nothing left to enumerate them by.
 
-Account closure is the one place that does it for you, and it follows exactly
+Deleting a document, a bundle or an agent is no longer in that paragraph.
+Those three are marked rather than deleted
+([Deleting, and taking it back](#deleting-and-taking-it-back)), and the
+thirty-day sweeper removes their rows and their objects together, keys first.
+`DELETE /documents/:id` used to delete the object immediately and now deletes
+nothing at all — a restored document pointing at a missing file would be worse
+than either outcome on its own.
+
+Account closure is the other place that does it for you, and it follows exactly
 that advice: `worker/src/routes/account.ts` reads the keys of every document in
 the workspaces it is about to remove, deletes the rows, and then deletes the
 objects. The difference is not technical but legal — for an ordinary delete an

--- a/src/components/agent-workspace.tsx
+++ b/src/components/agent-workspace.tsx
@@ -300,8 +300,9 @@ export function AgentWorkspace({ agentId, children }: { agentId: string; childre
                 <AlertDialogHeader>
                   <AlertDialogTitle>Delete {agent.name}?</AlertDialogTitle>
                   <AlertDialogDescription>
-                    This removes the shared agent and all private chats across the team. This cannot
-                    be undone.
+                    This takes the shared agent away from the whole team, along with every chat and
+                    routine attached to it — including private ones. It waits 30 days in Settings →
+                    Recently deleted, and comes back whole if you restore it.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>

--- a/src/components/recently-deleted-section.test.tsx
+++ b/src/components/recently-deleted-section.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RecentlyDeletedSection } from "./recently-deleted-section";
+
+const { list, restore, invalidateWorkspaceScoped, success, error, FakeApiError } = vi.hoisted(
+  () => ({
+    list: vi.fn(),
+    restore: vi.fn(),
+    invalidateWorkspaceScoped: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    FakeApiError: class FakeApiError extends Error {
+      status: number;
+      constructor(status: number, message: string) {
+        super(message);
+        this.status = status;
+      }
+    },
+  }),
+);
+
+// Mocked whole rather than partially, for the reason the neighbouring section
+// tests give: the real module builds a Supabase client at import time, which
+// needs an origin no unit test has.
+vi.mock("@/lib/api-client", () => ({
+  api: { trash: { list, restore } },
+  ApiError: FakeApiError,
+}));
+
+vi.mock("@/lib/workspace-queries", () => ({ invalidateWorkspaceScoped }));
+vi.mock("sonner", () => ({ toast: { success, error } }));
+
+const DAY = 86_400_000;
+
+function item(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    kind: "agent",
+    id: "a1",
+    name: "Support",
+    deletedAt: Date.now() - 2 * DAY,
+    deletedBy: "Ali",
+    parentName: null,
+    purgesAt: Date.now() + 28 * DAY,
+    ...over,
+  };
+}
+
+function renderSection(canWrite = true) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <RecentlyDeletedSection canWrite={canWrite} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  list.mockReset();
+  restore.mockReset();
+  invalidateWorkspaceScoped.mockReset();
+  success.mockReset();
+  error.mockReset();
+});
+
+describe("recently deleted", () => {
+  it("does not ask at all when the person cannot restore anything", async () => {
+    renderSection(false);
+    // A viewer is refused by `workspace_trash()` with a 403, so asking would
+    // produce an error toast on a page they merely opened.
+    await waitFor(() => expect(list).not.toHaveBeenCalled());
+  });
+
+  it("says how long is left, not just when it went", async () => {
+    list.mockResolvedValue({ retentionDays: 30, items: [item()] });
+    renderSection();
+
+    expect(await screen.findByText("Support")).toBeInTheDocument();
+    // The countdown is the whole reason somebody opens this section, and it is
+    // computed rather than stored — the kind of arithmetic that silently drifts.
+    expect(screen.getByText(/28 days left/)).toBeInTheDocument();
+    expect(screen.getByText(/deleted by Ali/)).toBeInTheDocument();
+  });
+
+  it("says 'deleted' rather than guessing when the deleter is gone", async () => {
+    list.mockResolvedValue({ retentionDays: 30, items: [item({ deletedBy: null })] });
+    renderSection();
+
+    expect(await screen.findByText("Support")).toBeInTheDocument();
+    expect(screen.queryByText(/deleted by/)).not.toBeInTheDocument();
+  });
+
+  it("names the bundle a deleted document came out of", async () => {
+    list.mockResolvedValue({
+      retentionDays: 30,
+      items: [item({ kind: "document", name: "notes.md", parentName: "Onboarding" })],
+    });
+    renderSection();
+
+    // Two files called notes.md from different bundles are otherwise the same
+    // row twice, with no way to tell which one is being restored.
+    expect(await screen.findByText(/Onboarding/)).toBeInTheDocument();
+  });
+
+  it("restores by the kind the listing gave back", async () => {
+    list.mockResolvedValue({ retentionDays: 30, items: [item({ kind: "bundle", id: "b9" })] });
+    restore.mockResolvedValue({ ok: true });
+    renderSection();
+
+    await userEvent.click(await screen.findByRole("button", { name: /Restore/ }));
+
+    await waitFor(() => expect(restore).toHaveBeenCalledWith("bundle", "b9"));
+    // An agent coming back brings its conversations and routines; a bundle
+    // brings its documents. Everything on screen could have changed.
+    await waitFor(() => expect(invalidateWorkspaceScoped).toHaveBeenCalled());
+  });
+
+  it("passes the server's wording through when the order is wrong", async () => {
+    list.mockResolvedValue({ retentionDays: 30, items: [item({ kind: "document" })] });
+    restore.mockRejectedValue(
+      new FakeApiError(400, "restore the bundle this document belongs to first"),
+    );
+    renderSection();
+
+    await userEvent.click(await screen.findByRole("button", { name: /Restore/ }));
+
+    // The one message worth repeating verbatim: it names the button to press.
+    await waitFor(() =>
+      expect(error).toHaveBeenCalledWith("restore the bundle this document belongs to first"),
+    );
+  });
+
+  it("promises the window rather than finality when there is nothing in it", async () => {
+    list.mockResolvedValue({ retentionDays: 30, items: [] });
+    renderSection();
+
+    expect(await screen.findByText("Nothing deleted")).toBeInTheDocument();
+    expect(screen.getByText(/30 days/)).toBeInTheDocument();
+  });
+});

--- a/src/components/recently-deleted-section.tsx
+++ b/src/components/recently-deleted-section.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Bot, FileText, Library, Undo2 } from "lucide-react";
+import { SectionHeading } from "@/components/page-container";
+import { DataRow, EmptyState } from "@/components/section-card";
+import { Button } from "@/components/ui/button";
+import { api, ApiError, type TrashItem, type TrashKind } from "@/lib/api-client";
+import { invalidateWorkspaceScoped } from "@/lib/workspace-queries";
+import { formatRelative } from "@/lib/relative-time";
+import { toast } from "sonner";
+
+const ICONS: Record<TrashKind, typeof Bot> = {
+  agent: Bot,
+  bundle: Library,
+  document: FileText,
+};
+
+/**
+ * What this workspace deleted and can still get back.
+ *
+ * Deleting used to be final and larger than it looked: an agent took every
+ * session anybody had with it, every message in those, and every routine
+ * pointed at it, because the foreign keys cascaded. Now it marks, and this is
+ * the thirty-day window before the sweeper finishes the job.
+ *
+ * The list shows only deletions somebody actually performed. The documents that
+ * went down with a bundle are not rows here — they were not separate decisions,
+ * and restoring the bundle is what brings them back. That is `deleted_via` in
+ * the schema and it is the reason a bundle of two hundred files does not arrive
+ * here as two hundred and one things to think about.
+ *
+ * Not rendered for a viewer: `workspace_trash()` refuses them with a 403 rather
+ * than an empty list, because an empty list would tell them there was nothing
+ * to restore, which is a different claim and possibly a false one.
+ */
+export function RecentlyDeletedSection({ canWrite }: { canWrite: boolean }) {
+  const queryClient = useQueryClient();
+  const [restoring, setRestoring] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["trash"],
+    queryFn: () => api.trash.list(),
+    enabled: canWrite,
+  });
+
+  if (!canWrite) return null;
+
+  const items = data?.items ?? [];
+  const days = data?.retentionDays ?? 30;
+
+  const restore = async (item: TrashItem) => {
+    if (restoring) return;
+    setRestoring(item.id);
+    try {
+      await api.trash.restore(item.kind, item.id);
+      // Everything on screen could have changed: an agent coming back brings
+      // its conversations and routines with it, and a bundle brings its
+      // documents. Refetching the workspace-scoped queries is what puts them
+      // back on the screens that list them.
+      await invalidateWorkspaceScoped(queryClient);
+      await queryClient.invalidateQueries({ queryKey: ["trash"] });
+      toast.success(`${item.name} restored`);
+    } catch (e) {
+      // The one message worth passing through verbatim: a document whose bundle
+      // is also deleted cannot come back on its own, and the server says which
+      // to press first.
+      toast.error(e instanceof ApiError ? e.message : "Couldn't restore that");
+    } finally {
+      setRestoring(null);
+    }
+  };
+
+  return (
+    <section className="mt-16">
+      <SectionHeading
+        title="Recently deleted"
+        turn={`Yours for ${days} more days.`}
+        meta={items.length > 0 ? `${items.length} waiting` : undefined}
+      />
+
+      <div className="mt-6">
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : items.length === 0 ? (
+          <EmptyState
+            title="Nothing deleted"
+            description={`Agents, knowledge bundles and documents wait here for ${days} days before they go for good. Their conversations and routines come back with them.`}
+          />
+        ) : (
+          <ul className="flex flex-col gap-2.5">
+            {items.map((item) => {
+              const Icon = ICONS[item.kind];
+              return (
+                <li key={`${item.kind}:${item.id}`}>
+                  <DataRow
+                    icon={
+                      <span className="grid h-9 w-9 shrink-0 place-items-center rounded-md border border-dashed border-border text-muted-foreground">
+                        <Icon className="h-4 w-4" />
+                      </span>
+                    }
+                    title={item.name}
+                    meta={metaFor(item, days)}
+                    trailing={
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => restore(item)}
+                        disabled={restoring === item.id}
+                      >
+                        <Undo2 className="h-4 w-4" />
+                        {restoring === item.id ? "Restoring…" : "Restore"}
+                      </Button>
+                    }
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * One line saying what it was, who took it, and how long is left.
+ *
+ * The deleter is omitted rather than guessed when it is null — that happens
+ * when the person has since closed their own account, and "deleted by someone"
+ * is worth less than saying nothing.
+ */
+function metaFor(item: TrashItem, days: number): string {
+  const parts: string[] = [
+    item.kind === "document" && item.parentName ? item.parentName : item.kind,
+  ];
+  parts.push(item.deletedBy ? `deleted by ${item.deletedBy}` : "deleted");
+  parts.push(formatRelative(item.deletedAt));
+  parts.push(remaining(item.purgesAt, days));
+  return parts.join(" · ");
+}
+
+function remaining(purgesAt: number, days: number): string {
+  const ms = purgesAt - Date.now();
+  if (!Number.isFinite(ms)) return `${days} days left`;
+  const left = Math.ceil(ms / 86_400_000);
+  if (left <= 0) return "going any moment";
+  if (left === 1) return "1 day left";
+  return `${left} days left`;
+}

--- a/src/components/workspace-activity-section.tsx
+++ b/src/components/workspace-activity-section.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Bot,
+  FileText,
+  Library,
+  LogOut,
+  MailPlus,
+  ShieldCheck,
+  Undo2,
+  UserMinus,
+  UserPlus,
+  Trash2,
+} from "lucide-react";
+import { SectionHeading } from "@/components/page-container";
+import { DataRow, EmptyState } from "@/components/section-card";
+import { Button } from "@/components/ui/button";
+import { api, type WorkspaceEvent } from "@/lib/api-client";
+import { formatRelative } from "@/lib/relative-time";
+
+/**
+ * Who did what, read off `workspace_events`.
+ *
+ * The rows are written by database triggers, not by the API, which is the point
+ * of the whole arrangement: an audit log an API writes can be skipped by
+ * anything that does not go through that API — and PostgREST, reachable with
+ * the anon key in the browser bundle, does not. A trigger cannot be routed
+ * around, and the table has no insert policy for anybody, so the log cannot be
+ * forged either.
+ *
+ * Twelve actions, all of them things a person does deliberately to somebody
+ * else's work or standing: deletions and their undos, role changes, joins and
+ * departures, invitations sent and revoked. Not a change feed — editing an
+ * agent's persona is not here, and adding it would bury the twelve that matter
+ * under a stream nobody reads.
+ */
+export function WorkspaceActivitySection({ isAdmin }: { isAdmin: boolean }) {
+  const [expanded, setExpanded] = useState(false);
+  const limit = expanded ? 100 : 12;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["workspace-events", limit],
+    queryFn: () => api.events.list({ limit }),
+    enabled: isAdmin,
+  });
+
+  if (!isAdmin) return null;
+
+  const events = data?.events ?? [];
+
+  return (
+    <section className="mt-16">
+      <SectionHeading
+        title="What happened."
+        turn="And who."
+        description="Deletions, restores, roles and invitations. Written by the database rather than by the app, so nothing that skips the app can skip this."
+      />
+
+      <div className="mt-6">
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : events.length === 0 ? (
+          <EmptyState
+            title="Nothing yet"
+            description="Once somebody deletes an agent, changes a role or sends an invitation, it lands here with their name on it."
+          />
+        ) : (
+          <>
+            <ul className="flex flex-col gap-2.5">
+              {events.map((e) => (
+                <li key={e.id}>
+                  <DataRow
+                    icon={
+                      <span className="grid h-9 w-9 shrink-0 place-items-center rounded-md border border-hairline text-muted-foreground">
+                        <EventIcon action={e.action} />
+                      </span>
+                    }
+                    title={describe(e)}
+                    meta={`${e.actor ?? "Someone no longer here"} · ${formatRelative(e.createdAt)}`}
+                  />
+                </li>
+              ))}
+            </ul>
+            {(data?.hasMore || expanded) && (
+              <div className="mt-4">
+                <Button variant="ghost" size="sm" onClick={() => setExpanded(!expanded)}>
+                  {expanded ? "Show less" : "Show more"}
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function EventIcon({ action }: { action: string }) {
+  const cls = "h-4 w-4";
+  if (action.endsWith(".restored")) return <Undo2 className={cls} />;
+  if (action.startsWith("agent.")) return <Bot className={cls} />;
+  if (action.startsWith("bundle.")) return <Library className={cls} />;
+  if (action.startsWith("document.")) return <FileText className={cls} />;
+  if (action === "member.role_changed") return <ShieldCheck className={cls} />;
+  if (action === "member.joined") return <UserPlus className={cls} />;
+  if (action === "member.left") return <LogOut className={cls} />;
+  if (action === "member.removed") return <UserMinus className={cls} />;
+  if (action.startsWith("invitation.")) return <MailPlus className={cls} />;
+  return <Trash2 className={cls} />;
+}
+
+/**
+ * One sentence per event, in the past tense, naming the thing.
+ *
+ * `subjectLabel` is the name the thing had at the time, stored on the row
+ * rather than joined — thirty days after a deletion the sweeper takes the row
+ * and `subjectId` points nowhere, and a log that can only say "an agent was
+ * deleted" is not a log.
+ *
+ * The default branch prints the raw action rather than swallowing it. An
+ * unknown action means the database learned to write one this file has not
+ * learned to read, and showing it is how that gets noticed.
+ */
+function describe(e: WorkspaceEvent): string {
+  const what = e.subjectLabel;
+  const role = (e.detail?.role as string | undefined) ?? null;
+
+  switch (e.action) {
+    case "agent.deleted":
+      return `Deleted the agent ${what}`;
+    case "agent.restored":
+      return `Restored the agent ${what}`;
+    case "bundle.deleted":
+      return `Deleted the knowledge bundle ${what}`;
+    case "bundle.restored":
+      return `Restored the knowledge bundle ${what}`;
+    case "document.deleted":
+      return `Deleted the document ${what}`;
+    case "document.restored":
+      return `Restored the document ${what}`;
+    case "member.role_changed":
+      return `Changed ${what} from ${e.detail?.from} to ${e.detail?.to}`;
+    case "member.joined":
+      return `${what} joined${role ? ` as ${role}` : ""}`;
+    case "member.left":
+      return `${what} left the workspace`;
+    case "member.removed":
+      return `Removed ${what} from the workspace`;
+    case "invitation.created":
+      return `Invited ${what}${role ? ` as ${role}` : ""}`;
+    case "invitation.revoked":
+      return `Revoked the invitation to ${what}`;
+    default:
+      return `${e.action} — ${what}`;
+  }
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -478,6 +478,66 @@ export const api = {
       request("PATCH", "/onboarding", patch),
     complete: (): Promise<{ completed: true }> => request("POST", "/onboarding/complete"),
   },
+  trash: {
+    /** 403 for a viewer, deliberately — an empty list would say the wrong thing. */
+    list: (): Promise<TrashListing> => request("GET", "/trash"),
+    /**
+     * `kind` is the word the listing gave back, not a type the caller invents.
+     * A 400 here is the one worth reading aloud: it means the document's bundle
+     * is deleted too, and that has to go first.
+     */
+    restore: (kind: TrashKind, id: string): Promise<{ ok: true }> =>
+      request("POST", `/trash/${kind}/${id}/restore`),
+  },
+  events: {
+    /** Admin-only at the policy, so a member gets an empty page, not an error. */
+    list: (params?: { limit?: number; before?: string }): Promise<EventPage> => {
+      const q = new URLSearchParams();
+      if (params?.limit) q.set("limit", String(params.limit));
+      if (params?.before) q.set("before", params.before);
+      const suffix = q.toString();
+      return request("GET", `/events${suffix ? `?${suffix}` : ""}`);
+    },
+  },
+};
+
+export type TrashKind = "agent" | "bundle" | "document";
+
+export type TrashItem = {
+  kind: TrashKind;
+  id: string;
+  name: string;
+  /** Epoch milliseconds, like every other timestamp this API returns. */
+  deletedAt: number;
+  /** Null once the person who deleted it has closed their own account. */
+  deletedBy: string | null;
+  /** Which bundle a deleted document came out of; null for the other kinds. */
+  parentName: string | null;
+  purgesAt: number;
+};
+
+export type TrashListing = {
+  items: TrashItem[];
+  retentionDays: number;
+};
+
+export type WorkspaceEvent = {
+  id: string;
+  action: string;
+  subjectType: string;
+  subjectId: string | null;
+  /** The name as it was at the time — the row it points at may be gone. */
+  subjectLabel: string;
+  detail: Record<string, unknown> | null;
+  createdAt: number;
+  /** What to pass as `before` for the next page — see the route for why. */
+  cursor: string;
+  actor: string | null;
+};
+
+export type EventPage = {
+  events: WorkspaceEvent[];
+  hasMore: boolean;
 };
 
 /**

--- a/src/routes/_authed.agents.$agentId.knowledge.tsx
+++ b/src/routes/_authed.agents.$agentId.knowledge.tsx
@@ -60,7 +60,7 @@ function KnowledgeTab() {
   const deleteBundle = (bundleId: string, name: string) => {
     if (
       !confirm(
-        `Delete "${name}"? This permanently removes its documents and detaches it from every agent. This cannot be undone.`,
+        `Delete "${name}"? Its documents go with it and it detaches from every agent. It waits 30 days in Settings → Recently deleted, and restoring it brings the documents back too.`,
       )
     ) {
       return;

--- a/src/routes/_authed.agents.$agentId.settings.tsx
+++ b/src/routes/_authed.agents.$agentId.settings.tsx
@@ -46,7 +46,7 @@ export const Route = createFileRoute("/_authed/agents/$agentId/settings")({
  * "Settings" held three read-only facts and the delete button. People looking
  * for the name or the model reasonably opened Settings and found neither.
  * Ordered by how often it is touched — the fields, then the facts, then the
- * button that cannot be undone.
+ * button nobody presses twice.
  */
 function SettingsTab() {
   const { agentId } = Route.useParams();
@@ -211,12 +211,14 @@ function AgentSettingsForm({ agent }: { agent: Agent }) {
         <section className="mt-10">
           <SectionHeading
             title="Danger zone"
-            description="Deleting the agent removes it for the entire team, along with everyone's private chats."
+            description="Deleting the agent takes it away from the entire team, along with everyone's private chats. Recoverable for 30 days."
           />
           <SectionCard className="mt-3 flex items-center justify-between gap-4 border-destructive/30">
             <div className="min-w-0">
               <div className="text-sm font-semibold">Delete {agent.name}</div>
-              <p className="mt-0.5 text-sm text-muted-foreground">This cannot be undone.</p>
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                Recoverable for 30 days from Settings.
+              </p>
             </div>
             <AlertDialog>
               <AlertDialogTrigger asChild>
@@ -231,8 +233,9 @@ function AgentSettingsForm({ agent }: { agent: Agent }) {
                 <AlertDialogHeader>
                   <AlertDialogTitle>Delete {agent.name}?</AlertDialogTitle>
                   <AlertDialogDescription>
-                    This removes the shared agent and every chat the team has had with it. This
-                    cannot be undone.
+                    This takes the shared agent away from the whole team, along with every chat and
+                    routine attached to it. It waits 30 days in Settings → Recently deleted, and
+                    comes back whole if you restore it.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>

--- a/src/routes/_authed.settings.tsx
+++ b/src/routes/_authed.settings.tsx
@@ -11,13 +11,14 @@ import { WorkspaceUsageSection } from "@/components/workspace-usage-section";
 import { PreferencesSection } from "@/components/preferences-section";
 import { ApiKeysSection } from "@/components/api-keys-section";
 import { ExportWorkspaceSection } from "@/components/export-workspace-section";
+import { RecentlyDeletedSection } from "@/components/recently-deleted-section";
 import { CloseAccountSection } from "@/components/close-account-section";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { api, ApiError, type Me, type Workspace } from "@/lib/api-client";
-import { isAdminRole } from "@/lib/roles";
+import { canWriteAsRole, isAdminRole } from "@/lib/roles";
 import { privacyLink, termsLink } from "@/lib/legal";
 import { LegalAnchor } from "@/components/legal-anchor";
 
@@ -198,7 +199,12 @@ function SettingsPage() {
 
   // Defaults to true while `me` loads, so the form does not visibly lock and
   // then unlock on every cold load — mirrors the same choice in agents-store.
-  const isAdmin = me ? isAdminRole(me.members.find((m) => m.id === me.user.id)?.role) : true;
+  const myRole = me?.members.find((m) => m.id === me.user.id)?.role;
+  const isAdmin = me ? isAdminRole(myRole) : true;
+  // False while `me` loads, unlike `isAdmin` above: this one decides whether a
+  // section is fetched at all, and a request that 403s before the role is known
+  // is worse than a section that appears a moment late.
+  const canWrite = me ? canWriteAsRole(myRole) : false;
 
   return (
     <AppShell>
@@ -259,6 +265,14 @@ function SettingsPage() {
             Not gated on a role — an export is a read, and it contains only what
             this person could already see. */}
         <ExportWorkspaceSection workspaceId={me?.workspace.id} workspaceName={me?.workspace.name} />
+
+        {/* Under the export and above closing the account, which is the same
+            argument as the one above it: somebody on this page because
+            something went wrong should meet the way to undo it before they meet
+            the way to destroy more. Hidden from a viewer — `workspace_trash()`
+            refuses them anyway, and a section that only ever 403s is worse than
+            no section. */}
+        <RecentlyDeletedSection canWrite={canWrite} />
 
         {/* Last on the page, under everything it would destroy. Not gated on a
             role: erasure is the caller's own right and an admin has no say in

--- a/src/routes/_authed.team.tsx
+++ b/src/routes/_authed.team.tsx
@@ -33,6 +33,7 @@ import { copyInviteText } from "@/lib/invite-text";
 import { formatRelative } from "@/lib/relative-time";
 import { InviteMemberDialog } from "@/components/invite-member-dialog";
 import { LiveKeyWarning } from "@/components/live-key-warning";
+import { WorkspaceActivitySection } from "@/components/workspace-activity-section";
 import { toast } from "sonner";
 
 export const Route = createFileRoute("/_authed/team")({
@@ -382,6 +383,12 @@ function TeamPage() {
             )}
           </section>
         )}
+
+        {/* Last on the page, and admin-only because the policy is. It sits with
+            the people rather than with the deleted things on Settings: what it
+            records is mostly what members did to each other's work and each
+            other's standing, and that is the question this page exists for. */}
+        <WorkspaceActivitySection isAdmin={isAdmin} />
       </PageContainer>
 
       <InviteMemberDialog open={inviteOpen} onOpenChange={setInviteOpen} />

--- a/supabase/migrations/0039_deletion_you_can_undo.sql
+++ b/supabase/migrations/0039_deletion_you_can_undo.sql
@@ -1,0 +1,884 @@
+-- 0039_deletion_you_can_undo.sql
+--
+-- Deleting an agent has been final since 0001, and larger than it looks. The
+-- foreign keys do the rest: every session anybody ever had with that agent,
+-- every message in those sessions, every routine pointed at it. A bundle takes
+-- its documents and their embeddings. Any `member` can do it, nothing asks
+-- twice, and afterwards nothing records who did.
+--
+-- docs/team.md has said this in plain words for a while — "None of it is
+-- recoverable from inside the product." That was survivable while the only
+-- people in a workspace were the people who built it.
+--
+-- This migration makes those three deletions reversible for thirty days, and
+-- writes a workspace-level record of the things people do to each other's work.
+-- Design: docs/superpowers/specs/2026-09-02-deletion-you-can-undo-design.md
+--
+-- WHAT THIS IS NOT. It does not change who may delete. A member deletes an
+-- agent today and still does after this; the deletion is reversible and
+-- recorded, not harder to reach.
+
+-- ===========================================================================
+-- 1. The columns
+-- ===========================================================================
+--
+-- `deleted_via` is the one doing the work. Foreign keys cascade on a real
+-- delete and do nothing at all on a soft one, so a soft-deleted agent would
+-- leave its sessions and routines sitting in place, visible, pointing at
+-- something that is gone. Marking the children at delete time is what keeps
+-- the screens honest — and naming WHICH ancestor hid them is what makes
+-- restoring exact: restoring X clears X and exactly the rows carrying
+-- `deleted_via = X`. A document deleted on its own (`deleted_via is null`)
+-- does not come back when its bundle is restored, which is what anyone would
+-- predict and what a bare timestamp comparison could not express.
+
+alter table public.agents
+  add column if not exists deleted_at  timestamptz,
+  add column if not exists deleted_by  uuid references public.profiles (id) on delete set null,
+  add column if not exists deleted_via uuid;
+
+alter table public.knowledge_bundles
+  add column if not exists deleted_at  timestamptz,
+  add column if not exists deleted_by  uuid references public.profiles (id) on delete set null,
+  add column if not exists deleted_via uuid;
+
+alter table public.documents
+  add column if not exists deleted_at  timestamptz,
+  add column if not exists deleted_by  uuid references public.profiles (id) on delete set null,
+  add column if not exists deleted_via uuid;
+
+-- Hidden with their agent, restored with it, never restorable on their own.
+-- No `deleted_by`: nobody deleted these directly, and a column that could only
+-- ever repeat the agent's answer is a column that will one day disagree with it.
+alter table public.chat_sessions
+  add column if not exists deleted_at  timestamptz,
+  add column if not exists deleted_via uuid;
+
+alter table public.routines
+  add column if not exists deleted_at  timestamptz,
+  add column if not exists deleted_via uuid;
+
+-- Partial indexes: the sweeper and the trash both ask for the rows that ARE
+-- deleted, which is nearly none of them. Everything else asks for
+-- `deleted_at is null`, which no index helps.
+create index if not exists agents_deleted_at_idx
+  on public.agents (deleted_at) where deleted_at is not null;
+create index if not exists knowledge_bundles_deleted_at_idx
+  on public.knowledge_bundles (deleted_at) where deleted_at is not null;
+create index if not exists documents_deleted_at_idx
+  on public.documents (deleted_at) where deleted_at is not null;
+create index if not exists chat_sessions_deleted_via_idx
+  on public.chat_sessions (deleted_via) where deleted_via is not null;
+create index if not exists routines_deleted_via_idx
+  on public.routines (deleted_via) where deleted_via is not null;
+
+-- ===========================================================================
+-- 2. Visibility
+-- ===========================================================================
+--
+-- Today deletion is real, so there is nothing to leak. Soft deletion opens a
+-- window, and it has to be closed HERE rather than in the API: PostgREST is
+-- reachable directly with the anon key that ships in the browser bundle
+-- (docs/architecture.md). A `.is("deleted_at", null)` in a route is a
+-- courtesy; the policy is the boundary.
+--
+-- The clause is `deleted_at is null`, for EVERYONE, with no branch admitting
+-- the people who could restore it. That is the whole decision in this section
+-- and it was made the other way first, so it is worth saying why it moved.
+--
+-- The obvious shape is `deleted_at is null or can_write_in_workspace(...)`,
+-- which lets a trash screen read the rows through the ordinary policy. Its cost
+-- is that every existing SELECT in the codebase — the agent list, the bundle
+-- page, the document picker, retrieval, export — becomes wrong unless it also
+-- carries `.is("deleted_at", null)`, because a member is exactly who runs those
+-- queries. That is roughly thirty call sites to get right today and an
+-- open-ended number to get right forever: the next query somebody adds is
+-- wrong by default, and it fails by showing deleted things rather than by
+-- erroring, so nothing catches it.
+--
+-- Hiding deleted rows from everyone inverts that. Every query in the codebase
+-- is correct as written and stays correct, and the one screen that needs the
+-- other answer asks for it explicitly, through `workspace_trash()` below —
+-- `security definer` with its own permission check, which is the arrangement
+-- 0032 already uses for `workspace_usage_all` and for the same reason: reading
+-- past RLS is the point, so the function checks for itself.
+
+drop policy if exists "agents_select_workspace_member" on public.agents;
+create policy "agents_select_workspace_member"
+  on public.agents for select
+  using (deleted_at is null and public.is_workspace_member(workspace_id));
+
+drop policy if exists "kb_select_member" on public.knowledge_bundles;
+create policy "kb_select_member"
+  on public.knowledge_bundles for select
+  using (deleted_at is null and public.is_workspace_member(workspace_id));
+
+-- Documents reach their workspace through the bundle, which is where it lives.
+-- A bundle's deletion marks its documents, so `documents.deleted_at` alone is
+-- the whole question — the bundle's own flag never has to be consulted.
+drop policy if exists "documents_select_member" on public.documents;
+create policy "documents_select_member"
+  on public.documents for select
+  using (
+    documents.deleted_at is null
+    and exists (
+      select 1 from public.knowledge_bundles b
+      where b.id = documents.bundle_id
+        and public.is_workspace_member(b.workspace_id)
+    )
+  );
+
+-- ---- the one that matters -------------------------------------------------
+--
+-- Chunks carry the document's text. `dc_select_member` gates on workspace
+-- membership and nothing else, so without this change a deleted document's
+-- contents stay readable straight from PostgREST by any member — the deletion
+-- would remove the row from a list and leave the words behind.
+--
+drop policy if exists "dc_select_member" on public.document_chunks;
+create policy "dc_select_member"
+  on public.document_chunks for select
+  using (
+    public.is_workspace_member(workspace_id)
+    and exists (
+      select 1 from public.documents d
+      where d.id = document_chunks.document_id
+        and d.deleted_at is null
+    )
+  );
+
+-- ---- sessions, and everything hanging off them ----------------------------
+--
+-- 0031 collapsed eleven policies onto this function precisely so a change like
+-- this is one line rather than five. `messages` and `ideas` name it and nothing
+-- else, so adding the condition here hides a deleted agent's entire
+-- conversation history — transcripts, boards and all — in one place.
+--
+-- No `can_write_in_workspace` branch: a session is never restorable on its own,
+-- so there is no screen that needs to list a deleted one. Deleted means
+-- invisible, and the rows come back only when the agent above them does.
+create or replace function public.session_is_visible(p_session_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = pg_catalog, public
+as $$
+  select exists (
+    select 1
+    from public.chat_sessions cs
+    where cs.id = p_session_id
+      and cs.deleted_at is null
+      and public.is_workspace_member(cs.workspace_id)
+      and (cs.user_id = auth.uid() or cs.visibility = 'shared')
+  );
+$$;
+
+drop policy if exists "chat_sessions_select_owner_or_shared" on public.chat_sessions;
+create policy "chat_sessions_select_owner_or_shared"
+  on public.chat_sessions for select
+  using (
+    deleted_at is null
+    and public.is_workspace_member(workspace_id)
+    and (user_id = auth.uid() or visibility = 'shared')
+  );
+
+drop policy if exists "routines_select_visible" on public.routines;
+create policy "routines_select_visible"
+  on public.routines for select
+  using (
+    deleted_at is null
+    and (
+      user_id = auth.uid()
+      or (visibility = 'shared' and public.is_workspace_member(workspace_id))
+    )
+  );
+
+-- ---- the one screen that asks the other question --------------------------
+--
+-- Everything above hides deleted rows from everybody, which leaves the trash
+-- with no way to read them. This is that way, and it is deliberately the only
+-- one: a single function to audit rather than a branch in five policies, and a
+-- signature that cannot accidentally be widened by a query somebody writes
+-- next year.
+--
+-- `deleted_via is null` is the filter that makes the list mean something. Only
+-- deletions somebody actually performed appear; the documents that went down
+-- with a bundle are not separate entries, because they are not separate
+-- decisions and restoring the bundle is what brings them back.
+create or replace function public.workspace_trash(p_workspace_id uuid)
+returns table (
+  kind          text,
+  id            uuid,
+  name          text,
+  deleted_at    timestamptz,
+  deleted_by_id uuid,
+  deleted_by_name text,
+  parent_name   text
+)
+language plpgsql
+security definer
+stable
+set search_path = pg_catalog, public
+as $$
+begin
+  if not public.can_write_in_workspace(p_workspace_id) then
+    raise exception 'you cannot see this workspace''s deleted items'
+      using errcode = '42501';
+  end if;
+
+  return query
+    select 'agent'::text, a.id, a.name, a.deleted_at, a.deleted_by,
+           coalesce(p.name, p.email), null::text
+      from public.agents a
+      left join public.profiles p on p.id = a.deleted_by
+     where a.workspace_id = p_workspace_id
+       and a.deleted_at is not null
+       and a.deleted_via is null
+    union all
+    select 'bundle'::text, b.id, b.name, b.deleted_at, b.deleted_by,
+           coalesce(p.name, p.email), null::text
+      from public.knowledge_bundles b
+      left join public.profiles p on p.id = b.deleted_by
+     where b.workspace_id = p_workspace_id
+       and b.deleted_at is not null
+       and b.deleted_via is null
+    union all
+    select 'document'::text, d.id, d.name, d.deleted_at, d.deleted_by,
+           coalesce(p.name, p.email), b.name
+      from public.documents d
+      join public.knowledge_bundles b on b.id = d.bundle_id
+      left join public.profiles p on p.id = d.deleted_by
+     where b.workspace_id = p_workspace_id
+       and d.deleted_at is not null
+       and d.deleted_via is null
+    order by 4 desc;
+end $$;
+
+revoke all on function public.workspace_trash(uuid) from anon;
+
+-- ===========================================================================
+-- 3. Retrieval has to forget too
+-- ===========================================================================
+--
+-- Left alone, `match_chunks` goes on grounding answers in a deleted document —
+-- "I deleted it and it is still quoting from it" — which is the worst way this
+-- feature can fail, because it looks like the deletion silently did nothing.
+--
+-- Two conditions, not one, and the second is not redundant. Retrieval scope
+-- lives on `document_chunks.bundle_id` rather than on `documents.bundle_id`;
+-- that is what makes moving a document between bundles a re-pointing of its
+-- chunks (0024), and it means a chunk can name a bundle its document no longer
+-- belongs to. Asking both makes a chunk retrievable only while the document it
+-- came from and the bundle it is filed under are BOTH alive.
+--
+-- `security invoker`, so `dc_select_member` above is already the backstop. This
+-- is written anyway: the RPC is what people read when they ask what the agent
+-- can see, and a retrieval function that does not mention deletion invites the
+-- reader to conclude it does not have to.
+create or replace function public.match_chunks(
+  p_agent_id uuid,
+  p_query_embedding vector(1536),
+  p_match_count int,
+  p_min_similarity float default 0
+)
+returns table (document_id uuid, document_name text, content text, similarity float)
+language sql
+stable
+security invoker
+set search_path = pg_catalog, public
+as $$
+  select dc.document_id,
+         d.name as document_name,
+         dc.content,
+         1 - (dc.embedding <=> p_query_embedding) as similarity
+  from public.document_chunks dc
+  join public.documents d on d.id = dc.document_id
+  join public.knowledge_bundles b on b.id = dc.bundle_id
+  where dc.embedding is not null
+    and d.deleted_at is null
+    and b.deleted_at is null
+    and (1 - (dc.embedding <=> p_query_embedding)) >= p_min_similarity
+    and dc.bundle_id in (
+      select ab.bundle_id from public.agent_bundles ab where ab.agent_id = p_agent_id
+    )
+  order by dc.embedding <=> p_query_embedding
+  limit p_match_count;
+$$;
+
+-- The engine holds a service-role client that RLS does not constrain, so the
+-- policy above does not reach it: without this it would go on running a routine
+-- whose agent was deleted, and go on delivering its output to Slack.
+create or replace function public.claim_due_routines(
+  p_limit int default 10,
+  p_stale_after interval default interval '15 minutes'
+)
+returns setof public.routines
+language sql
+security definer
+set search_path = pg_catalog, public
+as $$
+  update public.routines r
+  set claimed_at = now()
+  where r.id in (
+    select id from public.routines
+    where status = 'active'
+      and deleted_at is null
+      and next_run_at <= now()
+      and (claimed_at is null or claimed_at < now() - p_stale_after)
+    order by next_run_at
+    for update skip locked
+    limit p_limit
+  )
+  returning r.*;
+$$;
+
+revoke all on function public.claim_due_routines(int, interval) from public, anon, authenticated;
+grant execute on function public.claim_due_routines(int, interval) to service_role;
+
+-- ===========================================================================
+-- 4. Deleting and restoring
+-- ===========================================================================
+--
+-- Marking an agent plus its sessions plus its routines is several statements,
+-- and PostgREST offers no transaction across them. Worse,
+-- `chat_sessions_update_owner` is keyed to the session's owner, so an API doing
+-- this with the caller's client could not mark a colleague's conversations even
+-- though it has just deleted the agent underneath them — it would half-succeed
+-- and leave orphans on screen.
+--
+-- So the marking lives here, `security definer`, with each function checking its
+-- own permission the way `workspace_usage_all` does in 0032 and raising rather
+-- than returning quietly. `security definer` is doing one job and only one:
+-- reaching rows the caller's own policies would refuse to update, inside a
+-- single statement.
+--
+-- Three SQLSTATEs, all mapped by the API: 42501 is "you may not", P0002 is
+-- "there is no such row, or it is already deleted", P0001 is "not in that
+-- order".
+--
+-- Unlike `claim_due_routines`, whose grant IS its security boundary, these keep
+-- the default EXECUTE for `authenticated` — they are meant to be called through
+-- PostgREST and they check `can_write_in_workspace` for themselves before
+-- touching a row. `anon` is revoked anyway: an anonymous caller has no
+-- `auth.uid()` and would be refused on the check, so this removes a call that
+-- could only ever fail.
+
+create or replace function public.soft_delete_agent(p_agent_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_workspace_id uuid;
+  v_now timestamptz := now();
+  v_actor uuid := auth.uid();
+begin
+  select workspace_id into v_workspace_id
+  from public.agents
+  where id = p_agent_id and deleted_at is null;
+
+  if v_workspace_id is null then
+    raise exception 'no such agent' using errcode = 'P0002';
+  end if;
+
+  if not public.can_write_in_workspace(v_workspace_id) then
+    raise exception 'you cannot delete things in this workspace' using errcode = '42501';
+  end if;
+
+  update public.agents
+     set deleted_at = v_now, deleted_by = v_actor, deleted_via = null
+   where id = p_agent_id;
+
+  -- Bundles are deliberately untouched. A bundle is workspace-level and may be
+  -- attached to several agents; deleting an agent has always cascaded the
+  -- `agent_bundles` link and left the bundle standing, including the per-agent
+  -- `covan:chat-uploads:<agentId>` bundle. That stays true.
+  update public.chat_sessions
+     set deleted_at = v_now, deleted_via = p_agent_id
+   where agent_id = p_agent_id and deleted_at is null;
+
+  update public.routines
+     set deleted_at = v_now, deleted_via = p_agent_id
+   where agent_id = p_agent_id and deleted_at is null;
+end $$;
+
+create or replace function public.restore_agent(p_agent_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_workspace_id uuid;
+begin
+  select workspace_id into v_workspace_id
+  from public.agents
+  where id = p_agent_id and deleted_at is not null;
+
+  if v_workspace_id is null then
+    raise exception 'no such deleted agent' using errcode = 'P0002';
+  end if;
+
+  if not public.can_write_in_workspace(v_workspace_id) then
+    raise exception 'you cannot restore things in this workspace' using errcode = '42501';
+  end if;
+
+  update public.agents
+     set deleted_at = null, deleted_by = null, deleted_via = null
+   where id = p_agent_id;
+
+  -- Exactly the rows this agent's deletion hid. A session or routine deleted
+  -- some other way is not swept up by somebody else's restore.
+  update public.chat_sessions
+     set deleted_at = null, deleted_via = null
+   where deleted_via = p_agent_id;
+
+  update public.routines
+     set deleted_at = null, deleted_via = null
+   where deleted_via = p_agent_id;
+end $$;
+
+create or replace function public.soft_delete_bundle(p_bundle_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_workspace_id uuid;
+  v_now timestamptz := now();
+  v_actor uuid := auth.uid();
+begin
+  select workspace_id into v_workspace_id
+  from public.knowledge_bundles
+  where id = p_bundle_id and deleted_at is null;
+
+  if v_workspace_id is null then
+    raise exception 'no such bundle' using errcode = 'P0002';
+  end if;
+
+  if not public.can_write_in_workspace(v_workspace_id) then
+    raise exception 'you cannot delete things in this workspace' using errcode = '42501';
+  end if;
+
+  update public.knowledge_bundles
+     set deleted_at = v_now, deleted_by = v_actor, deleted_via = null
+   where id = p_bundle_id;
+
+  update public.documents
+     set deleted_at = v_now, deleted_by = v_actor, deleted_via = p_bundle_id
+   where bundle_id = p_bundle_id and deleted_at is null;
+end $$;
+
+create or replace function public.restore_bundle(p_bundle_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_workspace_id uuid;
+begin
+  select workspace_id into v_workspace_id
+  from public.knowledge_bundles
+  where id = p_bundle_id and deleted_at is not null;
+
+  if v_workspace_id is null then
+    raise exception 'no such deleted bundle' using errcode = 'P0002';
+  end if;
+
+  if not public.can_write_in_workspace(v_workspace_id) then
+    raise exception 'you cannot restore things in this workspace' using errcode = '42501';
+  end if;
+
+  update public.knowledge_bundles
+     set deleted_at = null, deleted_by = null, deleted_via = null
+   where id = p_bundle_id;
+
+  -- A document somebody deleted on its own before the bundle went keeps its own
+  -- deletion. It is in the trash under its own name, where it can be restored
+  -- by whoever wants it back.
+  update public.documents
+     set deleted_at = null, deleted_by = null, deleted_via = null
+   where deleted_via = p_bundle_id;
+end $$;
+
+create or replace function public.soft_delete_document(p_document_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_workspace_id uuid;
+begin
+  select b.workspace_id into v_workspace_id
+  from public.documents d
+  join public.knowledge_bundles b on b.id = d.bundle_id
+  where d.id = p_document_id and d.deleted_at is null;
+
+  if v_workspace_id is null then
+    raise exception 'no such document' using errcode = 'P0002';
+  end if;
+
+  if not public.can_write_in_workspace(v_workspace_id) then
+    raise exception 'you cannot delete things in this workspace' using errcode = '42501';
+  end if;
+
+  update public.documents
+     set deleted_at = now(), deleted_by = auth.uid(), deleted_via = null
+   where id = p_document_id;
+end $$;
+
+create or replace function public.restore_document(p_document_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_workspace_id uuid;
+  v_bundle_deleted timestamptz;
+begin
+  select b.workspace_id, b.deleted_at into v_workspace_id, v_bundle_deleted
+  from public.documents d
+  join public.knowledge_bundles b on b.id = d.bundle_id
+  where d.id = p_document_id and d.deleted_at is not null;
+
+  if v_workspace_id is null then
+    raise exception 'no such deleted document' using errcode = 'P0002';
+  end if;
+
+  if not public.can_write_in_workspace(v_workspace_id) then
+    raise exception 'you cannot restore things in this workspace' using errcode = '42501';
+  end if;
+
+  -- Restoring into a deleted bundle would produce a row visible from nowhere,
+  -- which reads as the restore having failed. Say which button to press instead.
+  -- P0001, not P0002: the row is there and the caller may have it back. What is
+  -- wrong is the order, and a 404 would send them looking for a document that
+  -- is sitting in front of them.
+  if v_bundle_deleted is not null then
+    raise exception 'restore the bundle this document belongs to first'
+      using errcode = 'P0001';
+  end if;
+
+  update public.documents
+     set deleted_at = null, deleted_by = null, deleted_via = null
+   where id = p_document_id;
+end $$;
+
+revoke all on function public.soft_delete_agent(uuid) from anon;
+revoke all on function public.restore_agent(uuid) from anon;
+revoke all on function public.soft_delete_bundle(uuid) from anon;
+revoke all on function public.restore_bundle(uuid) from anon;
+revoke all on function public.soft_delete_document(uuid) from anon;
+revoke all on function public.restore_document(uuid) from anon;
+
+-- ===========================================================================
+-- 5. The record of who did it
+-- ===========================================================================
+
+create table if not exists public.workspace_events (
+  id            uuid primary key default gen_random_uuid(),
+  workspace_id  uuid not null references public.workspaces (id) on delete cascade,
+  actor_id      uuid references public.profiles (id) on delete set null,
+  action        text not null,
+  subject_type  text not null check (subject_type in ('agent', 'bundle', 'document', 'member', 'invitation')),
+  subject_id    uuid,
+  -- The thing's name as it was at the time. Thirty days later the sweeper
+  -- removes the row and `subject_id` points nowhere; a log that can only say
+  -- "an agent was deleted" is not a log. Denormalised on purpose.
+  subject_label text not null,
+  detail        jsonb,
+  created_at    timestamptz not null default now()
+);
+
+create index if not exists workspace_events_workspace_created_idx
+  on public.workspace_events (workspace_id, created_at desc);
+
+alter table public.workspace_events enable row level security;
+
+-- 0023: from there on a migration that adds a table grants for it, in the same
+-- file. SELECT only, and only to authenticated — the rows are written by the
+-- triggers below, which run as the owner. Withholding the INSERT grant is a
+-- second lock on the same door as "no insert policy exists": either alone would
+-- do, and an audit log is the wrong place to rely on either alone.
+grant select on public.workspace_events to authenticated;
+grant select on public.workspace_events to service_role;
+
+drop policy if exists "workspace_events_select_admin" on public.workspace_events;
+create policy "workspace_events_select_admin"
+  on public.workspace_events for select
+  using (public.is_workspace_admin(workspace_id));
+
+-- No insert, update or delete policy, for anybody. An API that writes its own
+-- audit log is an API whose audit log can be skipped by anything that does not
+-- go through it — and PostgREST does not go through it. A trigger cannot be
+-- routed around.
+
+create or replace function public.log_workspace_event(
+  p_workspace_id  uuid,
+  p_action        text,
+  p_subject_type  text,
+  p_subject_id    uuid,
+  p_subject_label text,
+  p_detail        jsonb default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+begin
+  -- During a workspace cascade the parent row is already gone and the events
+  -- are being deleted in the same statement. The same exception
+  -- `trg_prevent_last_admin` makes, for the same reason: there is nothing left
+  -- to file an event against.
+  if not exists (select 1 from public.workspaces w where w.id = p_workspace_id) then
+    return;
+  end if;
+
+  insert into public.workspace_events
+    (workspace_id, actor_id, action, subject_type, subject_id, subject_label, detail)
+  values (
+    p_workspace_id,
+    -- Resolved through profiles rather than taken from auth.uid() directly: a
+    -- service-role caller has no uid, and an account mid-deletion has a uid
+    -- with no profile row. Either would be a foreign key violation that failed
+    -- the operation the log exists to observe.
+    (select p.id from public.profiles p where p.id = auth.uid()),
+    p_action,
+    p_subject_type,
+    p_subject_id,
+    coalesce(nullif(trim(p_subject_label), ''), '(unnamed)'),
+    p_detail
+  );
+end $$;
+
+revoke all on function public.log_workspace_event(uuid, text, text, uuid, text, jsonb)
+  from public, anon, authenticated;
+
+-- ---- deletions and restores ----------------------------------------------
+--
+-- Fires only when `deleted_via is null`, which is what keeps the log readable:
+-- deleting a bundle of two hundred documents writes ONE event, not two hundred
+-- and one. The cascaded rows are not separate decisions and reading them as
+-- such would bury the decision that was made.
+
+create or replace function public.trg_log_soft_delete()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_workspace_id uuid;
+  v_type text;
+begin
+  if tg_table_name = 'agents' then
+    v_type := 'agent';
+    v_workspace_id := new.workspace_id;
+  elsif tg_table_name = 'knowledge_bundles' then
+    v_type := 'bundle';
+    v_workspace_id := new.workspace_id;
+  else
+    v_type := 'document';
+    select b.workspace_id into v_workspace_id
+    from public.knowledge_bundles b where b.id = new.bundle_id;
+  end if;
+
+  if v_workspace_id is null then
+    return new;
+  end if;
+
+  if old.deleted_at is null and new.deleted_at is not null and new.deleted_via is null then
+    perform public.log_workspace_event(
+      v_workspace_id, v_type || '.deleted', v_type, new.id, new.name, null);
+  elsif old.deleted_at is not null and new.deleted_at is null and old.deleted_via is null then
+    perform public.log_workspace_event(
+      v_workspace_id, v_type || '.restored', v_type, new.id, new.name, null);
+  end if;
+
+  return new;
+end $$;
+
+drop trigger if exists trg_agents_log_soft_delete on public.agents;
+create trigger trg_agents_log_soft_delete
+  after update of deleted_at on public.agents
+  for each row when (old.deleted_at is distinct from new.deleted_at)
+  execute function public.trg_log_soft_delete();
+
+drop trigger if exists trg_bundles_log_soft_delete on public.knowledge_bundles;
+create trigger trg_bundles_log_soft_delete
+  after update of deleted_at on public.knowledge_bundles
+  for each row when (old.deleted_at is distinct from new.deleted_at)
+  execute function public.trg_log_soft_delete();
+
+drop trigger if exists trg_documents_log_soft_delete on public.documents;
+create trigger trg_documents_log_soft_delete
+  after update of deleted_at on public.documents
+  for each row when (old.deleted_at is distinct from new.deleted_at)
+  execute function public.trg_log_soft_delete();
+
+-- ---- membership -----------------------------------------------------------
+--
+-- `member.removed` and `member.left` are the same DELETE. They are told apart
+-- by whether the caller is the row's own user, because being removed and
+-- choosing to go are different events to everyone involved and the row is
+-- identical. `workspace_members_delete_self` (0020) is the policy that makes
+-- the second one reachable at all.
+--
+-- No INSERT trigger. A membership row is written by the signup trigger, by
+-- `create_workspace`, and by `accept_invitation` — the first two are somebody
+-- making their own workspace, which is not an event about a team, and the third
+-- is logged as `member.joined` from the invitation side where the inviter and
+-- the role are both in scope.
+
+create or replace function public.trg_log_membership()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_label text;
+  v_user_id uuid;
+begin
+  v_user_id := coalesce(new.user_id, old.user_id);
+
+  select coalesce(p.name, p.email, '(unknown)') into v_label
+  from public.profiles p where p.id = v_user_id;
+
+  if tg_op = 'UPDATE' then
+    perform public.log_workspace_event(
+      new.workspace_id, 'member.role_changed', 'member', new.user_id,
+      coalesce(v_label, '(unknown)'),
+      jsonb_build_object('from', old.role, 'to', new.role));
+    return new;
+  end if;
+
+  perform public.log_workspace_event(
+    old.workspace_id,
+    case when auth.uid() = old.user_id then 'member.left' else 'member.removed' end,
+    'member', old.user_id, coalesce(v_label, '(unknown)'),
+    jsonb_build_object('role', old.role));
+  return old;
+end $$;
+
+drop trigger if exists trg_workspace_members_log_role on public.workspace_members;
+create trigger trg_workspace_members_log_role
+  after update of role on public.workspace_members
+  for each row when (old.role is distinct from new.role)
+  execute function public.trg_log_membership();
+
+drop trigger if exists trg_workspace_members_log_delete on public.workspace_members;
+create trigger trg_workspace_members_log_delete
+  after delete on public.workspace_members
+  for each row execute function public.trg_log_membership();
+
+-- ---- invitations ----------------------------------------------------------
+--
+-- Revoking is a hard delete (docs/team.md), so the revoke event has to come off
+-- a DELETE trigger. An accepted invitation is never deleted, which is what lets
+-- `member.joined` come from an UPDATE of the same row.
+
+create or replace function public.trg_log_invitation()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+begin
+  if tg_op = 'INSERT' then
+    perform public.log_workspace_event(
+      new.workspace_id, 'invitation.created', 'invitation', new.id, new.email,
+      jsonb_build_object('role', new.role));
+    return new;
+  end if;
+
+  if tg_op = 'UPDATE' then
+    if new.status = 'accepted' and old.status <> 'accepted' then
+      perform public.log_workspace_event(
+        new.workspace_id, 'member.joined', 'member', new.accepted_by, new.email,
+        jsonb_build_object('role', new.role));
+    end if;
+    return new;
+  end if;
+
+  perform public.log_workspace_event(
+    old.workspace_id, 'invitation.revoked', 'invitation', old.id, old.email,
+    jsonb_build_object('role', old.role));
+  return old;
+end $$;
+
+drop trigger if exists trg_invitations_log on public.invitations;
+create trigger trg_invitations_log
+  after insert or delete on public.invitations
+  for each row execute function public.trg_log_invitation();
+
+drop trigger if exists trg_invitations_log_accept on public.invitations;
+create trigger trg_invitations_log_accept
+  after update of status on public.invitations
+  for each row when (old.status is distinct from new.status)
+  execute function public.trg_log_invitation();
+
+-- ---- one function 0038 wrote before documents could be deleted ------------
+--
+-- `document_citation_counts` is `security definer`, so RLS is off for its body
+-- and the policies above do not reach it. Left alone it answers for deleted
+-- documents too — handing back their ids and how heavily they were used, which
+-- is a small but exact statement about a file the caller has just been told is
+-- gone. The caller happens not to render it today, because it lists documents
+-- it can see and looks counts up against them; that is the caller's shape
+-- rather than a guarantee, and it is the kind that changes.
+--
+-- Patched here rather than in 0038 because this migration is what made a
+-- document deletable, and a consequence belongs with its cause.
+create or replace function public.document_citation_counts(p_bundle_ids uuid[])
+returns table (document_id uuid, citations bigint)
+language sql
+security definer
+stable
+set search_path = pg_catalog, public
+as $$
+  select d.id, count(*)
+  from public.documents d
+  join public.knowledge_bundles b on b.id = d.bundle_id
+  join public.messages m
+    on m.sources @> jsonb_build_array(jsonb_build_object('id', d.id::text))
+  join public.chat_sessions s on s.id = m.session_id
+  where d.bundle_id = any(p_bundle_ids)
+    and d.deleted_at is null
+    and b.deleted_at is null
+    -- Replies inside a deleted agent's conversations still happened, and the
+    -- document they cite is still there; excluding them would make a count
+    -- drop when somebody deletes an unrelated agent, and reappear on restore.
+    and s.workspace_id = b.workspace_id
+    and public.is_workspace_member(b.workspace_id)
+  group by d.id;
+$$;
+
+-- ===========================================================================
+-- 6. The sweeper's half of the bargain
+-- ===========================================================================
+--
+-- After thirty days a marked row is deleted for real, which is where the
+-- existing foreign keys take over and do what they always did. The Worker runs
+-- it (worker/src/lib/purge.ts) because it also has to delete the stored
+-- objects, and it collects their keys BEFORE deleting the rows — afterwards
+-- there is nothing left to enumerate them by. `worker/src/routes/account.ts`
+-- has followed that order since account closure existed.
+--
+-- This function exists so the window is defined in one place rather than in a
+-- constant on each side of the boundary.
+create or replace function public.purge_horizon()
+returns timestamptz
+language sql
+stable
+set search_path = pg_catalog, public
+as $$
+  select now() - interval '30 days';
+$$;

--- a/tests/rls/soft-deletion.test.ts
+++ b/tests/rls/soft-deletion.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Deletion that can be taken back, and the record of who took it.
+ *
+ * Every claim 0037 makes is a claim about policies, so this is where it has to
+ * be proved — against a real database, through PostgREST, with the anon key a
+ * browser actually carries. The API is not in the path of any of it, which is
+ * the point: soft deletion opens a window that only the policies can close, and
+ * an `.is("deleted_at", null)` in a route would prove nothing about what
+ * somebody typing into `curl` can read.
+ *
+ * The one that would go wrong quietly is `document_chunks`. A deleted document
+ * disappears from every list the moment its row is marked, so the feature looks
+ * finished — while the chunks still hold the document's text and their policy
+ * asks only about workspace membership. That is a whole file's contents left
+ * readable behind a deletion somebody believes happened.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeSql,
+  createTestUser,
+  destroyTestUsers,
+  serviceClient,
+  type TestUser,
+} from "./harness";
+import { seedWorkspace, type Seeded } from "./fixtures";
+
+let owner: TestUser;
+let viewer: TestUser;
+let outsider: TestUser;
+let seeded: Seeded;
+
+beforeAll(async () => {
+  owner = await createTestUser("del-owner");
+  viewer = await createTestUser("del-viewer");
+  outsider = await createTestUser("del-outsider");
+
+  seeded = await seedWorkspace(owner, "shared");
+
+  const { error } = await serviceClient()
+    .from("workspace_members")
+    .insert([{ workspace_id: owner.workspaceId, user_id: viewer.id, role: "viewer" }]);
+  if (error) throw new Error(`could not seed the viewer membership: ${error.message}`);
+
+  // A chunk carrying the document's words, so the leak has something to leak.
+  // Written with the service role: the app writes chunks through the caller's
+  // client, but the embedding column wants a vector and this test does not care
+  // about retrieval quality, only about who can read the text.
+  const { error: chunkError } = await serviceClient().from("document_chunks").insert({
+    document_id: seeded.documentId,
+    bundle_id: seeded.bundleId,
+    workspace_id: owner.workspaceId,
+    chunk_index: 0,
+    content: "the secret sentence inside the deleted document",
+  });
+  if (chunkError) throw new Error(`could not seed a chunk: ${chunkError.message}`);
+});
+
+afterAll(async () => {
+  await destroyTestUsers();
+  await closeSql();
+});
+
+/** Asked as the service role, so RLS cannot mask the answer. */
+async function rawRow(table: string, id: string) {
+  const { data } = await serviceClient().from(table).select("*").eq("id", id).maybeSingle();
+  return data as Record<string, unknown> | null;
+}
+
+/** Undo whatever a test did, so the next one starts from a live workspace. */
+async function undelete() {
+  const service = serviceClient();
+  for (const table of ["agents", "knowledge_bundles", "documents", "chat_sessions", "routines"]) {
+    await service
+      .from(table)
+      .update({ deleted_at: null, deleted_via: null })
+      .eq("workspace_id", owner.workspaceId);
+  }
+  // documents has no workspace_id — it reaches one through its bundle.
+  await service
+    .from("documents")
+    .update({ deleted_at: null, deleted_via: null })
+    .eq("bundle_id", seeded.bundleId);
+  await service.from("workspace_events").delete().eq("workspace_id", owner.workspaceId);
+}
+
+describe("a deleted agent stops existing for everybody", () => {
+  afterAll(undelete);
+
+  it("is hidden from the person who deleted it, not just from a viewer", async () => {
+    const { error } = await owner.db.rpc("soft_delete_agent", { p_agent_id: seeded.agentId });
+    expect(error).toBeNull();
+
+    const { data } = await owner.db.from("agents").select("id").eq("id", seeded.agentId);
+    expect(data ?? []).toHaveLength(0);
+
+    // Hidden, not destroyed — which is the entire promise.
+    expect(await rawRow("agents", seeded.agentId)).not.toBeNull();
+  });
+
+  it("takes its sessions, messages and ideas with it", async () => {
+    const asOwner = owner.db;
+
+    const { data: sessions } = await asOwner
+      .from("chat_sessions")
+      .select("id")
+      .eq("id", seeded.sessionId);
+    expect(sessions ?? []).toHaveLength(0);
+
+    // The session was shared, so this is not "private things stay private" —
+    // it is the parent's deletion reaching through session_is_visible.
+    const { data: messages } = await asOwner
+      .from("messages")
+      .select("id")
+      .eq("id", seeded.messageId);
+    expect(messages ?? []).toHaveLength(0);
+
+    const { data: ideas } = await asOwner.from("ideas").select("id").eq("id", seeded.ideaId);
+    expect(ideas ?? []).toHaveLength(0);
+  });
+
+  it("marks exactly what it hid, so a restore knows what to bring back", async () => {
+    const session = await rawRow("chat_sessions", seeded.sessionId);
+    expect(session?.deleted_via).toBe(seeded.agentId);
+
+    const routine = await rawRow("routines", seeded.routineId);
+    expect(routine?.deleted_via).toBe(seeded.agentId);
+  });
+
+  it("comes back whole", async () => {
+    const { error } = await owner.db.rpc("restore_agent", { p_agent_id: seeded.agentId });
+    expect(error).toBeNull();
+
+    const { data: agents } = await owner.db.from("agents").select("id").eq("id", seeded.agentId);
+    expect(agents ?? []).toHaveLength(1);
+
+    const { data: messages } = await owner.db
+      .from("messages")
+      .select("id")
+      .eq("id", seeded.messageId);
+    expect(messages ?? []).toHaveLength(1);
+  });
+});
+
+describe("a deleted document takes its words with it", () => {
+  afterAll(undelete);
+
+  it("hides the chunks, not just the document row", async () => {
+    await owner.db.rpc("soft_delete_document", { p_document_id: seeded.documentId });
+
+    const { data: docs } = await owner.db
+      .from("documents")
+      .select("id")
+      .eq("id", seeded.documentId);
+    expect(docs ?? []).toHaveLength(0);
+
+    // The leak. A member reading document_chunks directly through PostgREST is
+    // the shortest path to a deleted file's contents, and dc_select_member used
+    // to ask only whether they were in the workspace.
+    const { data: chunks } = await owner.db
+      .from("document_chunks")
+      .select("content")
+      .eq("document_id", seeded.documentId);
+    expect(chunks ?? []).toHaveLength(0);
+  });
+
+  it("is refused to a viewer as firmly as to anybody else", async () => {
+    const { data } = await viewer.db
+      .from("document_chunks")
+      .select("content")
+      .eq("document_id", seeded.documentId);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it("stops grounding answers", async () => {
+    // match_chunks is security invoker, so this runs under the caller's own
+    // policies — but it is asserted separately because the RPC is what people
+    // read when they ask what the agent can still see.
+    const { data, error } = await owner.db.rpc("match_chunks", {
+      p_agent_id: seeded.agentId,
+      p_query_embedding: new Array(1536).fill(0),
+      p_match_count: 10,
+      p_min_similarity: 0,
+    });
+    expect(error).toBeNull();
+    const hits = (data ?? []) as { document_id: string }[];
+    expect(hits.some((h) => h.document_id === seeded.documentId)).toBe(false);
+  });
+});
+
+describe("restoring brings back exactly what went", () => {
+  afterAll(undelete);
+
+  it("leaves a separately-deleted document deleted when its bundle returns", async () => {
+    // Delete the document on its own first, then the bundle around it. The
+    // document now carries `deleted_via = null` — it was its own decision — so
+    // restoring the bundle must not undo it.
+    await owner.db.rpc("soft_delete_document", { p_document_id: seeded.documentId });
+    await owner.db.rpc("soft_delete_bundle", { p_bundle_id: seeded.bundleId });
+
+    await owner.db.rpc("restore_bundle", { p_bundle_id: seeded.bundleId });
+
+    const { data: bundles } = await owner.db
+      .from("knowledge_bundles")
+      .select("id")
+      .eq("id", seeded.bundleId);
+    expect(bundles ?? []).toHaveLength(1);
+
+    const { data: docs } = await owner.db
+      .from("documents")
+      .select("id")
+      .eq("id", seeded.documentId);
+    expect(docs ?? []).toHaveLength(0);
+  });
+
+  it("refuses a document whose bundle is still deleted, and says which to press", async () => {
+    await owner.db.rpc("soft_delete_bundle", { p_bundle_id: seeded.bundleId });
+
+    const { error } = await owner.db.rpc("restore_document", {
+      p_document_id: seeded.documentId,
+    });
+    expect(error).not.toBeNull();
+    expect(error?.message).toMatch(/restore the bundle/i);
+  });
+});
+
+describe("who may delete", () => {
+  afterAll(undelete);
+
+  it("refuses a viewer", async () => {
+    const { error } = await viewer.db.rpc("soft_delete_agent", { p_agent_id: seeded.agentId });
+    expect(error?.code).toBe("42501");
+    expect(await rawRow("agents", seeded.agentId)).toMatchObject({ deleted_at: null });
+  });
+
+  it("refuses somebody who is not in the workspace at all", async () => {
+    const { error } = await outsider.db.rpc("soft_delete_agent", { p_agent_id: seeded.agentId });
+    // P0002 rather than 42501: the row is not visible to resolve, so the
+    // function cannot get as far as asking about permission. Either refusal is
+    // correct; what matters is that nothing was marked.
+    expect(error).not.toBeNull();
+    expect(await rawRow("agents", seeded.agentId)).toMatchObject({ deleted_at: null });
+  });
+
+  it("refuses a viewer the trash as an error, not as an empty list", async () => {
+    const { error } = await viewer.db.rpc("workspace_trash", {
+      p_workspace_id: owner.workspaceId,
+    });
+    expect(error?.code).toBe("42501");
+  });
+});
+
+describe("the trash lists decisions, not consequences", () => {
+  afterAll(undelete);
+
+  it("shows one row for a bundle, whatever it contained", async () => {
+    await owner.db.rpc("soft_delete_bundle", { p_bundle_id: seeded.bundleId });
+
+    const { data, error } = await owner.db.rpc("workspace_trash", {
+      p_workspace_id: owner.workspaceId,
+    });
+    expect(error).toBeNull();
+
+    const rows = (data ?? []) as { kind: string; id: string; deleted_by_name: string | null }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ kind: "bundle", id: seeded.bundleId });
+    expect(rows[0].deleted_by_name).not.toBeNull();
+  });
+});
+
+describe("the audit log", () => {
+  afterAll(undelete);
+
+  it("records one event for a bundle and none for its documents", async () => {
+    await owner.db.rpc("soft_delete_bundle", { p_bundle_id: seeded.bundleId });
+
+    const { data } = await owner.db
+      .from("workspace_events")
+      .select("action,subject_type,subject_label")
+      .eq("workspace_id", owner.workspaceId);
+
+    const events = (data ?? []) as { action: string }[];
+    expect(events).toHaveLength(1);
+    expect(events[0].action).toBe("bundle.deleted");
+  });
+
+  it("keeps the name the thing had, so the row survives the purge", async () => {
+    const { data } = await owner.db
+      .from("workspace_events")
+      .select("subject_label")
+      .eq("workspace_id", owner.workspaceId)
+      .limit(1);
+    expect((data ?? [])[0]?.subject_label).toBe("Seeded bundle");
+  });
+
+  it("is invisible to a member who is not an admin", async () => {
+    const { data } = await viewer.db
+      .from("workspace_events")
+      .select("id")
+      .eq("workspace_id", owner.workspaceId);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it("cannot be written to, by anybody", async () => {
+    // No insert policy exists and the INSERT grant is withheld. Both would have
+    // to be added back for this to succeed, which is the second lock.
+    const { error } = await owner.db.from("workspace_events").insert({
+      workspace_id: owner.workspaceId,
+      action: "agent.deleted",
+      subject_type: "agent",
+      subject_label: "something that never happened",
+    });
+    expect(error).not.toBeNull();
+  });
+});
+
+describe("removing somebody is told apart from their leaving", () => {
+  it("writes member.removed when an admin does it, and member.left when they do", async () => {
+    const service = serviceClient();
+
+    // Two people to spend, because each of these is a one-way door.
+    const removed = await createTestUser("del-removed");
+    const leaver = await createTestUser("del-leaver");
+
+    await service.from("workspace_members").insert([
+      { workspace_id: owner.workspaceId, user_id: removed.id, role: "member" },
+      { workspace_id: owner.workspaceId, user_id: leaver.id, role: "member" },
+    ]);
+
+    await owner.db
+      .from("workspace_members")
+      .delete()
+      .eq("workspace_id", owner.workspaceId)
+      .eq("user_id", removed.id);
+
+    await leaver.db
+      .from("workspace_members")
+      .delete()
+      .eq("workspace_id", owner.workspaceId)
+      .eq("user_id", leaver.id);
+
+    const { data } = await owner.db
+      .from("workspace_events")
+      .select("action,subject_id")
+      .eq("workspace_id", owner.workspaceId)
+      .in("action", ["member.removed", "member.left"]);
+
+    const events = (data ?? []) as { action: string; subject_id: string }[];
+    expect(events.find((e) => e.subject_id === removed.id)?.action).toBe("member.removed");
+    expect(events.find((e) => e.subject_id === leaver.id)?.action).toBe("member.left");
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -26,6 +26,9 @@ import { onboarding } from "./routes/onboarding";
 import { apiKeys } from "./routes/api-keys";
 import { account } from "./routes/account";
 import { exportRoutes } from "./routes/export";
+import { trash } from "./routes/trash";
+import { events } from "./routes/events";
+import { runPurge } from "./lib/purge";
 
 const app = new Hono<AppEnv>();
 
@@ -141,6 +144,8 @@ api.route("/", onboarding);
 api.route("/", apiKeys);
 api.route("/", account);
 api.route("/", exportRoutes);
+api.route("/", trash);
+api.route("/", events);
 
 app.route("/", api);
 
@@ -162,6 +167,20 @@ export default {
       runDueRoutines(env).catch((err) => {
         console.error("routine tick failed", err);
         throw err;
+      }),
+    );
+
+    // The thirty-day sweeper, and it lives HERE rather than on the cron Worker
+    // because that one takes `RoutineEnv`, which carries no R2 binding — a
+    // purged document's bytes have to go with its row, or the erasure is not
+    // one.
+    //
+    // Deliberately not chained onto the promise above: a failing routine tick
+    // must not stop the sweep, and a failing sweep must not mark the tick
+    // broken. They share a trigger and nothing else.
+    ctx.waitUntil(
+      runPurge(env).catch((err) => {
+        console.error("purge tick failed", err);
       }),
     );
   },

--- a/worker/src/lib/deletion.ts
+++ b/worker/src/lib/deletion.ts
@@ -1,0 +1,75 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Calling the soft-delete and restore functions, and turning their refusals
+ * back into HTTP.
+ *
+ * The marking lives in Postgres (0039) because it spans several tables and
+ * PostgREST offers no transaction across them — and because
+ * `chat_sessions_update_owner` would refuse to mark a colleague's conversations
+ * even for somebody who has just deleted the agent underneath them. So these
+ * are `security definer` functions that check `can_write_in_workspace` for
+ * themselves and raise when it is false.
+ *
+ * That makes the SQLSTATE the API contract. Three of them:
+ *
+ *   42501  the caller may not do this          -> 403
+ *   P0002  no such row, or already deleted     -> 404
+ *   P0001  right row, wrong order              -> 400, with the message
+ *
+ * P0001 carries a sentence written for a person ("restore the bundle this
+ * document belongs to first"), so it is the one case where the database's own
+ * message is passed through rather than replaced. The other two get wording
+ * from here, because their messages name functions and columns.
+ */
+
+type Db = SupabaseClient;
+
+export type DeletionFailure = { status: 400 | 403 | 404 | 500; message: string };
+
+const FALLBACK: Record<string, string> = {
+  "42501": "you do not have permission to change things in this workspace",
+  P0002: "not found",
+};
+
+export async function callDeletionFn(
+  db: Db,
+  fn: string,
+  args: Record<string, string>,
+  whenBroken: string,
+): Promise<DeletionFailure | null> {
+  const { error } = await db.rpc(fn, args);
+  if (!error) return null;
+
+  if (error.code === "42501") return { status: 403, message: FALLBACK["42501"] };
+  if (error.code === "P0002") return { status: 404, message: FALLBACK.P0002 };
+  if (error.code === "P0001") return { status: 400, message: error.message };
+
+  console.error(`${fn} failed`, error);
+  return { status: 500, message: whenBroken };
+}
+
+/**
+ * The three kinds a person can put in the trash and take back out, and the
+ * function pair behind each. Keyed by the same word the trash listing returns
+ * in its `kind` column, so a restore request is answered by the row it came
+ * from rather than by a second mapping that can drift from the first.
+ */
+export const RESTORABLE = {
+  agent: { del: "soft_delete_agent", restore: "restore_agent", arg: "p_agent_id" },
+  bundle: { del: "soft_delete_bundle", restore: "restore_bundle", arg: "p_bundle_id" },
+  document: {
+    del: "soft_delete_document",
+    restore: "restore_document",
+    arg: "p_document_id",
+  },
+} as const;
+
+export type Restorable = keyof typeof RESTORABLE;
+
+export function isRestorable(kind: string): kind is Restorable {
+  return Object.prototype.hasOwnProperty.call(RESTORABLE, kind);
+}
+
+/** How long a deleted thing waits before the sweeper takes it for real. */
+export const RETENTION_DAYS = 30;

--- a/worker/src/lib/export/tables.ts
+++ b/worker/src/lib/export/tables.ts
@@ -153,4 +153,6 @@ export const EXCLUDED: Record<string, string> = {
     "a person's setting, not a workspace's. It follows the account rather than the room, and the account is not what is being exported.",
   user_onboarding:
     "the same, and about a first run that has already happened. It would mean nothing in a new install.",
+  workspace_events:
+    "a record of this install rather than of the work. It says who deleted what and who changed whose role, which is exactly the sort of thing an archive should not carry into somewhere else — and half its rows point at ids the archive deliberately does not contain, because the things they name were deleted. Admins read it in place, on the Team screen, which is where the question it answers gets asked.",
 };

--- a/worker/src/lib/purge.test.ts
+++ b/worker/src/lib/purge.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { defaultHorizon, purgeExpired } from "./purge";
+import type { DocStore } from "./docstore";
+
+/**
+ * A hand-rolled stub rather than `test-support/fake-db`, which is the call that
+ * file's own docstring asks for: the sweep touches three tables in two shapes
+ * (`select().lt()` and `delete().in()`), and the strict fake models neither
+ * `.lt()` nor the ordering this test exists to assert.
+ *
+ * Every call is appended to `log`, in order. That is the assertion — the sweep
+ * is correct or incorrect entirely by the sequence it performs, because after
+ * the rows are gone nothing can enumerate the keys they named.
+ */
+function stubDb(rows: Record<string, Record<string, unknown>[]>) {
+  const log: string[] = [];
+
+  const db = {
+    from(table: string) {
+      return {
+        select(columns: string) {
+          return {
+            lt(column: string, _value: string) {
+              log.push(`select ${table}.${columns} where ${column} < cutoff`);
+              return Promise.resolve({ data: rows[table] ?? [], error: null });
+            },
+            in(column: string, values: string[]) {
+              log.push(`select ${table}.${columns} where ${column} in (${values.length})`);
+              return Promise.resolve({ data: rows[`${table}:in`] ?? [], error: null });
+            },
+          };
+        },
+        delete() {
+          return {
+            in(column: string, values: string[]) {
+              log.push(`delete ${table} where ${column} in (${values.length})`);
+              return Promise.resolve({ data: null, error: null });
+            },
+          };
+        },
+      };
+    },
+  } as unknown as SupabaseClient;
+
+  return { db, log };
+}
+
+function stubStore(log: string[], failOn: string[] = []): DocStore {
+  return {
+    get: async () => null,
+    put: async () => {},
+    delete: async (key: string) => {
+      log.push(`store delete ${key}`);
+      if (failOn.includes(key)) throw new Error("bucket said no");
+    },
+  } as unknown as DocStore;
+}
+
+const HORIZON = new Date("2026-08-03T00:00:00.000Z");
+
+describe("the thirty-day sweeper", () => {
+  it("collects every key before it deletes a single row", async () => {
+    const { db, log } = stubDb({
+      knowledge_bundles: [{ id: "bundle-1" }],
+      agents: [{ id: "agent-1" }],
+      documents: [{ id: "doc-1", r2_key: "keys/one.pdf" }],
+      // Documents that live inside the expiring bundle. They will be taken by
+      // the cascade whether or not they were marked, so their keys have to be
+      // collected too — this is the population a naive sweep misses, and the
+      // one whose files are then orphaned forever.
+      "documents:in": [{ r2_key: "keys/two.pdf" }],
+    });
+
+    await purgeExpired({ db, store: stubStore(log), horizon: HORIZON });
+
+    const firstDelete = log.findIndex((l) => l.startsWith("delete "));
+    const lastSelect = log.map((l) => l.startsWith("select ")).lastIndexOf(true);
+
+    expect(firstDelete).toBeGreaterThan(-1);
+    expect(lastSelect).toBeLessThan(firstDelete);
+  });
+
+  it("deletes the stored objects only after the rows that named them", async () => {
+    const { db, log } = stubDb({
+      knowledge_bundles: [{ id: "bundle-1" }],
+      agents: [],
+      documents: [{ id: "doc-1", r2_key: "keys/one.pdf" }],
+      "documents:in": [{ r2_key: "keys/two.pdf" }],
+    });
+
+    await purgeExpired({ db, store: stubStore(log), horizon: HORIZON });
+
+    const lastRowDelete = log.map((l) => l.startsWith("delete ")).lastIndexOf(true);
+    const firstObjectDelete = log.findIndex((l) => l.startsWith("store delete "));
+
+    expect(firstObjectDelete).toBeGreaterThan(lastRowDelete);
+    expect(log.filter((l) => l.startsWith("store delete "))).toEqual([
+      "store delete keys/one.pdf",
+      "store delete keys/two.pdf",
+    ]);
+  });
+
+  it("takes a bundle's documents even when only the bundle was marked", async () => {
+    const { db, log } = stubDb({
+      knowledge_bundles: [{ id: "bundle-1" }],
+      agents: [],
+      documents: [],
+      "documents:in": [{ r2_key: "keys/inside.pdf" }],
+    });
+
+    const result = await purgeExpired({ db, store: stubStore(log), horizon: HORIZON });
+
+    expect(result.bundles).toBe(1);
+    expect(result.documents).toBe(0);
+    expect(log).toContain("store delete keys/inside.pdf");
+  });
+
+  it("does nothing at all when nothing has expired", async () => {
+    const { db, log } = stubDb({ knowledge_bundles: [], agents: [], documents: [] });
+
+    const result = await purgeExpired({ db, store: stubStore(log), horizon: HORIZON });
+
+    expect(result).toEqual({
+      agents: 0,
+      bundles: 0,
+      documents: 0,
+      objects: 0,
+      objectFailures: 0,
+    });
+    expect(log.some((l) => l.startsWith("delete "))).toBe(false);
+    expect(log.some((l) => l.startsWith("store delete "))).toBe(false);
+  });
+
+  it("counts a failed object delete instead of abandoning the rest", async () => {
+    // The one failure in the sweep nothing downstream can repair: the rows that
+    // knew the key are already gone, so a throw here would strand every key
+    // after it as well.
+    const { db, log } = stubDb({
+      knowledge_bundles: [],
+      agents: [],
+      documents: [
+        { id: "doc-1", r2_key: "keys/bad.pdf" },
+        { id: "doc-2", r2_key: "keys/good.pdf" },
+      ],
+    });
+
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    const result = await purgeExpired({
+      db,
+      store: stubStore(log, ["keys/bad.pdf"]),
+      horizon: HORIZON,
+    });
+    errors.mockRestore();
+
+    expect(result.objectFailures).toBe(1);
+    expect(result.objects).toBe(1);
+    expect(log).toContain("store delete keys/good.pdf");
+  });
+
+  it("still removes the rows when no store is configured", async () => {
+    const { db, log } = stubDb({
+      knowledge_bundles: [],
+      agents: [{ id: "agent-1" }],
+      documents: [],
+    });
+
+    const result = await purgeExpired({ db, store: null, horizon: HORIZON });
+
+    expect(result.agents).toBe(1);
+    expect(result.objects).toBe(0);
+    expect(log.some((l) => l.startsWith("store delete "))).toBe(false);
+  });
+});
+
+describe("the horizon", () => {
+  it("is thirty days behind, so today's deletion survives today", () => {
+    const now = new Date("2026-09-02T12:00:00.000Z");
+    expect(defaultHorizon(now).toISOString()).toBe("2026-08-03T12:00:00.000Z");
+  });
+});

--- a/worker/src/lib/purge.ts
+++ b/worker/src/lib/purge.ts
@@ -1,0 +1,186 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Bindings } from "../types";
+import { serviceClient } from "./supabase";
+import { getDocStore, type DocStore } from "./docstore";
+import { RETENTION_DAYS } from "./deletion";
+
+/**
+ * The other half of recoverable deletion: after thirty days, the rows go for
+ * real and the foreign keys do what they always did.
+ *
+ * It runs on the API Worker's `scheduled` handler rather than on the cron
+ * Worker, and the reason is the object store. The cron Worker takes
+ * `RoutineEnv`, which deliberately carries no R2 binding — nothing it does
+ * touches an uploaded file. Sweeping does: a purged document's bytes have to
+ * go with its row, or the erasure is not one.
+ *
+ * No once-a-day guard and no state to keep. On a workspace with nothing
+ * expired — which is nearly every tick of nearly every workspace — this is
+ * three SELECTs against partial indexes that cover only the deleted rows, and
+ * they return nothing. A guard would cost more to keep honest than the queries
+ * it saved.
+ */
+
+export type PurgeDeps = {
+  db: SupabaseClient;
+  store: DocStore | null;
+  /** Overridable so a test can move the horizon without waiting thirty days. */
+  horizon: Date;
+};
+
+export type PurgeResult = {
+  agents: number;
+  bundles: number;
+  documents: number;
+  objects: number;
+  objectFailures: number;
+};
+
+export function defaultHorizon(now: Date = new Date()): Date {
+  const at = new Date(now);
+  at.setUTCDate(at.getUTCDate() - RETENTION_DAYS);
+  return at;
+}
+
+/**
+ * The ordering is the whole of the care here, and it is the one
+ * `worker/src/routes/account.ts` has followed since account closure existed:
+ * **collect the keys, delete the rows, then delete the objects.** Afterwards
+ * there is nothing left to enumerate the keys by — the rows that named them are
+ * gone, and an orphaned object in a bucket is invisible to everything in this
+ * codebase.
+ *
+ * Keys are collected for two populations, not one. A document expiring on its
+ * own is obvious. The other is a document sitting inside an expiring bundle:
+ * it may have been deleted later than the bundle was, or not marked at all if
+ * somebody restored and re-deleted around it, and the bundle's cascade will
+ * take it regardless. Missing that set is how a purge quietly leaves files
+ * behind forever.
+ */
+export async function purgeExpired(deps: PurgeDeps): Promise<PurgeResult> {
+  const { db, store, horizon } = deps;
+  const cutoff = horizon.toISOString();
+
+  const result: PurgeResult = {
+    agents: 0,
+    bundles: 0,
+    documents: 0,
+    objects: 0,
+    objectFailures: 0,
+  };
+
+  const expiredBundleIds = await idsOlderThan(db, "knowledge_bundles", cutoff);
+  const expiredAgentIds = await idsOlderThan(db, "agents", cutoff);
+
+  const keys = new Set<string>();
+  const documentIds = new Set<string>();
+
+  for (const row of await expiredDocuments(db, cutoff)) {
+    documentIds.add(row.id);
+    if (row.r2_key) keys.add(row.r2_key);
+  }
+  for (const row of await documentsInBundles(db, expiredBundleIds)) {
+    if (row.r2_key) keys.add(row.r2_key);
+  }
+
+  // Agents first: the cascade takes sessions, messages, routines and
+  // favourites, none of which own a stored object, so nothing here depends on
+  // the key collection above.
+  if (expiredAgentIds.length > 0) {
+    const { error } = await db.from("agents").delete().in("id", expiredAgentIds);
+    if (error) {
+      console.error("purge: failed to delete expired agents", error);
+    } else {
+      result.agents = expiredAgentIds.length;
+    }
+  }
+
+  // Bundles next, taking their documents and chunks with them.
+  if (expiredBundleIds.length > 0) {
+    const { error } = await db.from("knowledge_bundles").delete().in("id", expiredBundleIds);
+    if (error) {
+      console.error("purge: failed to delete expired bundles", error);
+    } else {
+      result.bundles = expiredBundleIds.length;
+    }
+  }
+
+  // Then whatever is left: documents deleted on their own, whose bundle is
+  // still very much alive.
+  const remaining = [...documentIds];
+  if (remaining.length > 0) {
+    const { error } = await db.from("documents").delete().in("id", remaining);
+    if (error) {
+      console.error("purge: failed to delete expired documents", error);
+    } else {
+      result.documents = remaining.length;
+    }
+  }
+
+  // Last, and best-effort. A failure here leaves a file nothing points at,
+  // which is a storage cost rather than a correctness problem — and retrying it
+  // is impossible anyway, because the rows that knew the key are gone. Logged
+  // loudly for exactly that reason: this is the one failure in the sweep that
+  // nothing downstream can repair.
+  if (store) {
+    for (const key of keys) {
+      try {
+        await store.delete(key);
+        result.objects += 1;
+      } catch (e) {
+        result.objectFailures += 1;
+        console.error("purge: failed to delete stored object", key, e);
+      }
+    }
+  }
+
+  return result;
+}
+
+async function idsOlderThan(db: SupabaseClient, table: string, cutoff: string): Promise<string[]> {
+  const { data, error } = await db.from(table).select("id").lt("deleted_at", cutoff);
+  if (error) {
+    console.error(`purge: failed to list expired rows in ${table}`, error);
+    return [];
+  }
+  return (data ?? []).map((r) => (r as { id: string }).id);
+}
+
+async function expiredDocuments(
+  db: SupabaseClient,
+  cutoff: string,
+): Promise<{ id: string; r2_key: string | null }[]> {
+  const { data, error } = await db.from("documents").select("id,r2_key").lt("deleted_at", cutoff);
+  if (error) {
+    console.error("purge: failed to list expired documents", error);
+    return [];
+  }
+  return (data ?? []) as { id: string; r2_key: string | null }[];
+}
+
+async function documentsInBundles(
+  db: SupabaseClient,
+  bundleIds: string[],
+): Promise<{ r2_key: string | null }[]> {
+  if (bundleIds.length === 0) return [];
+  const { data, error } = await db.from("documents").select("r2_key").in("bundle_id", bundleIds);
+  if (error) {
+    console.error("purge: failed to list documents inside expiring bundles", error);
+    return [];
+  }
+  return (data ?? []) as { r2_key: string | null }[];
+}
+
+/** What the scheduled handler calls. Resolves the store, which may not exist. */
+export async function runPurge(env: Bindings): Promise<PurgeResult> {
+  let store: DocStore | null = null;
+  try {
+    store = getDocStore(env);
+  } catch (e) {
+    // A deployment with neither DOCS nor DOCS_DIR cannot have stored anything,
+    // so there is nothing to orphan. The rows still go.
+    console.error("purge: no document store configured; rows only", e);
+  }
+
+  return purgeExpired({ db: serviceClient(env), store, horizon: defaultHorizon() });
+}

--- a/worker/src/lib/routines/executor.test.ts
+++ b/worker/src/lib/routines/executor.test.ts
@@ -94,6 +94,10 @@ function makeDb(
       select: () => {
         const chain: any = {
           eq: () => chain,
+          // The agent lookup asks `.is("deleted_at", null)`: the executor holds
+          // a service-role client, so nothing else is filtering a soft-deleted
+          // agent out of its way.
+          is: () => chain,
           order: () => chain,
           limit: () => chain,
           maybeSingle: async () => ({ data: await rowFor(table), error: null }),

--- a/worker/src/lib/routines/executor.ts
+++ b/worker/src/lib/routines/executor.ts
@@ -245,6 +245,12 @@ export async function runRoutine(
       .select("persona, model")
       .eq("id", routine.agent_id)
       .eq("workspace_id", routine.workspace_id)
+      // Service-role client, so RLS is not filtering this. `claim_due_routines`
+      // already skips routines marked by their agent's deletion and this should
+      // therefore be unreachable — it is written because "should be
+      // unreachable" is how a deleted agent's persona ends up in a Slack
+      // message some Tuesday.
+      .is("deleted_at", null)
       .maybeSingle();
 
     if (agentError) throw new Error(`agent lookup failed: ${agentError.message}`);

--- a/worker/src/routes/agents.ts
+++ b/worker/src/routes/agents.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { AppEnv } from "../types";
 import { mapAgent } from "../lib/dto";
 import { getActiveWorkspaceId } from "../lib/workspace";
+import { callDeletionFn } from "../lib/deletion";
 
 const agents = new Hono<AppEnv>();
 
@@ -119,15 +120,24 @@ agents.patch("/agents/:id", async (c) => {
 });
 
 // DELETE /agents/:id
+//
+// No longer a delete. `soft_delete_agent` marks the agent and, in the same
+// statement, the sessions and routines that hung off it — which the foreign
+// keys used to destroy outright, taking every message with them. The sweeper
+// finishes the job thirty days later if nobody asks for it back.
+//
+// The refusal now arrives as a raised exception rather than as a delete that
+// matched no rows. That is the improvement: RLS answers an unpermitted delete
+// with silence and `{ok:true}`, which is how a viewer used to be told they had
+// succeeded at something the database had just refused.
 agents.delete("/agents/:id", async (c) => {
-  const db = c.get("db");
-  const id = c.req.param("id");
-
-  const { error } = await db.from("agents").delete().eq("id", id);
-
-  if (error) {
-    return c.json({ error: "failed to delete agent" }, 500);
-  }
+  const failure = await callDeletionFn(
+    c.get("db"),
+    "soft_delete_agent",
+    { p_agent_id: c.req.param("id") },
+    "failed to delete agent",
+  );
+  if (failure) return c.json({ error: failure.message }, failure.status);
 
   return c.json({ ok: true });
 });

--- a/worker/src/routes/bundles.ts
+++ b/worker/src/routes/bundles.ts
@@ -9,6 +9,7 @@ import { getDocStore } from "../lib/docstore";
 import { guardQuota, recordQuota } from "../lib/entitlements/guard";
 import { embeddingCost } from "../lib/entitlements";
 import { insertChunkRows } from "../lib/chunk-store";
+import { callDeletionFn } from "../lib/deletion";
 
 const bundles = new Hono<AppEnv>();
 
@@ -156,10 +157,23 @@ bundles.patch("/bundles/:id", async (c) => {
 });
 
 // DELETE /bundles/:id
+//
+// Marks the bundle and its documents together (0037). The documents carry
+// `deleted_via = <bundle id>`, which is what keeps them out of the trash as
+// separate entries and brings exactly them back when the bundle is restored —
+// a document somebody deleted on its own beforehand keeps its own deletion.
+//
+// Their chunks and their uploaded files are untouched for thirty days, so
+// restoring costs no re-embedding. It also means a deleted bundle goes on
+// occupying storage until the sweeper reaches it.
 bundles.delete("/bundles/:id", async (c) => {
-  const db = c.get("db");
-  const { error } = await db.from("knowledge_bundles").delete().eq("id", c.req.param("id"));
-  if (error) return c.json({ error: "failed to delete bundle" }, 500);
+  const failure = await callDeletionFn(
+    c.get("db"),
+    "soft_delete_bundle",
+    { p_bundle_id: c.req.param("id") },
+    "failed to delete bundle",
+  );
+  if (failure) return c.json({ error: failure.message }, failure.status);
   return c.json({ ok: true });
 });
 

--- a/worker/src/routes/documents.test.ts
+++ b/worker/src/routes/documents.test.ts
@@ -200,29 +200,26 @@ describe("PATCH /documents/:id — moving a document to another bundle", () => {
 });
 
 /**
- * The caller's client for the delete path. `rowsDeleted` is the knob that
- * matters: a viewer's delete is refused by RLS as "matched no rows, no error",
- * which is indistinguishable from success unless the handler looks.
+ * The caller's client for the delete path, which is now one RPC.
+ *
+ * `soft_delete_document` checks `can_write_in_workspace` for itself and raises,
+ * so the knob that matters is the SQLSTATE. That is the improvement worth
+ * keeping in mind while reading these: RLS used to refuse a viewer's delete as
+ * "matched no rows, no error", which is indistinguishable from success unless
+ * the handler goes looking. A raised exception cannot be mistaken for anything.
  */
-function fakeDeleteDb(opts: {
-  row: { id: string; r2_key: string | null } | null;
-  rowsDeleted: number;
-}) {
-  return {
-    from: () => ({
-      select: () => ({
-        eq: () => ({ maybeSingle: async () => ({ data: opts.row, error: null }) }),
-      }),
-      delete: () => ({
-        eq: () => ({
-          select: async () => ({
-            data: opts.row && opts.rowsDeleted > 0 ? [opts.row] : [],
-            error: null,
-          }),
-        }),
-      }),
-    }),
+function fakeDeleteDb(opts: { code?: string; message?: string } = {}) {
+  const calls: { fn: string; args: Record<string, unknown> }[] = [];
+  const db = {
+    rpc: async (fn: string, args: Record<string, unknown>) => {
+      calls.push({ fn, args });
+      return {
+        data: null,
+        error: opts.code ? { code: opts.code, message: opts.message ?? "refused" } : null,
+      };
+    },
   } as never;
+  return { db, calls };
 }
 
 function appWith(db: unknown, deleted: string[]) {
@@ -247,41 +244,53 @@ function appWith(db: unknown, deleted: string[]) {
 }
 
 describe("DELETE /documents/:id", () => {
-  it("removes the stored object when RLS permits the row delete", async () => {
+  it("marks the row and leaves the stored object exactly where it is", async () => {
     const deleted: string[] = [];
-    const app = appWith(
-      fakeDeleteDb({ row: { id: "d1", r2_key: "b1/obj" }, rowsDeleted: 1 }),
-      deleted,
-    );
+    const { db, calls } = fakeDeleteDb();
+    const app = appWith(db, deleted);
 
     const res = await app.request("/documents/d1", { method: "DELETE" });
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
-    expect(deleted).toEqual(["b1/obj"]);
+    expect(calls).toEqual([{ fn: "soft_delete_document", args: { p_document_id: "d1" } }]);
+
+    // The reason the bytes stay: a restored document that came back as a row
+    // pointing at a missing file is worse than either outcome on its own. The
+    // sweeper deletes both, thirty days later.
+    expect(deleted).toEqual([]);
   });
 
-  it("leaves the bytes alone and 403s when RLS refuses the row delete", async () => {
+  it("403s when the database refuses, and still touches nothing", async () => {
     const deleted: string[] = [];
-    const app = appWith(
-      fakeDeleteDb({ row: { id: "d1", r2_key: "b1/obj" }, rowsDeleted: 0 }),
-      deleted,
-    );
+    const { db } = fakeDeleteDb({ code: "42501" });
+    const app = appWith(db, deleted);
 
     const res = await app.request("/documents/d1", { method: "DELETE" });
 
     expect(res.status).toBe(403);
-    // The whole point: a viewer must not be able to destroy the content.
     expect(deleted).toEqual([]);
   });
 
-  it("404s for a document the caller cannot see", async () => {
+  it("404s for a document the caller cannot see, or that is already deleted", async () => {
     const deleted: string[] = [];
-    const app = appWith(fakeDeleteDb({ row: null, rowsDeleted: 0 }), deleted);
+    const { db } = fakeDeleteDb({ code: "P0002" });
+    const app = appWith(db, deleted);
 
     const res = await app.request("/documents/nope", { method: "DELETE" });
 
     expect(res.status).toBe(404);
+    expect(deleted).toEqual([]);
+  });
+
+  it("500s on anything else rather than reporting a delete that did not happen", async () => {
+    const deleted: string[] = [];
+    const { db } = fakeDeleteDb({ code: "08006", message: "connection failure" });
+    const app = appWith(db, deleted);
+
+    const res = await app.request("/documents/d1", { method: "DELETE" });
+
+    expect(res.status).toBe(500);
     expect(deleted).toEqual([]);
   });
 });

--- a/worker/src/routes/documents.ts
+++ b/worker/src/routes/documents.ts
@@ -7,60 +7,34 @@ import { getDocStore } from "../lib/docstore";
 import { guardQuota, recordQuota } from "../lib/entitlements/guard";
 import { embeddingCost } from "../lib/entitlements";
 import { insertChunkRows } from "../lib/chunk-store";
+import { callDeletionFn } from "../lib/deletion";
 
 const documents = new Hono<AppEnv>();
 
-// DELETE /documents/:id — the row is the authority, and it goes first.
+// DELETE /documents/:id — a mark now, and the stored object stays put.
 //
-// This used to delete the stored object and then the row. RLS answers a delete
-// it has no policy for by matching no rows and reporting no error, so a viewer
-// — who passes documents_select_member but fails documents_delete_member —
-// destroyed the bytes and got {ok:true} back, leaving a row pointing at a key
-// that no longer exists. Deleting the row first, and reading back what was
-// actually deleted, makes the refusal visible before anything is lost.
+// It has twice been the case that this route destroyed bytes it should not
+// have. First it deleted the object and then the row, so a viewer — who passes
+// documents_select_member but fails documents_delete_member — destroyed the
+// file and got {ok:true} back, because RLS answers an unpermitted delete by
+// matching no rows and reporting no error. That was fixed by deleting the row
+// first and reading back what actually went.
+//
+// Now neither goes. `soft_delete_document` marks the row and raises 42501 on
+// refusal, so the viewer case is answered by an exception rather than by
+// silence; and the object is deliberately left in the store, because a restored
+// document that came back as a row pointing at a missing file would be worse
+// than either outcome on its own. `worker/src/lib/purge.ts` deletes both,
+// thirty days later, in the order account closure already uses: collect the
+// keys, delete the rows, then delete the objects.
 documents.delete("/documents/:id", async (c) => {
-  const db = c.get("db");
-  const id = c.req.param("id");
-
-  const { data: row, error: selErr } = await db
-    .from("documents")
-    .select("id,r2_key")
-    .eq("id", id)
-    .maybeSingle();
-
-  if (selErr) {
-    return c.json({ error: "failed to load document" }, 500);
-  }
-  if (!row) {
-    return c.json({ error: "not found" }, 404);
-  }
-
-  const { data: deleted, error: delErr } = await db
-    .from("documents")
-    .delete()
-    .eq("id", id)
-    .select("id,r2_key");
-
-  if (delErr) {
-    return c.json({ error: "failed to delete document" }, 500);
-  }
-  // Visible above, not deletable: RLS refused. Not "already gone" — the select
-  // two calls up found it.
-  if (!deleted || deleted.length === 0) {
-    return c.json({ error: "you do not have permission to delete this document" }, 403);
-  }
-
-  const key = deleted[0].r2_key;
-  if (key) {
-    try {
-      await getDocStore(c.env).delete(key);
-    } catch (e) {
-      // Best-effort by design: the row is gone, so the document is gone as far
-      // as the product is concerned. An orphaned object is a storage cost, not
-      // a correctness problem, and failing the request here would be a lie.
-      console.error("document store delete failed", e);
-    }
-  }
+  const failure = await callDeletionFn(
+    c.get("db"),
+    "soft_delete_document",
+    { p_document_id: c.req.param("id") },
+    "failed to delete document",
+  );
+  if (failure) return c.json({ error: failure.message }, failure.status);
 
   return c.json({ ok: true });
 });

--- a/worker/src/routes/events.ts
+++ b/worker/src/routes/events.ts
@@ -1,0 +1,101 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import type { AppEnv } from "../types";
+import { getActiveWorkspaceId } from "../lib/workspace";
+import { toEpochMs } from "../lib/dto";
+
+const events = new Hono<AppEnv>();
+
+const querySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  /** ISO timestamp; returns events strictly older than this. */
+  before: z.string().datetime().optional(),
+});
+
+type EventRow = {
+  id: string;
+  action: string;
+  subject_type: string;
+  subject_id: string | null;
+  subject_label: string;
+  detail: Record<string, unknown> | null;
+  created_at: string;
+  actor: { name: string | null; email: string | null } | null;
+};
+
+/**
+ * GET /events — the workspace's record of who did what.
+ *
+ * No workspace scope in the query beyond the active one, and no role check
+ * here: `workspace_events_select_admin` is the boundary, and it admits only an
+ * admin of the row's workspace. A member gets an empty list rather than a 403,
+ * which is the one place this differs from /trash — there, an empty list would
+ * be a false statement about whether anything is recoverable. Here it is true:
+ * there is nothing this person may see.
+ *
+ * Paged by `before` rather than by offset. The rows are written by triggers
+ * while somebody is reading, and an offset page would skip or repeat rows as
+ * the log grows underneath it.
+ */
+events.get("/events", async (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+
+  const parsed = querySchema.safeParse(c.req.query());
+  if (!parsed.success) {
+    return c.json({ error: "invalid query" }, 400);
+  }
+  const { limit, before } = parsed.data;
+
+  const workspaceId = await getActiveWorkspaceId(db, user.id);
+  if (!workspaceId) return c.json({ events: [], hasMore: false });
+
+  let query = db
+    .from("workspace_events")
+    .select(
+      "id,action,subject_type,subject_id,subject_label,detail,created_at,actor:profiles(name,email)",
+    )
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: false })
+    // One more than asked for, so "is there another page" is answered without a
+    // second count query against a table that is growing as this runs.
+    .limit(limit + 1);
+
+  if (before) query = query.lt("created_at", before);
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error("failed to load workspace events", error);
+    return c.json({ error: "failed to load activity" }, 500);
+  }
+
+  const rows = (data ?? []) as unknown as EventRow[];
+  const hasMore = rows.length > limit;
+
+  return c.json({
+    hasMore,
+    events: rows.slice(0, limit).map((r) => ({
+      id: r.id,
+      action: r.action,
+      subjectType: r.subject_type,
+      subjectId: r.subject_id,
+      subjectLabel: r.subject_label,
+      detail: r.detail,
+      createdAt: toEpochMs(r.created_at),
+      /**
+       * The ISO string as well, because `before` on the next page has to be a
+       * timestamp Postgres will compare against `created_at` — and a number
+       * round-tripped through the client would lose the microseconds Postgres
+       * keeps, which is how a paged log repeats or skips its boundary row.
+       */
+      cursor: r.created_at,
+      // Null for anything the system did on nobody's behalf, and for an actor
+      // whose account has since been deleted — `actor_id` nulls rather than
+      // cascading, so the event survives the person.
+      actor: r.actor ? (r.actor.name ?? r.actor.email) : null,
+    })),
+  });
+});
+
+export { events };

--- a/worker/src/routes/trash.ts
+++ b/worker/src/routes/trash.ts
@@ -1,0 +1,97 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+import { getActiveWorkspaceId } from "../lib/workspace";
+import { toEpochMs } from "../lib/dto";
+import { callDeletionFn, isRestorable, RESTORABLE, RETENTION_DAYS } from "../lib/deletion";
+
+const trash = new Hono<AppEnv>();
+
+type TrashRow = {
+  kind: string;
+  id: string;
+  name: string;
+  deleted_at: string;
+  deleted_by_id: string | null;
+  deleted_by_name: string | null;
+  parent_name: string | null;
+};
+
+/**
+ * GET /trash — what this workspace has deleted and can still get back.
+ *
+ * Reads through `workspace_trash()` rather than through the tables, because the
+ * policies added in 0039 hide deleted rows from everybody. That is the whole
+ * point of the arrangement: every other query in the codebase is correct
+ * without remembering deletion exists, and this one route asks for the
+ * exception in so many words. The function checks `can_write_in_workspace`
+ * itself and raises 42501, so a viewer gets a 403 here rather than an empty
+ * list — an empty list would tell them there was nothing to restore, which is
+ * a different and possibly false statement.
+ */
+trash.get("/trash", async (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+
+  const workspaceId = await getActiveWorkspaceId(db, user.id);
+  if (!workspaceId) return c.json({ items: [], retentionDays: RETENTION_DAYS });
+
+  const { data, error } = await db.rpc("workspace_trash", { p_workspace_id: workspaceId });
+
+  if (error) {
+    if (error.code === "42501") {
+      return c.json({ error: "only members can see what has been deleted" }, 403);
+    }
+    console.error("failed to load trash", error);
+    return c.json({ error: "failed to load deleted items" }, 500);
+  }
+
+  const rows = (data ?? []) as TrashRow[];
+
+  return c.json({
+    retentionDays: RETENTION_DAYS,
+    items: rows.map((r) => ({
+      kind: r.kind,
+      id: r.id,
+      name: r.name,
+      // Epoch milliseconds, as every other timestamp this API returns —
+      // `formatRelative` takes a number and an ISO string reaches it as NaN,
+      // which renders as a blank rather than as an error.
+      deletedAt: toEpochMs(r.deleted_at),
+      // Null when the person who deleted it has since been deleted themselves —
+      // `deleted_by` nulls rather than cascading, the same way the six
+      // attribution columns do. The row still says what went and when.
+      deletedBy: r.deleted_by_name,
+      // Which bundle a deleted document came out of. Two files called
+      // "notes.md" from different bundles are otherwise the same row twice.
+      parentName: r.parent_name,
+      purgesAt: toEpochMs(r.deleted_at) + RETENTION_DAYS * 86_400_000,
+    })),
+  });
+});
+
+/**
+ * POST /trash/:kind/:id/restore
+ *
+ * `kind` is the same word `workspace_trash` returned in its `kind` column, so a
+ * restore is addressed by the row it came from. Anything else is a 404 before
+ * a database call is made — the alternative is interpolating a caller-supplied
+ * string into a function name.
+ */
+trash.post("/trash/:kind/:id/restore", async (c) => {
+  const kind = c.req.param("kind");
+  if (!isRestorable(kind)) return c.json({ error: "not found" }, 404);
+
+  const { restore, arg } = RESTORABLE[kind];
+
+  const failure = await callDeletionFn(
+    c.get("db"),
+    restore,
+    { [arg]: c.req.param("id") },
+    `failed to restore ${kind}`,
+  );
+  if (failure) return c.json({ error: failure.message }, failure.status);
+
+  return c.json({ ok: true });
+});
+
+export { trash };

--- a/worker/src/service-client.static.test.ts
+++ b/worker/src/service-client.static.test.ts
@@ -39,6 +39,10 @@ const SERVICE_CLIENT_ALLOWLIST = new Map([
     "authentication, the same exemption authClient has: an API key is looked up before there is a caller for RLS to resolve, so there is no user client to do it with — it reads one row by hash and writes that row's last_used_at, and nothing else",
   ],
   [
+    "lib/purge.ts",
+    "the thirty-day sweeper runs on the cron with no caller, so there is no JWT for RLS to resolve — the same exemption as the dispatcher. It is also the one thing that must see past the policies 0039 installed: every row it exists to delete is a row those policies hide from everybody, so a user client would find nothing to sweep and report success",
+  ],
+  [
     "routes/account.ts",
     "erasure is the one thing a caller cannot do as themselves: auth.users is outside RLS entirely, so deleting your own account needs auth.admin.deleteUser, and the workspaces left with nobody in them have no DELETE policy for the same reason nobody has ever needed one. Both writes are keyed to the caller's own id, and the survey that decides which workspaces those are is done through the user client on purpose",
   ],


### PR DESCRIPTION
Any `member` could delete any agent in the workspace, and the foreign keys did the rest: every session anybody had with it, every message in those, every routine pointed at it. A bundle took its documents and their embeddings. `docs/team.md` said so in plain words — *"None of it is recoverable from inside the product"* — which was survivable while the only people in a workspace were the people who built it. It stops being survivable the week real customers start testing.

Agents, bundles and documents now wait thirty days, and a workspace keeps a record of who did what.

## Deletion

`deleted_at`, `deleted_by`, `deleted_via` on the three tables. Deleting goes through `soft_delete_agent()` / `_bundle()` / `_document()` rather than a `DELETE`.

**`deleted_via` is what makes a restore exact.** A soft delete cascades nothing, so a marked agent would otherwise leave its sessions and routines on screen pointing at something gone. Deleting an agent also marks them with `deleted_via = <agent id>`; restoring clears that id and no other, so a document deleted on its own does *not* come back when its bundle does. Restoring a document into a still-deleted bundle is refused with a message naming which button to press first.

The marking lives in Postgres because it spans tables with no transaction across them — and because `chat_sessions_update_owner` would refuse to mark a colleague's conversations even for somebody who has just deleted the agent underneath them.

## Deleted means invisible, to everybody

The one design call worth reviewing. The obvious shape is `deleted_at is null or can_write_in_workspace(...)`, letting the trash read through the ordinary policy. Its cost is that every existing SELECT becomes wrong unless it also carries `.is("deleted_at", null)` — because a member is exactly who runs the agent list, the bundle page, retrieval and export. Thirty call sites today, unbounded forever, failing by *showing deleted things* rather than by erroring.

So deleted rows are hidden from everyone, every query stays correct as written, and the trash asks through `workspace_trash()` — `security definer` with its own permission check, the arrangement `0032` already uses for `workspace_usage_all`.

Two policies needed more, and both are where the deletion would otherwise have been cosmetic:

- **`dc_select_member`** gated on workspace membership alone, so a deleted document's text stayed readable straight from PostgREST by any member. Chunks now require a live parent, with no exception for the person who could restore it.
- **`session_is_visible`** gained one line — which hides a deleted agent's entire transcript, because `messages` and `ideas` name that function and nothing else.

`match_chunks` asks twice: that the document is alive *and* that the bundle the chunk is filed under is alive. Retrieval scope lives on `document_chunks.bundle_id`, so a chunk can name a bundle its document has left. Without both, an agent goes on quoting a deleted file — the worst failure available here, because it looks like the deletion did nothing.

## The audit log

`workspace_events`: twelve deliberate actions — the six deletions and restores, role changes, joins, departures, invitations — written by `security definer` triggers and readable only by an admin.

**No insert policy for anybody, and no INSERT grant.** An audit log the API writes can be skipped by anything that does not go through the API, and PostgREST, reachable with the anon key in the browser bundle, does not. `subject_label` stores the name as it was, because thirty days later the sweeper takes the row and `subject_id` points nowhere. Cascaded marks emit nothing, so a bundle of two hundred documents is one event. `member.removed` and `member.left` are the same DELETE, told apart by whether the caller is the row's own user.

## The sweeper

On the API Worker's `scheduled` handler, not the cron Worker's — that one takes `RoutineEnv` and carries no R2 binding, and a purged document's bytes have to go with its row. Order is the one account closure already used: **collect the keys, delete the rows, then delete the objects.**

This is why `DELETE /documents/:id` stops deleting the stored object: a restored document that came back pointing at a missing file would be worse than either outcome alone.

**A deleted bundle still costs storage for thirty days.** Its chunks are still rows and its files are still objects. Against Supabase's 500 MB that is a real number, and it is the price of the window.

## Also

`document_citation_counts` (`0038`) is `security definer`, so the new policies do not reach it — it would answer for deleted documents, handing back their ids and how heavily they were used. Patched here, because this migration is what made a document deletable.

## Surfaces

- **Settings → Recently deleted** — restore, with a countdown. Hidden from a viewer; `workspace_trash()` refuses them with a 403 rather than an empty list, since an empty list would say there was nothing to recover.
- **Team → Activity** — the log, admin only.
- Every destructive dialog stopped promising finality and now says what is true.

## Testing

- `tests/rls/soft-deletion.test.ts` — 18 tests through PostgREST with the anon key, since every claim above is a claim about policies. Covers the chunk leak, `match_chunks`, exact restore, `42501` for a viewer, an unforgeable log, and removed-vs-left.
- `worker/src/lib/purge.test.ts` — 7 tests, mostly on ordering: after the rows go, nothing can enumerate the keys they named.
- `src/components/recently-deleted-section.test.tsx` — 7 tests.

Full local run: 406 frontend, 704 worker, 151 RLS (16 files), lint and both typechecks clean.

## Not in this PR

Two blocks sequenced behind this one: **per-agent access** inside a workspace, and **team notifications plus ownership transfer** for a departing member's routines and delivery channels. Both read this log and these visibility rules, which is why they come after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
