### PR TITLE
The first five minutes of a new account

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -30,6 +30,59 @@ it, not the workspace.
 Both roles can create, edit and delete bundles. There is no owner who has to
 approve it.
 
+## What a document should look like
+
+The accepted formats are listed further down, and they are the least interesting
+half of the answer. A file that is accepted can still be a file no question ever
+reaches, and the difference is not the extension.
+
+Four things decide it, all of them consequences of how retrieval works rather
+than house style:
+
+**One subject per file.** A question matches a passage, and the passage arrives
+with its neighbours. A single handbook covering pricing, onboarding and the
+deployment runbook competes with itself: the pricing question pulls a chunk that
+happens to sit between two unrelated ones. Six files beat one file six times the
+size.
+
+**Write the answer, not a pointer to it.** "See the Notion page" retrieves
+perfectly and answers nothing. So does a heading with nothing under it. The
+agent can only say what the text says.
+
+**Use the words people ask in.** Matching is on meaning as the embedding model
+represents it, so a document written entirely in internal shorthand and a
+question written in plain English may not meet. This is what makes a glossary of
+your own terms one of the highest-value files in a workspace.
+
+**Say when it was true.** Nothing updates a document in place — a re-upload
+makes a new one — so a date inside the text is the only version the agent can
+read. The source chip under an answer carries the upload date and warns past
+ninety days, which tells the reader the file is old but not what it was current
+for.
+
+Everything else is ordinary writing. Headings help, because they give the
+chunker a natural boundary to cut on, and they cost nothing.
+
+### Starting from nothing
+
+A team that has not written any of this down yet has the harder version of the
+problem, and it is the common one: the first agent is often made before the
+first document exists.
+
+The Knowledge tab carries six starter documents for exactly that — company
+overview, product notes, FAQ, how we work, glossary, and a meeting-notes shape.
+Each downloads as a Markdown file of headings with a bracketed prompt under
+each, and the prompts are questions rather than instructions. Fill one in and
+upload it back.
+
+They download rather than being created in place, and that is deliberate: an
+empty template inside a bundle is worse than no document at all. Retrieval would
+match it, the agent would ground an answer in `[Two or three sentences]`, and
+the source chip under that answer would report the file as read.
+
+If you fill in only one, make it the FAQ. It is the file whose headings are
+already phrased the way somebody will ask.
+
 ## Uploading
 
 There are two ways in, and they differ only in where the file lands.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,8 +18,14 @@ Auth; the Covan API is not in that path at all.
 
 What happens next depends on whether the deployment confirms email addresses. If
 sign-up returns a session, you are in the app immediately. If it does not, you
-are shown a "Check your email" screen, and the confirmation link has to be
-clicked before you can sign in.
+are shown a "Check your email" screen naming the address it went to, and the
+confirmation link has to be clicked before you can sign in.
+
+Clicking it brings you back to `/confirmed`, which says so and hands you a way
+into the app. That page is the whole point of the link having a destination of
+its own: sent to the site's front door instead — which is what Supabase does
+when nothing tells it otherwise — a confirmed account and an expired link look
+exactly alike, because both of them look like the home page.
 
 Either way, a database trigger gives the new account a profile and a workspace of
 its own, named after you — `Alex Rivera's Workspace`. Everything you make from
@@ -91,6 +97,13 @@ agent's own — created on the first file and attached straight away, so you can
 ask about it in the next message. It is a normal bundle, so anything below about
 bundles applies to it too. [Knowledge bundles](knowledge.md#uploading) has the
 longer version.
+
+If you do not have anything to drop in yet, the Knowledge tab carries six
+starter documents — company overview, product notes, FAQ, how we work, glossary,
+meeting notes. Each downloads as a page of headings with a prompt under each,
+which you fill in and upload back. [What a document should look
+like](knowledge.md#what-a-document-should-look-like) is the reasoning behind
+their shape, and applies just as well to a file you write yourself.
 
 Accepted file types are exactly these, up to 10 MB each:
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -540,6 +540,24 @@ The subject lines that go with them are in
 `{{ .ConfirmationURL }}` placeholder, which is what the button points at — change
 anything else you like, but not that, or the button leads nowhere.
 
+**Both links have to be allowed back in.** The app asks GoTrue to send the
+confirmation link to `/confirmed` and the reset link to `/reset-password`, and
+GoTrue will only honour a `redirect_to` it has been told about. An address that
+is not on the list is not an error: the link still works, the account is still
+confirmed, and the person is dropped on the Site URL instead — which is the front
+door, says nothing about what just happened, and is precisely the behaviour those
+two pages exist to replace. Add them under Authentication → URL Configuration →
+Redirect URLs on a hosted project, or to `additional_redirect_urls` in
+`supabase/config.toml` for a local stack:
+
+```
+https://your-covan.example.com/confirmed
+https://your-covan.example.com/reset-password
+```
+
+A compose stack that leaves `GOTRUE_MAILER_AUTOCONFIRM` on never sends the first
+of those at all, so only the reset URL matters there.
+
 Edit the source rather than the files: `bun run build:email-templates` in
 `worker/` rewrites them, and a test fails if the checked-in copies drift from it.
 `supabase/config.toml` can point a **local** stack at template files, but there is

--- a/docs/team.md
+++ b/docs/team.md
@@ -24,10 +24,20 @@ it. The address is lowercased before it is stored.
 
 **The email is a courtesy, and the row is the invitation.** After the row is
 written, the API emails the invitee through the same Resend account routine
-deliveries use — naming who invited them, which workspace, and which address to
-sign in with. It deliberately carries no link that accepts anything: acceptance
-is matched against the address, so a token in a URL would be a second and weaker
-key to the same door.
+deliveries use — naming who invited them, which workspace, and which address the
+invitation is matched to. It deliberately carries no link that accepts anything:
+acceptance is matched against the address, so a token in a URL would be a second
+and weaker key to the same door.
+
+What it does carry is two ordinary links, to `/sign-up` and to `/sign-in`, and
+it carries both because the sending route cannot tell which one the recipient
+needs: `profiles` is behind a policy scoped to the caller's own workspaces, and
+somebody who has not joined yet is not in one. The button used to be a single
+_Sign in to accept_ pointing at the bare origin, which is a marketing page on a
+hosted Covan and a redirect on a self-hosted one — so an invited person with no
+account landed on a page about the product, holding no password, having just
+been told to sign in. Neither link pre-fills the address, for the reason under
+_Tell them_ below.
 
 If that email fails, or if the deployment has no `RESEND_API_KEY` and
 `RESEND_FROM` — a supported configuration, not a broken one — the invitation
@@ -55,7 +65,9 @@ The URL is the front door, not a key. It carries no token and does not pre-fill
 the address, for the reason above and one more: a link that fills the field in
 gets forwarded in place of the address, and then somebody signs up as themselves
 and cannot see why nothing is waiting. Naming the address in prose keeps it
-visibly the thing that matters. Self-hosted installs get their own origin in
+visibly the thing that matters. The emailed invitation follows the same rule, so
+the two surfaces cannot drift into disagreeing about what a link is allowed to
+know. Self-hosted installs get their own origin in
 that sentence, so it reads `http://localhost:3000/sign-up` where that is true.
 
 The button is offered whether or not the email went out, because this list

--- a/src/components/knowledge-templates.tsx
+++ b/src/components/knowledge-templates.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { Download, FileText } from "lucide-react";
+import { KNOWLEDGE_TEMPLATES, type KnowledgeTemplate } from "@/lib/knowledge-templates";
+import { SectionHeading } from "@/components/page-container";
+
+/**
+ * "What am I supposed to upload?", answered with something you can fill in.
+ *
+ * The Knowledge tab is honest about which file types it accepts and says
+ * nothing about what belongs in one, which is fine for a team with a drive full
+ * of documents and useless for the team that has written nothing down yet. The
+ * gap was reported by somebody evaluating Covan with an empty startup behind
+ * them: the docs page did not make the shape of a good document clear, and what
+ * they asked for was example formats to fill in and upload.
+ *
+ * Downloads, never uploads — `src/lib/knowledge-templates.ts` has the argument.
+ *
+ * `FirstUploads` next door answers the same question one step earlier and for a
+ * different reader: it names four documents a team already has, which is the
+ * right answer when the files exist and nobody has thought to upload them. This
+ * one is for the team that goes looking and finds nothing — a startup two months
+ * old with everything still in people's heads. Both are on this tab; neither
+ * replaces the other, and the copy below says which case it is for so they do
+ * not read as the same advice given twice.
+ *
+ * Open by default only when the agent has nothing, because that is the state
+ * this exists for; once there are documents it collapses to one line and stops
+ * competing with them.
+ */
+export function KnowledgeTemplates({ openByDefault }: { openByDefault: boolean }) {
+  const [open, setOpen] = useState(openByDefault);
+
+  return (
+    <section className="mt-10">
+      <SectionHeading title="Nothing to upload yet?" />
+      <p className="mt-2 text-sm text-muted-foreground">
+        If the files above do not exist yet — nothing written down, everything still in people's
+        heads — these six are the ones that make an agent useful fastest. Download one, fill in the
+        prompts, and drop it back in: a filled-in page of your own words is worth more than a
+        polished document about somebody else's product.
+      </p>
+
+      {open ? (
+        <div className="mt-3 divide-y divide-hairline overflow-hidden rounded-xl border border-border bg-surface">
+          {KNOWLEDGE_TEMPLATES.map((template) => (
+            <div
+              key={template.filename}
+              className="flex items-center gap-3 px-5 py-3.5 text-sm transition-colors duration-200 hover:bg-surface-hover"
+            >
+              <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-medium">{template.title}</div>
+                <div className="text-xs text-muted-foreground">{template.blurb}</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => downloadTemplate(template)}
+                className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-accent"
+                aria-label={`Download ${template.filename}`}
+              >
+                <Download className="h-3.5 w-3.5" />
+                {template.filename}
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="mt-3 rounded-md border border-border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-accent"
+        >
+          Show the six templates
+        </button>
+      )}
+    </section>
+  );
+}
+
+/**
+ * Hand the browser a file it never fetched.
+ *
+ * A blob URL rather than a `data:` one: a data URL of this size is fine, but it
+ * lands in the address bar on some browsers and is subject to the page's CSP,
+ * where an object URL is neither. Revoked on the next frame — revoking in the
+ * same tick cancels the download in Safari, which reads the URL after the click
+ * handler returns.
+ */
+function downloadTemplate(template: KnowledgeTemplate): void {
+  const url = URL.createObjectURL(
+    new Blob([template.body], { type: "text/markdown;charset=utf-8" }),
+  );
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = template.filename;
+  link.click();
+  requestAnimationFrame(() => URL.revokeObjectURL(url));
+}

--- a/src/interface-language.static.test.ts
+++ b/src/interface-language.static.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The interface is in English, all of it.
+ *
+ * Two strings in the brainstorm pane shipped in Turkish — "Fikir Panosu" as the
+ * idea board's heading, "Board'a ekle" on the button under each candidate idea —
+ * and stayed there long enough for somebody to find them by using the product.
+ * They are the residue of building a feature quickly in the language it was
+ * being discussed in, which gives no signal at review time: both read as
+ * deliberate to anyone who speaks Turkish, and neither is near the other in the
+ * file.
+ *
+ * The obvious guard is to look for the letters Turkish has and English does not.
+ * It does not work, and finding that out is the reason this comment is long:
+ * **neither shipped string contains one.** "Fikir Panosu" and "Board'a ekle" are
+ * pure ASCII. A letter check would have passed on the exact two strings it would
+ * have been written to catch.
+ *
+ * So there are three passes, and the letters are the weakest of them:
+ *
+ * 1. The six letters Turkish has and English does not — dotless ı, dotted İ,
+ *    ğ/Ğ, ş/Ş. Narrower than the full alphabet on purpose: ö, ü and ç are shared
+ *    with several languages and turn up in names, and a check that fires on a
+ *    person's name is a check people learn to override.
+ * 2. A short list of Turkish words that are not also English words. Every entry
+ *    is spelled in ASCII, because anything with a Turkish letter in it is
+ *    already caught by the first pass.
+ * 3. An apostrophe followed by a Turkish case suffix — the `Board'a` shape.
+ *    English clitics after an apostrophe are a closed set (`'s`, `'t`, `'re`,
+ *    `'ve`, `'ll`, `'d`, `'m`) and none of them collide.
+ *
+ * Tests are exempt, deliberately: `use-dictation.test.ts` transcribes "merhaba
+ * dünya" and the export tests round-trip "toplantı-notları.md", because
+ * non-ASCII input is exactly what those two exist to prove survives. The rule is
+ * about what the product says, not about what it can carry.
+ */
+
+const SRC = join(import.meta.dirname ?? "src", ".");
+
+const TURKISH_LETTERS = /[ığĞşŞİ]/;
+
+const TURKISH_WORDS = new RegExp(
+  `\\b(${[
+    "fikir",
+    "pano",
+    "panosu",
+    "panoya",
+    "ekle",
+    "ekleyin",
+    "kaydet",
+    "kapat",
+    "iptal",
+    "geri",
+    "hata",
+    "dosya",
+    "belge",
+    "mesaj",
+    "sohbet",
+    "tamam",
+    "evet",
+    "hayir",
+    "merhaba",
+    "bilgi",
+    "listele",
+    "olustur",
+    "gonder",
+    "duzenle",
+    "yukle",
+    "bekleyin",
+    "kullanici",
+    "sifre",
+  ].join("|")})\\b`,
+  "i",
+);
+
+/** `Board'a`, `Covan'da`, `panoya'yı` — a case ending hung off an apostrophe. */
+const TURKISH_SUFFIX = /'(a|e|ya|ye|da|de|ta|te|dan|den|tan|ten|nin|nun|la|le|yi|yu)\b/i;
+
+const SKIP_FILES = new Set(["routeTree.gen.ts"]);
+
+/** Why this line looks Turkish, or null. Exported shape kept simple for the assertion below. */
+function turkishHit(line: string): string | null {
+  if (TURKISH_LETTERS.test(line)) return "letter";
+  const word = TURKISH_WORDS.exec(line);
+  if (word) return `word: ${word[1]}`;
+  const suffix = TURKISH_SUFFIX.exec(line);
+  if (suffix) return `suffix: '${suffix[1]}`;
+  return null;
+}
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    if (SKIP_FILES.has(entry.name)) return [];
+    if (/\.test\.tsx?$/.test(entry.name)) return [];
+    return /\.tsx?$/.test(entry.name) ? [path] : [];
+  });
+}
+
+describe("interface language", () => {
+  it("has no Turkish left in the shipped source", () => {
+    const offenders = sourceFiles(SRC).flatMap((path) =>
+      readFileSync(path, "utf8")
+        .split("\n")
+        .map((line, i) => ({ hit: turkishHit(line), line, n: i + 1 }))
+        .filter(({ hit }) => hit !== null)
+        .map(({ hit, line, n }) => `${path.slice(SRC.length + 1)}:${n} (${hit}): ${line.trim()}`),
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("catches the two strings that shipped, which no letter check would", () => {
+    expect(turkishHit(`<Sparkles /> Fikir Panosu`)).toBe("word: Fikir");
+    expect(turkishHit(`Board'a ekle`)).toBe("word: ekle");
+
+    // The replacements, and the English that has to keep passing around them.
+    expect(turkishHit("Idea board")).toBeNull();
+    expect(turkishHit("Add to board")).toBeNull();
+    expect(turkishHit("Don't have an account?")).toBeNull();
+    expect(turkishHit("the workspace's documents")).toBeNull();
+  });
+});

--- a/src/lib/knowledge-templates.test.ts
+++ b/src/lib/knowledge-templates.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { KNOWLEDGE_TEMPLATES } from "./knowledge-templates";
+import { extOf, validateUpload } from "./uploads";
+
+/**
+ * These files exist to be filled in and uploaded back, so the tests that matter
+ * are the ones about that round trip: the upload gate has to accept what it
+ * hands out, and a template has to be a skeleton rather than a document.
+ */
+describe("knowledge templates", () => {
+  it("hands out files its own upload gate accepts", () => {
+    for (const template of KNOWLEDGE_TEMPLATES) {
+      const size = new TextEncoder().encode(template.body).length;
+
+      expect(extOf(template.filename)).toBe("md");
+      expect(validateUpload({ name: template.filename, size })).toEqual({ ok: true });
+    }
+  });
+
+  it("gives every template a distinct filename, since they land in one folder", () => {
+    const names = KNOWLEDGE_TEMPLATES.map((t) => t.filename);
+
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("asks questions instead of answering them", () => {
+    // A template that reads like a finished document gets uploaded unedited,
+    // and then the agent grounds an answer in somebody else's placeholder
+    // company. Every one of these has to be visibly unfinished: the bracketed
+    // prompt is the signal, and there is at least one under every heading.
+    for (const template of KNOWLEDGE_TEMPLATES) {
+      const headings = template.body.match(/^#{1,2} .+$/gm) ?? [];
+      const prompts = template.body.match(/\[[^\]]+\]/g) ?? [];
+
+      expect(headings.length).toBeGreaterThanOrEqual(3);
+      expect(prompts.length).toBeGreaterThanOrEqual(headings.length - 1);
+    }
+  });
+
+  it("stays small enough to read in one sitting", () => {
+    // Not an arbitrary limit: a template long enough to be a chore is a
+    // template nobody fills in, which is the same outcome as not shipping one.
+    for (const template of KNOWLEDGE_TEMPLATES) {
+      expect(template.body.length).toBeLessThan(1600);
+      expect(template.blurb.length).toBeLessThan(90);
+    }
+  });
+
+  it("covers the six subjects it promises, starting with the company itself", () => {
+    // The order is what somebody reads top to bottom, and the first file should
+    // be the one every other answer leans on.
+    expect(KNOWLEDGE_TEMPLATES.map((t) => t.filename)).toEqual([
+      "company-overview.md",
+      "product-notes.md",
+      "faq.md",
+      "how-we-work.md",
+      "glossary.md",
+      "meeting-notes.md",
+    ]);
+  });
+});

--- a/src/lib/knowledge-templates.ts
+++ b/src/lib/knowledge-templates.ts
@@ -1,0 +1,195 @@
+/**
+ * Six documents to start from, for the account that has nothing to upload yet.
+ *
+ * The Knowledge tab used to answer "what should I put in here?" with a list of
+ * file extensions. That is the answer to a different question. Somebody
+ * evaluating Covan for a team that has not written anything down — which is most
+ * early teams, and exactly the ones an agent that reads what you wrote down is
+ * for — reads `md, txt, csv, json, pdf` and learns nothing about what a good
+ * document *is*. It was reported in those words: the format was not clear even
+ * after reading the docs page, and what was wanted was a form to fill in.
+ *
+ * So these are forms to fill in. Each is a heading structure with a bracketed
+ * prompt under it, and the prompts are questions rather than instructions,
+ * because a question is a thing you can answer in one sitting.
+ *
+ * Three decisions worth not re-deriving:
+ *
+ * **They download rather than upload.** An empty template inside a bundle is
+ * worse than no document: retrieval would match it, the agent would ground an
+ * answer in `[Two or three sentences]`, and the source chip under that answer
+ * would say the file was read. A skeleton has to be filled in somewhere the
+ * agent cannot see it.
+ *
+ * **Each file is one subject.** A bundle is the unit of what an agent can see
+ * (docs/knowledge.md), and a chunk is what a question actually matches. One
+ * enormous "company handbook" retrieves worse than six files, because the
+ * passage that answers a pricing question sits in a document about everything.
+ *
+ * **The prompts ask for prose, not for bullets of nouns.** Retrieval is
+ * similarity between the question's meaning and the passage's, so a line that
+ * reads "Pricing: TBD" matches almost nothing anybody would actually ask.
+ */
+
+export type KnowledgeTemplate = {
+  /** Stable, and used as the download's filename. */
+  filename: string;
+  title: string;
+  /** One line, shown next to the title. Says what the file is for, not what is in it. */
+  blurb: string;
+  body: string;
+};
+
+export const KNOWLEDGE_TEMPLATES: KnowledgeTemplate[] = [
+  {
+    filename: "company-overview.md",
+    title: "Company overview",
+    blurb: "What you do and who for — the file every other answer leans on.",
+    body: `# Company overview
+
+## What we do
+[Two or three sentences a new hire would understand. What the product is, in
+plain words, without the pitch.]
+
+## Who it is for
+[Which kind of company, which role inside it, and what they were doing before
+they found you.]
+
+## The problem we solve
+[What goes wrong for that person without us, described the way they would
+describe it rather than the way we would.]
+
+## How we are different from the alternatives
+[Name the alternatives, including "a spreadsheet" and "nothing". For each one,
+the one thing we do that it does not.]
+
+## What we deliberately do not do
+[The requests we turn down, and why. This is the section that stops an agent
+inventing a feature we do not have.]
+
+## Where we are today
+[Stage, team size, how many customers, what is next. Put a date on it.]
+`,
+  },
+  {
+    filename: "product-notes.md",
+    title: "Product notes",
+    blurb: "What it does, what it cannot do yet, and the limits people hit.",
+    body: `# Product notes
+
+## What the product does
+[The main jobs it performs, one short paragraph each. Order them by how often
+somebody uses them, not by how hard they were to build.]
+
+## How somebody gets started
+[The first five minutes, step by step, as if writing to a customer.]
+
+## Limits and known gaps
+[Sizes, counts, formats, anything that fails. Be specific: "files up to 10 MB"
+beats "large files may not work". An agent that knows the limits stops
+promising things.]
+
+## Things people commonly get wrong
+[The misunderstandings that come up in support, and the correct version of
+each.]
+
+## What is coming, and what is not
+[Only what has been decided. A roadmap the agent reads becomes a promise
+somebody quotes back.]
+`,
+  },
+  {
+    filename: "faq.md",
+    title: "FAQ",
+    blurb: "Real questions with real answers — the highest-value file to upload first.",
+    body: `# FAQ
+
+[Write the questions in the words people actually use, including the clumsy
+ones. Retrieval matches a question against these, so a heading phrased the way
+a customer types it is worth more than a tidy one.]
+
+## [How much does it cost?]
+[The answer, in full. If the answer is "it depends", say what it depends on.]
+
+## [Can I use it with <the tool everyone asks about>?]
+[The answer.]
+
+## [What happens to my data?]
+[The answer.]
+
+## [How do I get support, and how fast do you reply?]
+[The answer.]
+
+## [Question we get every week that is not on this list]
+[The answer.]
+`,
+  },
+  {
+    filename: "how-we-work.md",
+    title: "How we work",
+    blurb: "Process, ownership and tools — what a new teammate asks in week one.",
+    body: `# How we work
+
+## Who owns what
+[Name each area and the person accountable for it. Roles, not org chart.]
+
+## The tools we use, and for what
+[One line each: where code lives, where decisions are written, where customers
+reach us, where money is tracked.]
+
+## How work gets picked up
+[From idea to shipped: who decides, what has to be true before it starts, what
+has to be true before it is called done.]
+
+## Our regular meetings
+[When, who is in them, what each one is for, and what it is not for.]
+
+## Decisions we have already made
+[The arguments we do not want to have again, with the reasoning. This is the
+section that pays for itself.]
+`,
+  },
+  {
+    filename: "glossary.md",
+    title: "Glossary",
+    blurb: "Your internal words, so the agent answers in your vocabulary.",
+    body: `# Glossary
+
+[Every team invents words. An agent that does not know them answers questions
+about something else entirely — and this is the cheapest file here to write.]
+
+## [Term]
+[What it means here specifically, not what it means in general. Note it if the
+wider industry uses the word differently.]
+
+## [Acronym]
+[What it stands for, and when somebody would say it.]
+
+## [A word we use for a thing customers call something else]
+[Both words, and which one to use when writing to a customer.]
+`,
+  },
+  {
+    filename: "meeting-notes.md",
+    title: "Meeting notes",
+    blurb: "A shape to reuse — the notes a team already takes, made retrievable.",
+    body: `# [Meeting name] — [YYYY-MM-DD]
+
+**Present:** [names]
+
+## What we talked about
+[A paragraph per topic. Enough context that this reads correctly in six months
+to somebody who was not there.]
+
+## What we decided
+[One line per decision, with the reason. A decision without its reason gets
+reopened.]
+
+## What we did not decide
+[Open questions, and who is finding out.]
+
+## Next steps
+- [ ] [Who] — [what] — [by when]
+`,
+  },
+];

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthedRouteImport } from './routes/_authed'
+import { Route as ConfirmedRouteImport } from './routes/confirmed'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
@@ -38,6 +39,11 @@ const IndexRoute = IndexRouteImport.update({
 } as any)
 const AuthedRoute = AuthedRouteImport.update({
   id: '/_authed',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ConfirmedRoute = ConfirmedRouteImport.update({
+  id: '/confirmed',
+  path: '/confirmed',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
@@ -144,6 +150,7 @@ const AuthedAgentsAgentIdRoutinesRoutineIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/confirmed': typeof ConfirmedRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -166,6 +173,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/confirmed': typeof ConfirmedRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -189,6 +197,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authed': typeof AuthedRouteWithChildren
+  '/confirmed': typeof ConfirmedRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -213,6 +222,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/confirmed'
     | '/forgot-password'
     | '/privacy'
     | '/reset-password'
@@ -235,6 +245,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/confirmed'
     | '/forgot-password'
     | '/privacy'
     | '/reset-password'
@@ -257,6 +268,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/_authed'
+    | '/confirmed'
     | '/forgot-password'
     | '/privacy'
     | '/reset-password'
@@ -281,6 +293,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthedRoute: typeof AuthedRouteWithChildren
+  ConfirmedRoute: typeof ConfirmedRoute
   ForgotPasswordRoute: typeof ForgotPasswordRoute
   PrivacyRoute: typeof PrivacyRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
@@ -303,6 +316,13 @@ declare module '@tanstack/react-router' {
       path: ''
       fullPath: '/'
       preLoaderRoute: typeof AuthedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/confirmed': {
+      id: '/confirmed'
+      path: '/confirmed'
+      fullPath: '/confirmed'
+      preLoaderRoute: typeof ConfirmedRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/forgot-password': {
@@ -489,6 +509,7 @@ const AuthedRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthedRoute: AuthedRouteWithChildren,
+  ConfirmedRoute: ConfirmedRoute,
   ForgotPasswordRoute: ForgotPasswordRoute,
   PrivacyRoute: PrivacyRoute,
   ResetPasswordRoute: ResetPasswordRoute,

--- a/src/routes/_authed.agents.$agentId.chat.tsx
+++ b/src/routes/_authed.agents.$agentId.chat.tsx
@@ -889,7 +889,7 @@ function ChatTab() {
         <div className="flex h-full flex-col border-l border-border">
           <div className="flex items-center justify-between border-b border-border px-4 py-3">
             <div className="flex items-center gap-2 text-sm font-semibold">
-              <Sparkles className="h-4 w-4 text-muted-foreground" /> Fikir Panosu
+              <Sparkles className="h-4 w-4 text-muted-foreground" /> Idea board
             </div>
             {/* Secondary on purpose: the composer's send is this view's one
                 primary action (DESIGN.md §2). */}
@@ -928,7 +928,7 @@ function ChatTab() {
                       }
                       className="shrink-0 rounded-md border border-border px-2 py-1 text-xs font-medium hover:bg-secondary"
                     >
-                      Board'a ekle
+                      Add to board
                     </button>
                   </div>
                 ))}

--- a/src/routes/_authed.agents.$agentId.knowledge.test.tsx
+++ b/src/routes/_authed.agents.$agentId.knowledge.test.tsx
@@ -117,3 +117,36 @@ describe("a workspace with nothing in it", () => {
     expect(screen.queryByText("Start with four files")).not.toBeInTheDocument();
   });
 });
+
+// The neighbouring answer to the same question, for the team that does not have
+// the four files above either. "Start with four files" names documents you
+// already wrote; this names six you can fill in when you have written none.
+describe("the starter templates on the Knowledge tab", () => {
+  beforeEach(withKnowledge);
+
+  it("opens itself for the agent that has nothing yet", async () => {
+    const documents = store.agents[0].documents;
+    store.agents[0].documents = [];
+    try {
+      await renderTab(true);
+
+      expect(screen.getByLabelText(/download company-overview\.md/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/download faq\.md/i)).toBeInTheDocument();
+    } finally {
+      store.agents[0].documents = documents;
+    }
+  });
+
+  it("collapses once there are real documents, rather than competing with them", async () => {
+    await renderTab(true);
+
+    expect(screen.queryByLabelText(/download company-overview\.md/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /show the six templates/i })).toBeInTheDocument();
+  });
+
+  it("is not offered to a viewer, who could not upload the result", async () => {
+    await renderTab(false);
+
+    expect(screen.queryByText(/nothing to upload yet/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/routes/_authed.agents.$agentId.knowledge.tsx
+++ b/src/routes/_authed.agents.$agentId.knowledge.tsx
@@ -6,6 +6,7 @@ import { PageContainer, PageHeader, SectionHeading } from "@/components/page-con
 import { FirstUploads } from "@/components/first-uploads";
 import { Chip, EmptyState } from "@/components/section-card";
 import { DocsLink } from "@/components/docs-link";
+import { KnowledgeTemplates } from "@/components/knowledge-templates";
 import { RevisitPanel } from "@/components/revisit-panel";
 import { Switch } from "@/components/ui/switch";
 import { Input } from "@/components/ui/input";
@@ -287,8 +288,11 @@ function KnowledgeTab() {
                     dragging ? "text-accent-orange" : "text-muted-foreground",
                   )}
                 />
+                {/* The bundle name was missing from this sentence, which ended
+                    mid-air on "Drop files into " — the one place the interface
+                    says out loud where a file is about to go. */}
                 <div className="font-dm text-[17px] font-medium">
-                  {dragging ? "Drop to upload" : `Drop files into `}
+                  {dragging ? "Drop to upload" : `Drop files into ${selectedBundle.name}`}
                 </div>
                 <div className="text-xs text-muted-foreground">TXT, Markdown, CSV, JSON, PDF</div>
                 <input
@@ -340,7 +344,13 @@ function KnowledgeTab() {
         </section>
       )}
 
-      {/* Section 3 — What the agent actually reads.
+      {/* Section 3 — Starter templates, for the account with nothing to upload.
+          Only where uploading is possible: offering a viewer a form to fill in
+          and then refusing the upload is a worse experience than not offering
+          it. */}
+      {canWrite && <KnowledgeTemplates openByDefault={agent.documents.length === 0} />}
+
+      {/* Section 4 — What the agent actually reads.
           Outside the `canWrite` branch, and outside the bundle selector, because
           it answers a question neither of them is about: what does this agent
           know? `agent.documents` is every document in every bundle attached to

--- a/src/routes/confirmed.test.tsx
+++ b/src/routes/confirmed.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (options: { component: () => React.ReactElement }) => options,
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+const getSession = vi.fn();
+const onAuthStateChange = vi.fn();
+vi.mock("@/lib/supabase/client", () => ({
+  supabase: { auth: { getSession: () => getSession(), onAuthStateChange } },
+}));
+
+/**
+ * The page a confirmation link lands on.
+ *
+ * Its whole job is to say which of three things happened, so the tests are one
+ * per outcome. The one that matters most is the third: before this page
+ * existed, every outcome looked identical, because every outcome was the site's
+ * front door.
+ */
+async function renderConfirmed(url: string) {
+  window.history.replaceState(null, "", url);
+  const { Route } = await import("./confirmed");
+  const Component = (Route as unknown as { component: () => React.ReactElement }).component;
+  render(<Component />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  onAuthStateChange.mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } });
+  getSession.mockResolvedValue({ data: { session: null } });
+});
+
+afterEach(() => {
+  window.history.replaceState(null, "", "/");
+});
+
+describe("the confirmation landing page", () => {
+  it("says the address is confirmed once the link's session arrives", async () => {
+    getSession.mockResolvedValue({ data: { session: { user: { id: "u1" } } } });
+
+    await renderConfirmed("/confirmed#access_token=abc&type=signup");
+
+    expect(await screen.findByText(/address confirmed/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /continue to covan/i })).toHaveAttribute(
+      "href",
+      "/app",
+    );
+  });
+
+  it("takes the session from the auth event when it lands after the first look", async () => {
+    // supabase-js parses the fragment itself, and on a slow exchange
+    // getSession() answers "none" before it has finished. Without the
+    // subscription the page would settle on the neutral state and tell somebody
+    // whose account was just confirmed to go and confirm it.
+    await renderConfirmed("/confirmed#access_token=abc&type=signup");
+
+    const [handler] = onAuthStateChange.mock.calls[0];
+    handler("SIGNED_IN", { user: { id: "u1" } });
+
+    expect(await screen.findByText(/address confirmed/i)).toBeInTheDocument();
+  });
+
+  it("reads an expired link out of the URL and offers the two ways forward", async () => {
+    await renderConfirmed(
+      "/confirmed#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired",
+    );
+
+    expect(screen.getByText(/that link didn't work/i)).toBeInTheDocument();
+    // Decoded, including the `+` that a URL-encoded sentence uses for a space.
+    expect(screen.getByText("Email link is invalid or has expired")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^sign in$/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /send a new link/i })).toBeInTheDocument();
+
+    // Nothing to wait for: the answer was in the URL before React rendered.
+    expect(onAuthStateChange).not.toHaveBeenCalled();
+  });
+
+  it("claims nothing when it was opened without a link behind it", async () => {
+    await renderConfirmed("/confirmed");
+
+    // The tempting shortcut is to treat "no error" as "confirmed". It is a
+    // guess, and it would be presented as a fact about somebody's account.
+    await waitFor(() => expect(screen.getByText(/confirm your address/i)).toBeInTheDocument());
+    expect(screen.queryByText(/address confirmed/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/routes/confirmed.tsx
+++ b/src/routes/confirmed.tsx
@@ -1,0 +1,182 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { ArrowLeft, CheckCircle2 } from "lucide-react";
+import { AuthLayout } from "@/components/auth-layout";
+import { Button } from "@/components/ui/button";
+import { supabase } from "@/lib/supabase/client";
+
+/**
+ * Where the confirmation link in a new account's first email lands.
+ *
+ * It used to land on `/`, because that is what Supabase does when nothing tells
+ * it otherwise: `emailRedirectTo` was never set, so GoTrue fell back to the
+ * project's Site URL. On this build `/` is a redirect that reads the session and
+ * forwards you to the app; on the hosted build it is the marketing page. Either
+ * way the person who just clicked "Confirm my address" is looking at a page that
+ * says nothing about whether the thing they clicked worked. The account was
+ * confirmed. Nothing told them.
+ *
+ * So this page exists to be the answer to one question, and it answers it in
+ * three ways rather than one, because the link can arrive in three states:
+ *
+ * - The session is there — confirmed, and there is a way into the app.
+ * - Supabase put an error in the URL — expired or already used, said plainly,
+ *   with the two things worth trying next.
+ * - Neither — somebody has the URL open without a link behind it. Claiming an
+ *   address was confirmed here would be a guess presented as a fact, so it says
+ *   what it knows instead.
+ *
+ * The mechanics are `reset-password.tsx`'s, and for the same reason: supabase-js
+ * parses the token out of the URL fragment itself (`detectSessionInUrl`, on by
+ * default) before this component's effect ever runs, so the work is to wait for
+ * that and report it, not to do it.
+ *
+ * One deployment step travels with this file: the URL has to be on the project's
+ * redirect allow-list, next to `/reset-password`, or GoTrue ignores it and falls
+ * back to the Site URL — which is exactly the behaviour this replaces, arriving
+ * silently. `docs/self-hosting.md` says where.
+ */
+export const Route = createFileRoute("/confirmed")({
+  component: Confirmed,
+});
+
+/** Supabase reports a rejected link via an error in the URL hash or query. */
+function readUrlError(): string | null {
+  if (typeof window === "undefined") return null;
+  const hash = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+  const query = new URLSearchParams(window.location.search);
+  const desc = hash.get("error_description") ?? query.get("error_description");
+  return desc ? decodeURIComponent(desc.replace(/\+/g, " ")) : null;
+}
+
+function Confirmed() {
+  // Read at mount rather than announced by an effect: the fragment is in the URL
+  // before React renders, so a state that starts as "checking" and flips to
+  // "invalid" a tick later is a spinner nobody needed to see.
+  const [urlError] = useState(readUrlError);
+  const [status, setStatus] = useState<"checking" | "confirmed" | "invalid" | "unknown">(
+    urlError ? "invalid" : "checking",
+  );
+
+  useEffect(() => {
+    if (urlError) return;
+
+    let active = true;
+
+    // Both halves are needed. getSession() resolves after the client has
+    // finished with the URL, which covers the ordinary case; the subscription
+    // covers a token that takes a moment longer to exchange, where getSession()
+    // would otherwise have already answered "none" and settled on `unknown`.
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (active && session) setStatus("confirmed");
+    });
+
+    void supabase.auth.getSession().then(({ data }) => {
+      if (!active) return;
+      setStatus((s) => (data.session ? "confirmed" : s === "checking" ? "unknown" : s));
+    });
+
+    return () => {
+      active = false;
+      subscription.subscription.unsubscribe();
+    };
+  }, [urlError]);
+
+  if (status === "checking") {
+    return (
+      <AuthLayout title="Confirming your address" subtitle="One moment.">
+        <div className="flex min-h-24 items-center justify-center text-sm text-muted-foreground">
+          Loading…
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  if (status === "invalid") {
+    return (
+      <AuthLayout
+        title="That link didn't work"
+        subtitle="It has expired, or it had already been used."
+        footer={
+          <Link
+            to="/sign-in"
+            className="inline-flex items-center gap-1.5 font-medium text-foreground hover:underline"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" /> Back to sign in
+          </Link>
+        }
+      >
+        <div className="flex flex-col items-center gap-3 py-2 text-center">
+          {urlError && <p className="text-sm text-destructive">{urlError}</p>}
+          <p className="text-sm text-muted-foreground">
+            If you have confirmed this address already, sign in. If you have not, signing up again
+            with the same address sends a new link.
+          </p>
+          <div className="mt-1 flex flex-wrap justify-center gap-2">
+            <Button asChild size="sm">
+              <Link to="/sign-in">Sign in</Link>
+            </Button>
+            <Button asChild size="sm" variant="outline">
+              <Link to="/sign-up">Send a new link</Link>
+            </Button>
+          </div>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  if (status === "unknown") {
+    return (
+      <AuthLayout
+        title="Confirm your address"
+        subtitle="This page opens from the link in your confirmation email."
+        footer={
+          <Link
+            to="/sign-in"
+            className="inline-flex items-center gap-1.5 font-medium text-foreground hover:underline"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" /> Back to sign in
+          </Link>
+        }
+      >
+        <div className="flex flex-col items-center gap-3 py-2 text-center">
+          <p className="text-sm text-muted-foreground">
+            Open the email we sent and click the button in it. If you have already confirmed, you
+            can sign in from here.
+          </p>
+          <Button asChild size="sm" className="mt-1">
+            <Link to="/sign-in">Sign in</Link>
+          </Button>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <AuthLayout
+      title="Address confirmed"
+      subtitle="Your account is active and you are signed in."
+      footer={
+        <>
+          Signed in on the wrong account?{" "}
+          <Link to="/sign-in" className="font-medium text-foreground hover:underline">
+            Sign in as someone else
+          </Link>
+        </>
+      }
+    >
+      <div className="flex flex-col items-center gap-3 py-2 text-center">
+        <span className="grid h-11 w-11 place-items-center rounded-full bg-primary/10 text-primary">
+          <CheckCircle2 className="h-5 w-5" />
+        </span>
+        <p className="text-sm text-muted-foreground">
+          If a colleague invited you, the invitation is matched to this address and is waiting
+          inside.
+        </p>
+        <Button asChild size="sm" className="mt-1">
+          <Link to="/app">Continue to Covan</Link>
+        </Button>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/src/routes/sign-up.test.tsx
+++ b/src/routes/sign-up.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+
+const navigate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (options: { component: () => React.ReactElement }) => options,
+  useNavigate: () => navigate,
+  Link: ({ children, ...props }: { children: React.ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+type SignUpResult = { data: { session: { user: { id: string } } | null }; error: null };
+const signUp = vi.fn(async (): Promise<SignUpResult> => ({ data: { session: null }, error: null }));
+vi.mock("@/lib/supabase/client", () => ({ supabase: { auth: { signUp } } }));
+
+vi.mock("@/lib/legal", () => ({
+  termsLink: () => ({ href: "/terms", external: false }),
+  privacyLink: () => ({ href: "/privacy", external: false }),
+}));
+
+async function renderSignUp() {
+  const { Route } = await import("./sign-up");
+  const Component = (Route as unknown as { component: () => React.ReactElement }).component;
+  render(<Component />);
+}
+
+async function fillAndSubmit(user: ReturnType<typeof userEvent.setup>, email = "you@company.com") {
+  await user.type(screen.getByLabelText(/full name/i), "Alex Rivera");
+  await user.type(screen.getByLabelText(/work email/i), email);
+  await user.type(screen.getByLabelText(/^password$/i), "hunter2hunter2");
+  await user.type(screen.getByLabelText(/confirm password/i), "hunter2hunter2");
+  await user.click(screen.getByRole("checkbox"));
+  await user.click(screen.getByRole("button", { name: /create account/i }));
+}
+
+describe("signing up", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    signUp.mockResolvedValue({ data: { session: null }, error: null });
+  });
+
+  // Left unset, GoTrue sends the confirmation link to the project's Site URL —
+  // `/`, which is a marketing page on the hosted build. Confirming worked and
+  // said nothing, which is how it was reported: "no feedback on whether it was
+  // confirmed".
+  it("asks for the confirmation link to come back to a page that reports on it", async () => {
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await fillAndSubmit(user);
+
+    expect(signUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          emailRedirectTo: `${window.location.origin}/confirmed`,
+        }),
+      }),
+    );
+  });
+
+  it("names the inbox it just sent to", async () => {
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await fillAndSubmit(user, "someone@example.com");
+
+    expect(screen.getByText(/check your email/i)).toBeInTheDocument();
+    expect(screen.getByText("someone@example.com")).toBeInTheDocument();
+  });
+
+  it("goes straight in when the deployment confirms nothing", async () => {
+    signUp.mockResolvedValue({ data: { session: { user: { id: "u1" } } }, error: null });
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await fillAndSubmit(user);
+
+    expect(navigate).toHaveBeenCalledWith({ to: "/app" });
+  });
+});

--- a/src/routes/sign-up.tsx
+++ b/src/routes/sign-up.tsx
@@ -19,7 +19,9 @@ function SignUp() {
   const [showPassword, setShowPassword] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [confirmEmailSent, setConfirmEmailSent] = useState(false);
+  // The address, not a boolean: "check your email" is advice, and which inbox to
+  // check is the part of it that is actually information.
+  const [sentTo, setSentTo] = useState<string | null>(null);
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -39,7 +41,16 @@ function SignUp() {
     const { data, error } = await supabase.auth.signUp({
       email,
       password: String(password ?? ""),
-      options: { data: { name } },
+      options: {
+        data: { name },
+        // Without this, GoTrue sends the confirmation link to the project's Site
+        // URL — `/`, which is a redirect here and a marketing page on the hosted
+        // build, and in both cases a page with nothing to say about the click
+        // that led to it. `/confirmed` is that missing sentence. It has to be on
+        // the project's redirect allow-list or GoTrue silently falls back to the
+        // Site URL again; see `src/routes/confirmed.tsx`.
+        emailRedirectTo: `${window.location.origin}/confirmed`,
+      },
     });
     setSubmitting(false);
 
@@ -53,10 +64,10 @@ function SignUp() {
       return;
     }
 
-    setConfirmEmailSent(true);
+    setSentTo(email);
   }
 
-  if (confirmEmailSent) {
+  if (sentTo) {
     return (
       <AuthLayout
         title="Check your email"
@@ -71,8 +82,9 @@ function SignUp() {
         }
       >
         <p className="text-sm text-muted-foreground">
-          We sent a confirmation link to your email address. Click the link to activate your
-          account, then sign in.
+          We sent a confirmation link to{" "}
+          <span className="font-medium text-foreground">{sentTo}</span>. Clicking it activates the
+          account and brings you back signed in.
         </p>
       </AuthLayout>
     );
@@ -131,6 +143,12 @@ function SignUp() {
               className="pl-9"
             />
           </div>
+          {/* No `?email=` prefill here, and the invitation mail does not send
+              one — see `src/lib/invite-text.ts` and docs/team.md. A link that
+              fills the field in gets forwarded in place of the address, and the
+              person who follows it signs up as somebody else. The address is
+              named in prose in the mail instead, where it stays visibly the
+              thing that matters. */}
         </div>
 
         <div className="space-y-1.5">

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -160,7 +160,16 @@ site_url = "http://127.0.0.1:3000"
 # The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
 # external_url = ""
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+# The two paths are the pages that report what a link did: sign-up asks GoTrue to send the
+# confirmation link to /confirmed, and the reset mail lands on /reset-password. An address missing
+# from this list does not fail — GoTrue quietly falls back to site_url, which is the front door and
+# says nothing about the click that led there. Hosted projects keep the same list under
+# Authentication → URL Configuration → Redirect URLs; see docs/self-hosting.md.
+additional_redirect_urls = [
+  "https://127.0.0.1:3000",
+  "http://127.0.0.1:3000/confirmed",
+  "http://127.0.0.1:3000/reset-password",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to auth.external_url.

--- a/supabase/templates/confirm-signup.html
+++ b/supabase/templates/confirm-signup.html
@@ -39,7 +39,7 @@
         <tr>
           <td class="card ink" style="background:#ffffff;border:1px solid #e8e6dd;border-radius:8px;padding:32px 28px">
             <h1 style="margin:0 0 18px;font-family:'DM Sans','Segoe UI',Helvetica,Arial,sans-serif;font-size:22px;font-weight:600;line-height:1.25;letter-spacing:-0.01em;color:#251f19">Confirm your address</h1>
-            <div style="font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif"><p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19">You are one click from a Covan account. Confirming tells us the address is really yours — after that you can sign in.</p><p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19">If a colleague invited you, the invitation is matched to this address and will be waiting once you are in.</p></div>
+            <div style="font-family:Geist,-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif"><p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19">You are one click from a Covan account. Confirming tells us the address is really yours, and the link brings you back to Covan signed in.</p><p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#251f19">If a colleague invited you, the invitation is matched to this address and will be waiting once you are in.</p></div>
             
       <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:8px 0 4px">
         <tr>

--- a/worker/src/lib/emails/auth.ts
+++ b/worker/src/lib/emails/auth.ts
@@ -28,7 +28,7 @@ export const authEmailTemplates = [
       preheader: "Confirm your address to activate your Covan account.",
       heading: "Confirm your address",
       bodyHtml: [
-        `<p style="${P}">You are one click from a Covan account. Confirming tells us the address is really yours — after that you can sign in.</p>`,
+        `<p style="${P}">You are one click from a Covan account. Confirming tells us the address is really yours, and the link brings you back to Covan signed in.</p>`,
         `<p style="${P}">If a colleague invited you, the invitation is matched to this address and will be waiting once you are in.</p>`,
       ].join(""),
       action: { label: "Confirm my address", url: "{{ .ConfirmationURL }}" },

--- a/worker/src/lib/emails/invitation.test.ts
+++ b/worker/src/lib/emails/invitation.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { invitationEmail } from "./invitation";
+
+/**
+ * The invitation mail is the only thing standing between an invited person and
+ * an account, and for a while it pointed them at a page that could not give
+ * them one: the button said "Sign in to accept" and went to the bare origin.
+ * On the hosted build that is the marketing page; the recipient has no
+ * password, because they have never had an account, and nothing on that page
+ * offers to make one.
+ *
+ * These tests hold the two halves of the fix apart, because they pull in
+ * opposite directions and one is easy to "improve" into the other: the mail has
+ * to name a destination that can actually create an account, and it must not
+ * put the address in the URL while doing it.
+ */
+
+const args = {
+  workspaceName: "Northwind",
+  inviterName: "Ali",
+  role: "member",
+  email: "veli@example.com",
+  appUrl: "https://covan.app",
+};
+
+describe("invitationEmail", () => {
+  it("sends somebody with no account to a page that can make them one", () => {
+    const mail = invitationEmail(args);
+
+    expect(mail.text).toContain("https://covan.app/sign-up");
+    // The button itself, by href, not just the string somewhere in the page:
+    // the shell's footer signs every mail with a link to the bare origin, so
+    // "the origin appears in the HTML" is true of a broken mail as well.
+    expect(mail.html).toContain(`href="https://covan.app/sign-up"`);
+  });
+
+  it("offers sign-in as well, because the mail cannot tell who has an account", () => {
+    const mail = invitationEmail(args);
+
+    // `profiles` is behind RLS scoped to the caller's workspaces and an invitee
+    // is not in one, so the sending route genuinely cannot look this up. Two
+    // links is the honest shape.
+    expect(mail.text).toContain("https://covan.app/sign-in");
+    expect(mail.html).toContain("https://covan.app/sign-in");
+  });
+
+  it("keeps the address out of both URLs and in the prose", () => {
+    const mail = invitationEmail(args);
+
+    // Same rule as `src/lib/invite-text.ts`, argued in docs/team.md: a link that
+    // pre-fills the address gets forwarded in place of the address, and then
+    // somebody signs up as themselves and cannot see why nothing is waiting.
+    expect(mail.text).not.toMatch(/sign-(up|in)\?/);
+    expect(mail.html).not.toMatch(/sign-(up|in)\?/);
+    expect(mail.text).not.toMatch(/[?&]email=/);
+    expect(mail.html).not.toMatch(/[?&]email=/);
+
+    expect(mail.text).toContain(args.email);
+    expect(mail.html).toContain(`<strong>${args.email}</strong>`);
+  });
+
+  it("still says everything in the plain-text half on its own", () => {
+    const mail = invitationEmail(args);
+
+    // The HTML is an addition, not the message. A client that strips it must
+    // still leave a reader who knows who invited them, where, and as what.
+    expect(mail.text).toContain("Ali");
+    expect(mail.text).toContain("Northwind");
+    expect(mail.text).toContain("a member");
+    expect(mail.subject).toBe("Ali invited you to Northwind on Covan");
+    expect(mail.to).toBe(args.email);
+  });
+
+  it("says admin when that is the role, since it decides what they can do", () => {
+    expect(invitationEmail({ ...args, role: "admin" }).text).toContain("an admin");
+  });
+});

--- a/worker/src/lib/emails/invitation.ts
+++ b/worker/src/lib/emails/invitation.ts
@@ -11,6 +11,27 @@ import { paragraphs } from "./prose";
  * in a URL would be a second, weaker one guarding the same door. What the
  * recipient needs to know is which address to use; that is what this says.
  *
+ * Where it did not send them, for a long time, is anywhere useful. The button
+ * read "Sign in to accept" and pointed at the bare origin — a marketing page on
+ * the hosted build, a redirect to sign-in on the self-hosted one. Somebody
+ * invited to a product they have never used therefore landed on a page about it,
+ * holding no account and no password, having just been told to sign in. Reported
+ * from outside by a person who could not get in at all.
+ *
+ * So the button goes to `/sign-up`, and a second, named link goes to `/sign-in`
+ * for the recipient who already has an account. Two links rather than a guess:
+ * this route cannot tell which of the two it is writing to, because `profiles`
+ * is behind RLS scoped to the caller's own workspaces and an invitee is by
+ * definition not in one yet.
+ *
+ * Neither URL carries the address, and that is the same rule
+ * `src/lib/invite-text.ts` follows for the copy-paste version — a link that
+ * fills the field in is a link that gets forwarded in place of the address,
+ * after which somebody signs up as themselves and cannot see why nothing is
+ * waiting. The address is in the body in bold, where it stays visibly the thing
+ * that decides whether the invitation is ever found. docs/team.md argues it at
+ * length.
+ *
  * Two halves, not two mails. The text below was the whole message for as long as
  * this route existed, on the reasoning that an HTML mail which renders as a
  * blank card in a client that strips styles is worse than no HTML at all. That
@@ -26,6 +47,8 @@ export function invitationEmail(args: {
   appUrl: string;
 }) {
   const asRole = args.role === "admin" ? "an admin" : "a member";
+  const signUpUrl = `${args.appUrl}/sign-up`;
+  const signInUrl = `${args.appUrl}/sign-in`;
   return {
     to: args.email,
     subject: `${args.inviterName} invited you to ${args.workspaceName} on Covan`,
@@ -40,16 +63,20 @@ export function invitationEmail(args: {
       "Covan is where a team keeps its AI agents: the agents and the knowledge",
       "they read are shared, and your own conversations stay yours.",
       "",
-      "To accept, sign in and the invitation will be waiting:",
+      "Create your account here, and the invitation will be waiting inside:",
       "",
-      `  ${args.appUrl}`,
+      `  ${signUpUrl}`,
       "",
-      "Sign in with the address this was sent to:",
+      "Already have a Covan account? Sign in instead:",
+      "",
+      `  ${signInUrl}`,
+      "",
+      "Either way, use the address this was sent to:",
       "",
       `  ${args.email}`,
       "",
-      "If you do not have an account yet, sign up with that same address — it is",
-      "what the invitation is matched to, so a different one will not find it.",
+      "That address is what the invitation is matched to, so a different one",
+      "will not find it.",
       "",
       "If you were not expecting this, you can ignore it. Nothing happens until",
       "you accept.",
@@ -60,9 +87,10 @@ export function invitationEmail(args: {
       bodyHtml: paragraphs(
         `You have been invited as ${asRole}.`,
         "Covan is where a team keeps its AI agents: the agents and the knowledge they read are shared, and your own conversations stay yours.",
-        `Sign in with <strong>${escapeHtml(args.email)}</strong> — that address is what the invitation is matched to, so a different one will not find it. If you do not have an account yet, sign up with that same address.`,
+        `Sign up with <strong>${escapeHtml(args.email)}</strong> — that address is what the invitation is matched to, so a different one will not find it. The invitation is waiting once you are in.`,
+        `Already have a Covan account? <a href="${escapeHtml(signInUrl)}" style="color:#251f19">Sign in instead</a>.`,
       ),
-      action: { label: "Sign in to accept", url: args.appUrl },
+      action: { label: "Create your account", url: signUpUrl },
       footnote:
         "If you were not expecting this, you can ignore it. Nothing happens until you accept.",
     }),


### PR DESCRIPTION
The first walkthrough by somebody with no context — a friend of the owner, testing on covan.app — and four of its findings were defects in the first five minutes of an account. All four are here.

**The confirmation link had no destination.** `signUp()` never set `emailRedirectTo`, so GoTrue sent the link to the project's Site URL: the landing page on the hosted build, a redirect on this one. Confirming worked and said nothing about having worked. New `/confirmed` route reports one of three things, because the link arrives in three states — the session is there, Supabase put an expiry error in the URL, or the page was opened with no link behind it, where claiming an address was confirmed would be a guess presented as a fact. The "check your email" screen now names the address it sent to.

**The invitation email's button went to the bare origin.** It read "Sign in to accept", so an invitee with no account landed on a page about the product, holding no password, having just been told to sign in. There was no way through. It goes to `/sign-up` now, with a second named link to `/sign-in` for the recipient who already has an account — two links rather than a guess, because `profiles` is behind a policy scoped to the caller's own workspaces and an invitee is by definition not in one. Neither URL carries the address, which is the rule `invite-text.ts` already follows and docs/team.md argues.

**"What do I upload?" was answered with a list of file extensions.** Six starter documents on the Knowledge tab — company overview, product notes, FAQ, how we work, glossary, meeting notes — as headings with a bracketed prompt under each. They download rather than being created in place: an empty template inside a bundle would be matched by retrieval, and the agent would ground an answer in `[Two or three sentences]` with a source chip under it reporting the file as read. This sits beside `FirstUploads` from #92 and answers the next case along: that one names four documents a team already has, this one is for the team that goes looking and finds nothing.

**Two strings shipped in Turkish** — "Fikir Panosu" and "Board'a ekle" in the brainstorm pane. The guard that catches them is not the obvious one: neither string contains a letter Turkish has and English does not, so a letter check would have passed on the exact two strings it would have been written to catch. Three passes instead — the letters, a list of Turkish words that are not also English words, and the `Board'a` shape.

One line away and included: the upload drop zone's sentence ended mid-air on "Drop files into " — the bundle name was never interpolated, in the one place the interface says out loud where a file is about to go.

**One step this cannot do for itself:** `/confirmed` has to be on the project's redirect allow-list (Authentication → URL Configuration → Redirect URLs), or GoTrue ignores it and falls back to the Site URL — silently, and looking exactly like the bug it replaces. Written down in docs/self-hosting.md and in `supabase/config.toml` for the local stack.

Frontend 433 tests, worker 700, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)