### PR TITLE
What an answer actually stood on

### DIFF
--- a/src/lib/chat-messages.test.ts
+++ b/src/lib/chat-messages.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import type { Message } from "@/lib/agents-store";
+import { mergeRealtimeMessage, optimisticId } from "./chat-messages";
+
+const msg = (over: Partial<Message> & { id: string }): Message => ({
+  role: "user",
+  content: "hello",
+  createdAt: 1000,
+  ...over,
+});
+
+describe("mergeRealtimeMessage", () => {
+  it("ignores a message already in the list", () => {
+    const list = [msg({ id: "m1" })];
+    expect(mergeRealtimeMessage(list, msg({ id: "m1" }))).toBe(list);
+  });
+
+  it("appends a peer's message", () => {
+    const out = mergeRealtimeMessage([msg({ id: "m1" })], msg({ id: "m2", createdAt: 2000 }));
+    expect(out.map((m) => m.id)).toEqual(["m1", "m2"]);
+  });
+
+  it("replaces the sender's own optimistic copy instead of showing it twice", () => {
+    // In a shared session your own message comes back over the subscription
+    // under its real id, so it used to sit next to the copy drawn when you
+    // pressed send until the refetch cleared it up.
+    const out = mergeRealtimeMessage(
+      [msg({ id: optimisticId(), content: "how many vacation days?" })],
+      msg({ id: "server-1", content: "how many vacation days?", createdAt: 2000 }),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("server-1");
+  });
+
+  it("keeps an optimistic message that says something else", () => {
+    const out = mergeRealtimeMessage(
+      [msg({ id: optimisticId(), content: "mine" })],
+      msg({ id: "server-1", content: "theirs", createdAt: 2000 }),
+    );
+    expect(out.map((m) => m.content)).toEqual(["mine", "theirs"]);
+  });
+
+  it("does not mistake an assistant reply for an identical question", () => {
+    const out = mergeRealtimeMessage(
+      [msg({ id: optimisticId(), role: "user", content: "ok" })],
+      msg({ id: "server-1", role: "assistant", content: "ok", createdAt: 2000 }),
+    );
+    expect(out).toHaveLength(2);
+  });
+
+  it("inserts by timestamp rather than always at the end", () => {
+    // A local message carries this browser's clock, which can run ahead of the
+    // database's — appending blindly would show the transcript in an order it
+    // will not still be in after the next refetch.
+    const out = mergeRealtimeMessage(
+      [msg({ id: "m1", createdAt: 1000 }), msg({ id: "m3", createdAt: 3000 })],
+      msg({ id: "m2", createdAt: 2000 }),
+    );
+    expect(out.map((m) => m.id)).toEqual(["m1", "m2", "m3"]);
+  });
+});

--- a/src/lib/chat-messages.ts
+++ b/src/lib/chat-messages.ts
@@ -1,0 +1,38 @@
+import type { Message } from "@/lib/agents-store";
+
+/** The id a message is given while it exists only on this screen. */
+export const OPTIMISTIC_PREFIX = "temp-";
+
+export const optimisticId = () => `${OPTIMISTIC_PREFIX}${crypto.randomUUID()}`;
+
+const isOptimistic = (m: Message) => m.id.startsWith(OPTIMISTIC_PREFIX);
+
+/**
+ * Fold a message that arrived over Realtime into the list on screen.
+ *
+ * Two things have to happen here that appending does not do.
+ *
+ * The first is the round trip a sender sees of their own message. It is drawn
+ * optimistically the moment they press send, under a temporary id, and then
+ * comes back over the subscription under its real one — so in a shared session
+ * everyone's own messages appeared twice for as long as the refetch took. The
+ * optimistic copy is the same message and is replaced rather than kept beside
+ * it.
+ *
+ * The second is order. A peer's message can land while a local one is still
+ * only optimistic, and the optimistic row is stamped with this browser's clock,
+ * which is not the database's. Inserting by timestamp rather than appending
+ * keeps the transcript in the order it will still be in after the refetch,
+ * instead of letting it re-shuffle under the reader a moment later.
+ */
+export function mergeRealtimeMessage(list: Message[], incoming: Message): Message[] {
+  if (list.some((m) => m.id === incoming.id)) return list;
+
+  const withoutOptimistic = list.filter(
+    (m) => !(isOptimistic(m) && m.role === incoming.role && m.content === incoming.content),
+  );
+
+  const at = withoutOptimistic.findIndex((m) => m.createdAt > incoming.createdAt);
+  if (at === -1) return [...withoutOptimistic, incoming];
+  return [...withoutOptimistic.slice(0, at), incoming, ...withoutOptimistic.slice(at)];
+}

--- a/src/lib/chat-scroll.test.ts
+++ b/src/lib/chat-scroll.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { isPinnedToBottom, STICK_TOLERANCE_PX } from "./chat-scroll";
+
+const box = (scrollTop: number) => ({ scrollTop, scrollHeight: 2000, clientHeight: 800 });
+
+describe("isPinnedToBottom", () => {
+  it("is true at the bottom", () => {
+    expect(isPinnedToBottom(box(1200))).toBe(true);
+  });
+
+  it("is true within the tolerance, so a few pixels of rounding do not unstick it", () => {
+    expect(isPinnedToBottom(box(1200 - STICK_TOLERANCE_PX))).toBe(true);
+  });
+
+  it("is false once the reader has scrolled up to read something", () => {
+    // The whole point: a streaming reply must not drag the view back down
+    // while someone is reading an earlier answer.
+    expect(isPinnedToBottom(box(400))).toBe(false);
+  });
+
+  it("is true when there is nothing to scroll", () => {
+    expect(isPinnedToBottom({ scrollTop: 0, scrollHeight: 500, clientHeight: 800 })).toBe(true);
+  });
+
+  it("is true past the bottom, where a rubber-banding trackpad leaves it", () => {
+    expect(isPinnedToBottom(box(1400))).toBe(true);
+  });
+});

--- a/src/lib/chat-scroll.ts
+++ b/src/lib/chat-scroll.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether the conversation should keep following its own bottom edge.
+ *
+ * A chat that scrolls to the bottom on every token is right until the moment
+ * someone scrolls up — which is the moment they most want it to hold still.
+ * Reading back over what the agent said two answers ago while a long reply is
+ * streaming was impossible: each token yanked the view back down, so the only
+ * way to read the conversation was to wait for the answer to finish.
+ *
+ * So the view follows the stream only while the reader is already at the
+ * bottom. The tolerance is what makes that usable — "at the bottom" has to
+ * survive a few pixels of rounding, a rubber-banding trackpad, and the growth
+ * of the last line as it wraps.
+ */
+export const STICK_TOLERANCE_PX = 96;
+
+export type ScrollBox = { scrollTop: number; scrollHeight: number; clientHeight: number };
+
+export function isPinnedToBottom(box: ScrollBox, tolerance = STICK_TOLERANCE_PX): boolean {
+  const distanceFromBottom = box.scrollHeight - box.scrollTop - box.clientHeight;
+  return distanceFromBottom <= tolerance;
+}

--- a/src/routes/_authed.agents.$agentId.chat.tsx
+++ b/src/routes/_authed.agents.$agentId.chat.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { Textarea } from "@/components/ui/textarea";
 import { useAgentsStore, type ChatSession, type Message } from "@/lib/agents-store";
-import { api, getAccessToken } from "@/lib/api-client";
+import { ApiError, api, getAccessToken } from "@/lib/api-client";
 import { supabase } from "@/lib/supabase/client";
 import { IdeaBoard } from "@/components/idea-board";
 import {
@@ -31,6 +31,8 @@ import { appendDictation, useDictation } from "@/lib/use-dictation";
 import { useChatUploads } from "@/lib/use-chat-uploads";
 import { useQuota, quotaSentence } from "@/lib/quota";
 import { startersFor } from "@/lib/chat-starters";
+import { isPinnedToBottom } from "@/lib/chat-scroll";
+import { mergeRealtimeMessage, optimisticId } from "@/lib/chat-messages";
 import { SourceChip } from "@/components/source-chip";
 
 export const Route = createFileRoute("/_authed/agents/$agentId/chat")({
@@ -98,11 +100,17 @@ function ChatTab() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["sessions"] }),
   });
 
-  const [suggestions, setSuggestions] = useState<{ title: string; detail: string | null }[]>([]);
+  // Candidate ideas carry a local id rather than being keyed by their title.
+  // The extractor is a language model reading a conversation, and it will
+  // happily propose the same title twice — which collided as a React key, and
+  // meant adding one of them to the board removed both from the list.
+  const [suggestions, setSuggestions] = useState<
+    { id: string; title: string; detail: string | null }[]
+  >([]);
   const suggestMutation = useMutation({
     mutationFn: (sessionId: string) => api.brainstorm.suggest(sessionId),
     onSuccess: (res) => {
-      setSuggestions(res.ideas);
+      setSuggestions(res.ideas.map((idea) => ({ ...idea, id: crypto.randomUUID() })));
       if (res.ideas.length === 0) toast.message("No clear ideas to extract yet.");
     },
     onError: () => toast.error("Could not extract ideas."),
@@ -113,12 +121,13 @@ function ChatTab() {
       title,
       detail,
     }: {
+      id: string;
       sessionId: string;
       title: string;
       detail: string | null;
     }) => api.ideas.create(sessionId, { title, detail: detail ?? undefined }),
     onSuccess: (_i, vars) => {
-      setSuggestions((prev) => prev.filter((s) => s.title !== vars.title));
+      setSuggestions((prev) => prev.filter((s) => s.id !== vars.id));
       void queryClient.invalidateQueries({ queryKey: ["ideas", vars.sessionId] });
       toast.success("Added to the board");
     },
@@ -182,17 +191,15 @@ function ChatTab() {
             created_at: string;
           };
           const key = ["messages", activeId] as const;
-          queryClient.setQueryData<Message[]>(key, (old) => {
-            const list = old ?? [];
-            if (list.some((m) => m.id === row.id)) return list; // dedupe by id
-            const incoming: Message = {
-              id: row.id,
-              role: row.role,
-              content: row.content,
-              createdAt: new Date(row.created_at).getTime(),
-            };
-            return [...list, incoming];
-          });
+          const incoming: Message = {
+            id: row.id,
+            role: row.role,
+            content: row.content,
+            createdAt: new Date(row.created_at).getTime(),
+          };
+          queryClient.setQueryData<Message[]>(key, (old) =>
+            mergeRealtimeMessage(old ?? [], incoming),
+          );
           // Refetch so embedded sender/sources (not in the Realtime payload) fill in.
           void queryClient.invalidateQueries({ queryKey: ["messages", activeId] });
         },
@@ -217,19 +224,51 @@ function ChatTab() {
   const [replyingIn, setReplyingIn] = useState<string | null>(null);
   const [thinking, setThinking] = useState(false);
   const [streamText, setStreamText] = useState("");
+  // The session whose revealed text is waiting for the server's copy to arrive.
+  // Separate from `replyingIn` because the two end at different moments: the
+  // composer is handed back the instant a stream stops, while the text that was
+  // already on screen has to stay there until the refetch replaces it. Both
+  // used to be the same flag, so the "keep it visible" delay below was keeping
+  // nothing visible — the answer blinked out and blinked back 700ms later.
+  const [settlingIn, setSettlingIn] = useState<string | null>(null);
   const streamAbort = useRef<AbortController | null>(null);
   // Tracks the pending reconcile timeout (from `stop()` or the drop-fallback
   // below) so a fast stop→resend can't let a stale timer fire mid-stream.
   const reconcileTimer = useRef<number | null>(null);
+  // A send is in flight. `busy` cannot cover this on its own: it is derived
+  // from state, and the gap between the click and React re-rendering is long
+  // enough to fit a second click — which sent the same question twice.
+  const sending = useRef(false);
   const busy = replyingIn !== null;
 
   useEffect(() => {
-    return () => streamAbort.current?.abort();
+    return () => {
+      streamAbort.current?.abort();
+      if (reconcileTimer.current) window.clearTimeout(reconcileTimer.current);
+    };
   }, []);
 
   const scrollRef = useRef<HTMLDivElement>(null);
+  // Whether the reader is still following the bottom. Kept in a ref rather than
+  // state because it changes on every scroll event and nothing renders from it.
+  const pinned = useRef(true);
   useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      pinned.current = isPinnedToBottom(el);
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
+  // Opening a conversation starts at its end, wherever the last one was left.
+  useEffect(() => {
+    pinned.current = true;
+  }, [active?.id]);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !pinned.current) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
   }, [messages.length, thinking, streamText]);
 
   const invalidateMessages = (sessionId: string) => {
@@ -249,6 +288,7 @@ function ChatTab() {
       reconcileTimer.current = null;
     }
     setReplyingIn(sessionId);
+    setSettlingIn(null);
     setThinking(true);
     setStreamText("");
 
@@ -326,6 +366,11 @@ function ChatTab() {
             setThinking(false);
             partial += event.text;
             setStreamText(partial);
+          } else if (event.type === "truncated") {
+            // The model ran into its output cap. The answer stops mid-thought
+            // and otherwise looks finished, which is the worst way for a reply
+            // to be wrong: nothing on screen says the end is missing.
+            toast.message("That answer hit its length limit — ask it to carry on.");
           } else if (event.type === "done") {
             terminalSeen = true;
             setStreamText("");
@@ -349,8 +394,10 @@ function ChatTab() {
         // drops before a terminal event; keep the revealed text visible until
         // the refetch reconciles so it doesn't flash out.
         const hadPartial = partial.trim().length > 0;
+        setSettlingIn(hadPartial ? sessionId : null);
         if (reconcileTimer.current) window.clearTimeout(reconcileTimer.current);
         reconcileTimer.current = window.setTimeout(() => {
+          setSettlingIn(null);
           setStreamText("");
           invalidateMessages(sessionId);
         }, 700);
@@ -366,6 +413,7 @@ function ChatTab() {
       setStreamText("");
       setThinking(false);
       setReplyingIn(null);
+      setSettlingIn(null);
     } finally {
       streamAbort.current = null;
     }
@@ -385,8 +433,10 @@ function ChatTab() {
     streamAbort.current = null;
     setThinking(false);
     setReplyingIn(null);
+    setSettlingIn(sessionId);
     if (reconcileTimer.current) window.clearTimeout(reconcileTimer.current);
     reconcileTimer.current = window.setTimeout(() => {
+      setSettlingIn(null);
       setStreamText("");
       invalidateMessages(sessionId);
     }, 700);
@@ -394,13 +444,22 @@ function ChatTab() {
 
   const submit = async (raw: string) => {
     const text = raw.trim();
-    if (!text || !active || busy) return;
+    // `sending` as well as `busy`: see the ref's declaration. Two taps on a
+    // starter card, or a double-click on send, used to post the same question
+    // twice — the second one then found the stream already open and returned
+    // without answering it, leaving a question in the transcript that nothing
+    // ever replied to.
+    if (!text || !active || busy || sending.current) return;
+    sending.current = true;
     setInput("");
+    // Sending is a deliberate move to the end of the conversation, even if the
+    // reader had scrolled up.
+    pinned.current = true;
     const sessionId = active.id;
 
     const key = ["messages", sessionId] as const;
     const optimistic: Message = {
-      id: `temp-${crypto.randomUUID()}`,
+      id: optimisticId(),
       role: "user",
       content: text,
       createdAt: Date.now(),
@@ -408,14 +467,24 @@ function ChatTab() {
     queryClient.setQueryData<Message[]>(key, (old = []) => [...old, optimistic]);
 
     try {
-      await api.messages.create({ sessionId, role: "user", content: text });
-    } catch {
-      toast.error("Couldn't send your message.");
+      try {
+        await api.messages.create({ sessionId, role: "user", content: text });
+      } catch {
+        toast.error("Couldn't send your message.");
+        // Hand the words back. The composer was cleared optimistically, so a
+        // failed send used to destroy what had just been typed — the one thing
+        // the person could not get back, and the thing they were most likely
+        // to want after being told to try again. Anything typed in the
+        // meantime wins; this only refills an empty box.
+        setInput((draft) => (draft.trim().length > 0 ? draft : text));
+        invalidateMessages(sessionId);
+        return;
+      }
       invalidateMessages(sessionId);
-      return;
+      await streamReply(sessionId);
+    } finally {
+      sending.current = false;
     }
-    invalidateMessages(sessionId);
-    await streamReply(sessionId);
   };
 
   const send = () => void submit(input);
@@ -441,16 +510,27 @@ function ChatTab() {
     }
     // The last of the eleven in #68, and the one that stays. The other ten were
     // effects copying something into state that could have been read or derived
-    // instead; this one sends a message. `submit` sets state on the way — that
-    // is what the rule sees — but the state is a consequence of the send, not
-    // the point of the effect, and there is nothing to derive it from: the
-    // draft is a handoff from another route, it is deleted as it is read, and
-    // it can only go once the session is loaded and still empty. Doing it
-    // during render would send a message twice under StrictMode.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // instead; this one sends a message. `submit` sets state on the way, but
+    // the state is a consequence of the send, not the point of the effect, and
+    // there is nothing to derive it from: the draft is a handoff from another
+    // route, it is deleted as it is read, and it can only go once the session
+    // is loaded and still empty. Doing it during render would send a message
+    // twice under StrictMode.
     void submit(draft);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active?.id, messages.length, busy]);
+
+  // Rewriting a conversation — regenerating a reply or editing a past turn —
+  // discards every message after the anchor, and the delete policy is keyed to
+  // whoever owns the session. A non-owner reading a shared thread gets a 403,
+  // which is worth reading out rather than flattening into "couldn't update".
+  const rewriteFailed = (e: unknown) => {
+    const message =
+      e instanceof ApiError && e.status === 403
+        ? "Only the person who started this conversation can rewrite it."
+        : "Couldn't update the conversation.";
+    toast.error(message);
+  };
 
   // Regenerate: drop the reply after a user turn and answer it again. The
   // user message is unchanged, so we only need its id to trim after it.
@@ -458,8 +538,8 @@ function ChatTab() {
     if (!active || busy) return;
     try {
       await api.messages.deleteAfter(userMessageId);
-    } catch {
-      toast.error("Couldn't update the conversation.");
+    } catch (e) {
+      rewriteFailed(e);
       invalidateMessages(active.id);
       return;
     }
@@ -481,8 +561,8 @@ function ChatTab() {
     try {
       await api.messages.update(id, text);
       await api.messages.deleteAfter(id);
-    } catch {
-      toast.error("Couldn't update the conversation.");
+    } catch (e) {
+      rewriteFailed(e);
       invalidateMessages(active.id);
       return;
     }
@@ -497,6 +577,12 @@ function ChatTab() {
       () => toast.error("Couldn't copy"),
     );
   };
+  // A mark on a reply, and nothing more: nothing stores it, no endpoint
+  // receives it, and it is gone the moment this component unmounts. It used to
+  // answer with "Thanks for the feedback" — a sentence about somebody having
+  // received something, when nobody had. The highlighted thumb is the whole of
+  // what happens, so it is now the whole of what is claimed. Wiring it to a
+  // real store is a feature, not a fix, and needs a table to put it in.
   const rate = (id: string, v: "up" | "down") => {
     setFeedback((prev) => {
       const next = { ...prev };
@@ -504,7 +590,6 @@ function ChatTab() {
       else next[id] = v;
       return next;
     });
-    toast.success(v === "up" ? "Thanks for the feedback" : "Feedback noted");
   };
 
   const isEmpty = !active || messages.length === 0;
@@ -754,7 +839,15 @@ function ChatTab() {
                         >
                           <ThumbsDown className="h-3.5 w-3.5" />
                         </MsgAction>
-                        {isLast && prevUser && (
+                        {/* Ownership, not role — the same rule as Edit above,
+                            and for the same reason. Regenerating discards
+                            every message after the anchor, and
+                            messages_delete_owner is keyed to whoever owns the
+                            SESSION. Offered to a colleague reading a shared
+                            thread it deleted nothing, reported nothing, and
+                            then failed to answer a question that already had
+                            an answer sitting under it. */}
+                        {isLast && prevUser && isOwner && (
                           <MsgAction
                             label="Regenerate"
                             onClick={() => void regenerate(prevUser.id)}
@@ -768,7 +861,7 @@ function ChatTab() {
                 );
               })}
 
-              {replyingIn === active?.id && (
+              {(replyingIn === active?.id || settlingIn === active?.id) && (
                 <div className="flex flex-col gap-2">
                   <div className="flex items-center gap-2">
                     <AgentAvatar emoji={agent.emoji} className="h-7 w-7 text-sm" />
@@ -794,7 +887,12 @@ function ChatTab() {
                     ) : (
                       <span className="whitespace-pre-wrap text-[15px] leading-relaxed text-foreground">
                         {streamText}
-                        <span className="stream-caret ml-0.5 inline-block h-4 w-[3px] translate-y-0.5 rounded-sm bg-foreground/70 align-middle" />
+                        {/* No caret once the stream has stopped — this text is
+                            waiting to be replaced by the server's copy, not
+                            still arriving. */}
+                        {replyingIn === active?.id && (
+                          <span className="stream-caret ml-0.5 inline-block h-4 w-[3px] translate-y-0.5 rounded-sm bg-foreground/70 align-middle" />
+                        )}
                       </span>
                     )}
                   </div>
@@ -846,7 +944,12 @@ function ChatTab() {
                 <ChatAttach uploads={uploads} canWrite={canWrite} />
                 <ChatMic dictation={dictation} />
               </div>
-              {busy ? (
+              {/* Stop belongs to the conversation that is actually streaming.
+                  There is one stream at a time, so opening a second
+                  conversation while a reply runs used to show a Stop button
+                  over a composer with nothing to stop — and pressing it cut
+                  off the answer in the tab you had just left. */}
+              {replyingIn === active?.id ? (
                 <button
                   onClick={stop}
                   aria-label="Stop generating"
@@ -857,8 +960,9 @@ function ChatTab() {
               ) : (
                 <button
                   onClick={send}
-                  disabled={!input.trim()}
+                  disabled={!input.trim() || busy}
                   aria-label="Send message"
+                  title={busy ? "Waiting for the current reply to finish" : undefined}
                   className="grid h-9 w-9 shrink-0 place-items-center rounded-sm bg-accent-orange text-[#251f19] transition-opacity duration-200 hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   <ArrowUp className="h-4 w-4" />
@@ -910,7 +1014,7 @@ function ChatTab() {
               <div className="flex flex-col gap-1.5">
                 {suggestions.map((s) => (
                   <div
-                    key={s.title}
+                    key={s.id}
                     className="flex items-start justify-between gap-2 rounded-lg border border-border bg-card p-2"
                   >
                     <div className="min-w-0">
@@ -921,6 +1025,7 @@ function ChatTab() {
                       type="button"
                       onClick={() =>
                         addIdeaMutation.mutate({
+                          id: s.id,
                           sessionId: active.id,
                           title: s.title,
                           detail: s.detail,

--- a/worker/src/lib/doc-question.test.ts
+++ b/worker/src/lib/doc-question.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { refersToDocuments, namesDocument } from "./doc-question";
+
+const NAMES = ["Q3 Handbook.pdf", "onboarding.md", "notes.txt"];
+
+describe("refersToDocuments", () => {
+  it.each([
+    "summarize the file",
+    "What's in the document?",
+    "Summarize what you know",
+    "can you read the pdf I uploaded?",
+    "what does the transcript say",
+  ])("says yes to %s", (message) => {
+    expect(refersToDocuments(message, NAMES)).toBe(true);
+  });
+
+  it.each([
+    "dosyayı özetler misin",
+    "yüklediğim belgede ne yazıyor",
+    "bu dokümanın içinde ne var",
+    "ÖZET GEÇER MİSİN",
+  ])("says yes to %s", (message) => {
+    expect(refersToDocuments(message, NAMES)).toBe(true);
+  });
+
+  it.each([
+    "thanks!",
+    "merhaba",
+    "say that again in English",
+    "write me a cold email to a fintech CTO",
+    "who won the world cup in 2018",
+  ])("says no to %s", (message) => {
+    // The ones that were pulling every attached document into the prompt, and
+    // hanging a row of source chips under an answer they had nothing to do
+    // with.
+    expect(refersToDocuments(message, NAMES)).toBe(false);
+  });
+
+  it("recognises every starter card an empty conversation offers", () => {
+    // Verbatim from src/lib/chat-starters.ts. Those cards exist to produce a
+    // first answer with a citation on it — the fastest path through a new
+    // agent — so one of them falling outside this heuristic silently undoes
+    // the feature. "Draft something for me" is deliberately absent: it asks
+    // for writing, not for a document.
+    const starters = [
+      "What does handbook.md say?",
+      "What do these documents have in common?",
+      "Summarize what you know",
+      "What should I know that I haven't asked about?",
+    ];
+    for (const starter of starters) {
+      expect(refersToDocuments(starter, ["handbook.md"]), starter).toBe(true);
+    }
+  });
+
+  it("says yes when the question names a file", () => {
+    expect(refersToDocuments("what does onboarding.md say?", NAMES)).toBe(true);
+    expect(refersToDocuments("anything about Q3 Handbook?", NAMES)).toBe(true);
+  });
+
+  it("does not fire on a name too short to be distinctive", () => {
+    // "cv" or "q3" appear inside ordinary sentences; treating them as
+    // filenames would put the fallback back where it started.
+    expect(refersToDocuments("I have a cv of the situation", ["cv.pdf"])).toBe(false);
+  });
+
+  it("says no when there is nothing to say it about", () => {
+    expect(refersToDocuments("", NAMES)).toBe(false);
+    expect(refersToDocuments("   ", NAMES)).toBe(false);
+  });
+
+  it("still recognises a keyword when the agent has no documents", () => {
+    // The caller checks `hasKnowledge` separately; this must not depend on it.
+    expect(refersToDocuments("summarize the file", [])).toBe(true);
+  });
+});
+
+describe("namesDocument", () => {
+  it("matches with or without the extension", () => {
+    expect(namesDocument("what does onboarding.md say", "onboarding.md")).toBe(true);
+    expect(namesDocument("what does onboarding say", "onboarding.md")).toBe(true);
+  });
+
+  it("is case insensitive across the Turkish dotted I", () => {
+    expect(namesDocument("İŞE ALIM notlarında ne var", "işe alım.md")).toBe(true);
+  });
+
+  it("does not match a different file", () => {
+    expect(namesDocument("what does onboarding.md say", "notes.txt")).toBe(false);
+  });
+});

--- a/worker/src/lib/doc-question.ts
+++ b/worker/src/lib/doc-question.ts
@@ -1,0 +1,129 @@
+/**
+ * Is this turn asking about the agent's documents?
+ *
+ * The question exists because of the fallback in `routes/chat.ts`. Semantic
+ * retrieval misses a whole class of legitimate question — "summarize the file",
+ * "what's in the doc" — because they are *about* a document rather than about
+ * anything written in one, so they embed near no single passage and every chunk
+ * falls under the similarity floor. The fallback answers that by grounding on
+ * the documents' stored text directly.
+ *
+ * Firing it on *every* miss is what went wrong. "thanks", "merhaba", "rewrite
+ * that in English" all miss too, and each one was pulling the agent's files
+ * into the prompt, paying for them, and — because the fallback also recorded
+ * them — hanging a row of source chips under an answer that came from nothing
+ * but the persona. So the fallback now needs a reason.
+ *
+ * The trade this makes: a content question that genuinely misses the floor gets
+ * no grounding rather than the newest few thousand characters of whatever
+ * happens to be attached. That is the better failure. The dumped text was not
+ * selected for relevance to the question — it was selected for being recent —
+ * so it answered the question only by luck, and `RAG_MIN_SIMILARITY` is the
+ * dial that exists for a floor set too high.
+ *
+ * Turkish and English both, because the product is used in both, and a
+ * heuristic that only understood one would silently switch the feature off for
+ * half its users.
+ */
+
+/**
+ * Stems, matched as substrings so suffixes come free: "dosyada", "dosyanın"
+ * and "dosyayı" all follow from "dosya", and "documents" from "document".
+ * Deliberately narrow — a word that shows up in ordinary conversation ("rapor",
+ * "note", "text") would re-open the behaviour this exists to close.
+ */
+const DOCUMENT_WORDS = [
+  // English
+  "file",
+  "document",
+  "the doc",
+  "docs",
+  "pdf",
+  "upload",
+  "attach",
+  "summar", // summary, summarize, summarise
+  "transcript",
+  "spreadsheet",
+  "csv",
+  "knowledge base",
+  "what you know",
+  "what does it say",
+  "what's in it",
+  "whats in it",
+  // The starter cards an empty conversation offers (src/lib/chat-starters.ts).
+  // They are written to produce a first answer with a citation on it, so the
+  // ones that do not happen to contain the word "document" have to be
+  // recognised here or the whole point of them is lost.
+  "should i know",
+  // Turkish
+  "dosya",
+  "belge",
+  "doküman",
+  "dokuman",
+  "özet",
+  "ozet",
+  "yükledi", // yükledim, yüklediğim
+  "yukledi",
+  "yüklediğ",
+  "ne diyor",
+  "ne yazıyor",
+  "ne yaziyor",
+  "içinde ne",
+  "icinde ne",
+  "neler var",
+  "bilmem gereken",
+  "ne bilmeliyim",
+];
+
+/**
+ * A filename is only a signal when it is distinctive. Two- and three-character
+ * stems ("ai", "q3", "cv") appear inside ordinary words often enough that
+ * matching them would fire on almost every sentence.
+ */
+const MIN_NAME_STEM = 4;
+
+/**
+ * Lowercase, with Turkish's four I's collapsed onto one.
+ *
+ * JavaScript lowercases by Unicode's default rules, not Turkish's: "İ" becomes
+ * "i" plus a combining dot (U+0307), and "I" becomes "i" where Turkish would
+ * make it "ı". So "İŞE ALIM" lowercases to "i̇şe alim" and stops matching a file
+ * called "işe alım.md" — over a letter, in the language half the users type in.
+ * Folding i/ı/İ/I together costs nothing here (this is a keyword match, not a
+ * display name) and makes all four spellings the same string.
+ *
+ * Needles are folded with the same function, so both sides agree.
+ */
+function fold(value: string): string {
+  return value.toLowerCase().replace(/̇/g, "").replace(/ı/g, "i");
+}
+
+const DOCUMENT_NEEDLES = DOCUMENT_WORDS.map(fold);
+
+/** "Q3 Handbook.pdf" -> ["q3 handbook.pdf", "q3 handbook"] */
+function nameNeedles(name: string): string[] {
+  const full = fold(name).trim();
+  if (!full) return [];
+  const stem = full.replace(/\.[a-z0-9]{1,8}$/, "");
+  return stem && stem !== full ? [full, stem] : [full];
+}
+
+/** Whether this message names this particular document. */
+export function namesDocument(message: string, docName: string): boolean {
+  const text = fold(message);
+  if (!text.trim()) return false;
+  return nameNeedles(docName).some(
+    (needle) => needle.length >= MIN_NAME_STEM && text.includes(needle),
+  );
+}
+
+export function refersToDocuments(message: string, docNames: readonly string[]): boolean {
+  const text = fold(message);
+  if (!text.trim()) return false;
+
+  if (DOCUMENT_NEEDLES.some((word) => text.includes(word))) return true;
+
+  // Naming a file is the strongest signal there is, and the one the starter
+  // prompts on an empty conversation lean on ("What does handbook.md say?").
+  return docNames.some((name) => namesDocument(message, name));
+}

--- a/worker/src/lib/prompt.test.ts
+++ b/worker/src/lib/prompt.test.ts
@@ -6,6 +6,7 @@ import {
   BRAINSTORM_INSTRUCTIONS,
   CONCISION_INSTRUCTIONS,
   DEFAULT_PERSONA,
+  MANIFEST_NAME_LIMIT,
 } from "./prompt";
 
 describe("buildSystemPrefix", () => {
@@ -32,6 +33,38 @@ describe("buildSystemPrefix", () => {
     const out = buildSystemPrefix({ persona: "P", mode: "normal", docNames: ["a.md", "b.md"] });
     expect(out).toContain("a.md, b.md");
     expect(out).toContain("never claim you cannot read files");
+  });
+
+  it("tells the agent excerpts only arrive when retrieval finds them", () => {
+    // The prefix is byte-identical on every turn, including the ones where
+    // nothing was retrieved and no excerpt block follows. Promising the
+    // contents "below" on those turns named a file, attached nothing, and left
+    // the model to fill the gap.
+    const out = buildSystemPrefix({ persona: "P", mode: "normal", docNames: ["a.md"] });
+    expect(out).toContain("whenever retrieval finds them");
+    expect(out).toContain("rather than inventing what it contains");
+    expect(out).not.toContain("provided below");
+  });
+
+  it("counts the tail of a long document list instead of naming all of it", () => {
+    const names = Array.from({ length: MANIFEST_NAME_LIMIT + 7 }, (_, i) => `doc-${i}.md`);
+    const out = buildSystemPrefix({ persona: "P", mode: "normal", docNames: names });
+    expect(out).toContain("doc-0.md");
+    expect(out).toContain(`doc-${MANIFEST_NAME_LIMIT - 1}.md`);
+    expect(out).not.toContain(`doc-${MANIFEST_NAME_LIMIT}.md`);
+    expect(out).toContain("and 7 more");
+  });
+
+  it("names every document while the list is short enough to be useful", () => {
+    const names = Array.from({ length: MANIFEST_NAME_LIMIT }, (_, i) => `doc-${i}.md`);
+    const out = buildSystemPrefix({ persona: "P", mode: "normal", docNames: names });
+    expect(out).toContain(`doc-${MANIFEST_NAME_LIMIT - 1}.md`);
+    expect(out).not.toContain("more");
+  });
+
+  it("ignores blank document names rather than listing a gap", () => {
+    const out = buildSystemPrefix({ persona: "P", mode: "normal", docNames: ["", "  "] });
+    expect(out).not.toContain("The team has shared");
   });
 
   it("omits the manifest when there are no documents", () => {

--- a/worker/src/lib/prompt.ts
+++ b/worker/src/lib/prompt.ts
@@ -40,11 +40,43 @@ export const CONCISION_INSTRUCTIONS = [
   "Expand freely when the user asks for detail, or when the subject genuinely requires it — brevity must never cost accuracy or omit a caveat that matters.",
 ].join("\n");
 
+/**
+ * How many filenames the manifest names before it starts counting instead.
+ *
+ * The manifest rides in the cacheable prefix, so its cost is amortised rather
+ * than per-turn — but a workspace with three hundred documents would still push
+ * the model's context out with a list nobody reads. Forty names is enough for
+ * the manifest's actual job: letting the agent recognise a file when the user
+ * names one.
+ */
+export const MANIFEST_NAME_LIMIT = 40;
+
+/**
+ * The line that tells the agent which files it has.
+ *
+ * The wording matters more than it looks. This sits in the *cacheable* prefix,
+ * which is byte-identical on every turn — including the turns where retrieval
+ * found nothing and no excerpt block follows it. The previous version pointed
+ * at "the shared knowledge provided below" unconditionally, so on those turns
+ * it named a document, promised its contents were attached, attached nothing,
+ * and left the model to fill the gap. Saying that excerpts arrive *when
+ * retrieval finds them* is true on both kinds of turn, and gives the model
+ * somewhere honest to go when they don't.
+ */
 const MANIFEST = (names: string) =>
-  `\n\nYou have access to the following team documents: ${names}. ` +
-  `When the user refers to "the file", "the document", "the video", or asks you to ` +
-  `summarize or explain what was uploaded, use the shared knowledge provided below — ` +
-  `never claim you cannot read files.`;
+  `\n\nThe team has shared these documents with you: ${names}. ` +
+  `When the user says "the file", "the document", "the video", or asks what was ` +
+  `uploaded, they mean one of these — never claim you cannot read files. ` +
+  `Relevant excerpts are supplied in a separate system message whenever retrieval ` +
+  `finds them; answer from those. If no excerpt is present, say which of these ` +
+  `documents you would need to look at rather than inventing what it contains.`;
+
+function manifestNames(names: string[]): string {
+  if (names.length <= MANIFEST_NAME_LIMIT) return names.join(", ");
+  const shown = names.slice(0, MANIFEST_NAME_LIMIT).join(", ");
+  const rest = names.length - MANIFEST_NAME_LIMIT;
+  return `${shown}, and ${rest} more`;
+}
 
 export function buildSystemPrefix(input: {
   persona: string | null;
@@ -60,8 +92,9 @@ export function buildSystemPrefix(input: {
   } else {
     prefix += `\n\n${CONCISION_INSTRUCTIONS}`;
   }
-  if (input.docNames.length > 0) {
-    prefix += MANIFEST(input.docNames.join(", "));
+  const names = input.docNames.filter((n) => n && n.trim().length > 0);
+  if (names.length > 0) {
+    prefix += MANIFEST(manifestNames(names));
   }
   return prefix;
 }

--- a/worker/src/lib/rag.test.ts
+++ b/worker/src/lib/rag.test.ts
@@ -1,17 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { buildContextBlock, ragMinSimilarity, DEFAULT_RAG_MIN_SIMILARITY } from "./rag";
+import {
+  buildContextBlock,
+  ragMinSimilarity,
+  retrievalQuery,
+  DEFAULT_RAG_MIN_SIMILARITY,
+} from "./rag";
 
 describe("buildContextBlock", () => {
   it("returns empty string when no chunks", () => {
-    expect(buildContextBlock([])).toBe("");
+    expect(buildContextBlock([])).toEqual({ text: "", used: [] });
   });
 
   it("includes document names and content", () => {
     const out = buildContextBlock([
       { documentName: "handbook.md", content: "vacation policy is 20 days" },
     ]);
-    expect(out).toContain("handbook.md");
-    expect(out).toContain("vacation policy is 20 days");
+    expect(out.text).toContain("handbook.md");
+    expect(out.text).toContain("vacation policy is 20 days");
   });
 
   it("stops adding chunks once the budget is exhausted", () => {
@@ -21,11 +26,134 @@ describe("buildContextBlock", () => {
         { documentName: "a", content: big },
         { documentName: "b", content: big },
       ],
+      5400,
+    );
+    expect(out.text).toContain("Document: a");
+    expect(out.text).not.toContain("Document: b");
+  });
+
+  it("keeps the whole block inside the budget it was given", () => {
+    // Framing used to be free: the header, the "Document: name" lines and the
+    // separators were all added on top of the budget, so a block asked for
+    // 4000 chars came back at 4300 and the cost of a turn was consistently
+    // under-counted.
+    const big = "x".repeat(5000);
+    const out = buildContextBlock(
+      [
+        { documentName: "a", content: big },
+        { documentName: "b", content: big },
+      ],
       6000,
     );
-    // second chunk's full content should not fully fit
-    expect(out.length).toBeLessThanOrEqual(6000 + 500); // + framing overhead
-    expect(out).toContain("a");
+    expect(out.text.length).toBeLessThanOrEqual(6000);
+  });
+
+  it("reports only the chunks it actually admitted", () => {
+    // The whole reason `used` exists. Sources on a reply are drawn from this
+    // list, and a document whose passage was dropped for space grounded
+    // nothing — citing it puts a chip under an answer that never saw it.
+    const big = "x".repeat(5000);
+    const out = buildContextBlock(
+      [
+        { documentId: "d1", documentName: "a", content: big },
+        { documentId: "d2", documentName: "b", content: big },
+        { documentId: "d3", documentName: "c", content: big },
+      ],
+      5400,
+    );
+    expect(out.used.map((u) => u.documentId)).toEqual(["d1"]);
+  });
+
+  it("admits a short document whole rather than dropping it for a long one's leftovers", () => {
+    const out = buildContextBlock(
+      [
+        { documentName: "short", content: "20 days" },
+        { documentName: "long", content: "x".repeat(5000) },
+      ],
+      1200,
+    );
+    expect(out.text).toContain("20 days");
+    expect(out.used.map((u) => u.documentName)).toEqual(["short", "long"]);
+  });
+
+  it("refuses to admit a fragment too small to answer anything", () => {
+    // Sending forty characters of a document costs its framing, cannot answer
+    // the question, and still claims the citation.
+    const out = buildContextBlock(
+      [
+        { documentName: "a", content: "x".repeat(900) },
+        { documentName: "b", content: "y".repeat(900) },
+      ],
+      1000,
+    );
+    expect(out.used.map((u) => u.documentName)).toEqual(["a"]);
+  });
+
+  it("marks a passage that was cut, so the model knows it did not end there", () => {
+    const out = buildContextBlock([{ documentName: "a", content: "x".repeat(5000) }], 1000);
+    expect(out.text).toContain("[truncated]");
+  });
+
+  it("skips a chunk with no content instead of citing an empty document", () => {
+    const out = buildContextBlock([
+      { documentId: "d1", documentName: "empty.md", content: "   " },
+      { documentId: "d2", documentName: "real.md", content: "the answer" },
+    ]);
+    expect(out.used.map((u) => u.documentId)).toEqual(["d2"]);
+    expect(out.text).not.toContain("empty.md");
+  });
+
+  it("returns nothing when the budget cannot even hold the header", () => {
+    const out = buildContextBlock([{ documentName: "a", content: "hello" }], 10);
+    expect(out).toEqual({ text: "", used: [] });
+  });
+});
+
+describe("retrievalQuery", () => {
+  it("embeds a self-contained question on its own", () => {
+    const question = "What is the vacation policy for new joiners in the Istanbul office?";
+    expect(retrievalQuery([{ role: "user", content: question }])).toBe(question);
+  });
+
+  it("carries the previous question into a follow-up that has no subject", () => {
+    // "peki ikinci maddesi?" embeds near nothing on its own, so retrieval
+    // returned nothing and the agent lost a document it had been reading
+    // correctly one turn earlier.
+    const out = retrievalQuery([
+      { role: "user", content: "Summarize the vacation policy in handbook.md" },
+      { role: "assistant", content: "It gives 20 days, accrued monthly, plus public holidays." },
+      { role: "user", content: "peki ikinci maddesi?" },
+    ]);
+    expect(out).toContain("handbook.md");
+    expect(out).toContain("peki ikinci maddesi?");
+  });
+
+  it("reaches past the assistant for the antecedent, not into it", () => {
+    // The assistant's reply is long and full of its own vocabulary; letting it
+    // into the vector would drown the question rather than complete it.
+    const out = retrievalQuery([
+      { role: "user", content: "What does the onboarding checklist cover?" },
+      { role: "assistant", content: "Laptops, badges, payroll forms and the buddy programme." },
+      { role: "user", content: "and the third one?" },
+    ]);
+    expect(out).toContain("onboarding checklist");
+    expect(out).not.toContain("buddy programme");
+  });
+
+  it("leaves a short first question alone when there is nothing before it", () => {
+    expect(retrievalQuery([{ role: "user", content: "hi" }])).toBe("hi");
+  });
+
+  it("caps what it hands the embedding model", () => {
+    // A pasted contract is longer than text-embedding-3-small's own context
+    // window: the call 400s, chat.ts logs "retrieval failed", and the answer
+    // comes back ungrounded with nothing on screen to explain why.
+    const out = retrievalQuery([{ role: "user", content: "x".repeat(50_000) }]);
+    expect(out.length).toBeLessThanOrEqual(4000);
+  });
+
+  it("returns nothing for no turns at all", () => {
+    expect(retrievalQuery([])).toBe("");
   });
 });
 

--- a/worker/src/lib/rag.ts
+++ b/worker/src/lib/rag.ts
@@ -1,4 +1,25 @@
-export type RetrievedChunk = { documentName: string; content: string };
+export type RetrievedChunk = {
+  /**
+   * The document this passage came from. Optional only because one caller
+   * (the whole-document fallback) has the row rather than a chunk; when it is
+   * absent the citation falls back to the name, which is what pre-0005 replies
+   * already do.
+   */
+  documentId?: string | null;
+  documentName: string;
+  content: string;
+};
+
+/**
+ * What went into the prompt, and what may therefore be cited.
+ *
+ * `used` is the point of this type. The block has a char budget and drops
+ * whatever does not fit, so the list of candidates and the list of documents
+ * that actually grounded the answer are different lists — and the caller was
+ * citing the first one. An agent with a dozen files answered every question
+ * with a dozen source chips, most of them naming text the model never saw.
+ */
+export type ContextBlock = { text: string; used: RetrievedChunk[] };
 
 /**
  * The cosine-similarity floor, below which a chunk is treated as irrelevant.
@@ -30,28 +51,122 @@ export function ragMinSimilarity(env: { RAG_MIN_SIMILARITY?: string }): number {
   return n;
 }
 
+/**
+ * Below this length a question is treated as a follow-up rather than a question
+ * that stands on its own. "peki ikinci maddesi?" is 20 characters and means
+ * nothing to an embedding model; the turn before it is where its subject is.
+ */
+const FOLLOW_UP_CHARS = 80;
+
+/** How much of the preceding question to carry, when one is carried. */
+const ANTECEDENT_CHARS = 400;
+
+/**
+ * Hard cap on what is embedded. The embedding models have a context window of
+ * their own (8k tokens for text-embedding-3-small), and a pasted contract sails
+ * past it — the call 400s, `chat.ts` catches it as "retrieval failed", and the
+ * answer comes back ungrounded with nothing on screen to say why. The first
+ * few thousand characters of a question are the question anyway.
+ */
+const QUERY_CHARS = 4000;
+
+/**
+ * The text to embed for this turn's retrieval.
+ *
+ * The latest message alone is the obvious choice and it is wrong for exactly
+ * the questions people ask most in a conversation: "and the second one?",
+ * "peki ya maliyeti?", "why?". They carry no nouns, so they embed near nothing,
+ * so retrieval returns nothing, so the agent loses the thread halfway through a
+ * conversation about a document it had been reading correctly. Short turns get
+ * the previous question prepended to supply the missing subject; long ones
+ * stand on their own and are left alone, since padding them would only dilute
+ * the vector.
+ *
+ * `turns` arrive oldest-first, ending with the message being answered.
+ */
+export function retrievalQuery(turns: { role: "user" | "assistant"; content: string }[]): string {
+  const latest = turns[turns.length - 1];
+  if (!latest) return "";
+  const question = latest.content.trim();
+  if (question.length >= FOLLOW_UP_CHARS) return question.slice(0, QUERY_CHARS);
+
+  const antecedent = turns
+    .slice(0, -1)
+    .reverse()
+    .find((t) => t.role === "user" && t.content.trim().length > 0);
+  if (!antecedent) return question.slice(0, QUERY_CHARS);
+
+  return `${antecedent.content.trim().slice(0, ANTECEDENT_CHARS)}\n${question}`.slice(
+    0,
+    QUERY_CHARS,
+  );
+}
+
 const HEADER =
   "The team has shared the following knowledge. Use it to ground your answers. " +
   "Answer naturally in your own words — do not cite, quote, or mention the document " +
   "names, filenames, or that these documents were provided; the interface shows " +
   "sources separately:\n\n";
 
+const SEPARATOR = "\n\n---\n\n";
+const TRUNCATION_MARK = "\n…[truncated]";
+
+/**
+ * The least amount of a passage worth sending. Below this a chunk is a
+ * sentence fragment: it cannot answer anything, it still costs its framing,
+ * and — the part that actually mattered — it still put the document's name in
+ * the citations, so an answer claimed a source on the strength of forty
+ * characters the model could not use.
+ */
+const MIN_USEFUL_EXCERPT = 200;
+
 /**
  * Assembles retrieved chunks into a system-prompt context block under a total
- * char budget. Chunks are added newest-relevance-first (caller passes them in
- * similarity order); once the budget is exhausted, remaining chunks are dropped.
- * Returns "" when there is nothing to add (caller then skips the block).
+ * char budget, and reports which of them fitted.
+ *
+ * Chunks are added most-relevant-first (the caller passes them in similarity
+ * order) and the budget covers the whole block — header, per-document framing
+ * and separators included, which it did not before, so a block asked for 4000
+ * chars no longer returns 4300. Once what is left cannot hold a useful excerpt
+ * the rest are dropped rather than admitted as fragments; they are the least
+ * relevant ones by construction.
+ *
+ * `text` is "" when nothing fits, and `used` is empty with it — the caller
+ * skips the block and cites nothing.
  */
-export function buildContextBlock(chunks: RetrievedChunk[], budget = 4000): string {
-  if (chunks.length === 0) return "";
-  let remaining = budget;
+export function buildContextBlock(chunks: RetrievedChunk[], budget = 4000): ContextBlock {
+  const empty: ContextBlock = { text: "", used: [] };
+  if (chunks.length === 0) return empty;
+
+  let remaining = budget - HEADER.length;
   const blocks: string[] = [];
+  const used: RetrievedChunk[] = [];
+
   for (const ch of chunks) {
-    if (remaining <= 0) break;
-    const body = ch.content.slice(0, remaining);
-    remaining -= body.length;
+    const content = ch.content.trim();
+    if (!content || !ch.documentName) continue;
+
+    const frame =
+      `Document: ${ch.documentName}\n`.length + (blocks.length > 0 ? SEPARATOR.length : 0);
+    const room = remaining - frame;
+    // A short document is admitted whole whenever there is room for it; a long
+    // one only when enough of it survives to be worth reading.
+    if (room < Math.min(MIN_USEFUL_EXCERPT, content.length)) break;
+
+    let body: string;
+    if (content.length <= room) {
+      body = content;
+    } else {
+      const keep = Math.max(0, room - TRUNCATION_MARK.length);
+      if (keep < MIN_USEFUL_EXCERPT) break;
+      body = content.slice(0, keep) + TRUNCATION_MARK;
+    }
+
+    remaining -= frame + body.length;
     blocks.push(`Document: ${ch.documentName}\n${body}`);
+    used.push(ch);
   }
-  if (blocks.length === 0) return "";
-  return HEADER + blocks.join("\n\n---\n\n");
+
+  if (blocks.length === 0) return empty;
+  return { text: HEADER + blocks.join(SEPARATOR), used };
 }

--- a/worker/src/routes/chat.test.ts
+++ b/worker/src/routes/chat.test.ts
@@ -1,0 +1,397 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type OpenAI from "openai";
+import type { AppEnv } from "../types";
+import { fakeDb, type FakeDbSpec, type QueryContext } from "../test-support/fake-db";
+import { chat } from "./chat";
+
+/**
+ * What this file is for: the citations under an answer, and what it costs to
+ * produce one.
+ *
+ * The retrieval pieces are unit-tested next door (rag, doc-question, prompt).
+ * The bug they were extracted from was not in any of them — it was in how this
+ * route wired them together. It cited every candidate rather than every
+ * candidate that fitted, and it fell back to reading whole documents on turns
+ * that had nothing to do with any document. Both are only visible from here,
+ * with a real request going through a real handler.
+ */
+
+const USER = { id: "user-1", email: "a@example.com" };
+const SESSION = { id: "sess-1", agent_id: "agent-1", kind: "chat" };
+const AGENT = { id: "agent-1", persona: "You are our PM.", model: null, mode: "normal" };
+
+const embedTexts = vi.fn();
+const completionCreate = vi.fn();
+const serviceInsert = vi.fn();
+
+vi.mock("../lib/embeddings", () => ({
+  embedTexts: (...args: unknown[]) => embedTexts(...args),
+}));
+
+vi.mock("../lib/openai", () => ({
+  createOpenAI: () => ({ chat: { completions: { create: completionCreate } } }),
+}));
+
+vi.mock("../lib/entitlements/guard", () => ({
+  guardQuota: async () => null,
+  recordQuota: async () => {},
+}));
+
+vi.mock("../lib/supabase", () => ({
+  serviceClient: () => ({
+    from: (table: string) => {
+      if (table === "messages") {
+        return {
+          insert: (row: Record<string, unknown>) => {
+            serviceInsert(row);
+            return {
+              select: () => ({
+                single: async () => ({
+                  data: {
+                    id: "assistant-1",
+                    role: "assistant",
+                    content: row.content,
+                    created_at: "2026-09-02T10:00:00Z",
+                    sources: row.sources,
+                  },
+                  error: null,
+                }),
+              }),
+            };
+          },
+        };
+      }
+      return { update: () => ({ eq: async () => ({ error: null }) }) };
+    },
+  }),
+}));
+
+/** A streamed completion of one delta plus the usage-only final chunk. */
+function streamOf(text: string, finishReason = "stop") {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield { choices: [{ delta: { content: text } }] };
+      yield { choices: [{ delta: {}, finish_reason: finishReason }] };
+      yield {
+        choices: [],
+        usage: { prompt_tokens: 100, completion_tokens: 20, prompt_tokens_details: {} },
+      };
+    },
+  };
+}
+
+type Doc = { id: string; name: string; content: string | null };
+type Match = { document_id: string; document_name: string; content: string };
+
+function appWith(spec: {
+  question: string;
+  history?: Array<{ role: string; content: string }>;
+  documents?: Doc[];
+  matches?: Match[];
+}) {
+  const documents = spec.documents ?? [];
+  const rows = [...(spec.history ?? []), { role: "user", content: spec.question }].map((m, i) => ({
+    id: `m${i}`,
+    role: m.role,
+    content: m.content,
+    created_at: `2026-09-0${i + 1}T10:00:00Z`,
+  }));
+
+  const dbSpec: FakeDbSpec = {
+    tables: {
+      chat_sessions: { select: () => ({ data: SESSION, error: null }) },
+      agents: { select: () => ({ data: AGENT, error: null }) },
+      // The route reads newest-first and reverses, so hand it back reversed.
+      messages: { select: () => ({ data: [...rows].reverse(), error: null }) },
+      agent_bundles: {
+        select: () => ({
+          data: documents.length > 0 ? [{ bundle_id: "bundle-1" }] : [],
+          error: null,
+        }),
+      },
+      documents: {
+        select: (ctx: QueryContext) => ({
+          data: ctx.columns?.includes("content")
+            ? documents
+            : documents.map((d) => ({ name: d.name })),
+          error: null,
+        }),
+      },
+    },
+    rpc: {
+      match_chunks: () => ({ data: spec.matches ?? [], error: null }),
+    },
+  };
+
+  const { db, calls } = fakeDb(dbSpec);
+
+  const app = new Hono<AppEnv>();
+  app.use("/*", async (c, next) => {
+    c.set("user", USER as never);
+    c.set("db", db as never);
+    await next();
+  });
+  app.route("/", chat);
+  return { app, calls };
+}
+
+async function ask(app: Hono<AppEnv>) {
+  const res = await app.request(
+    "/chat/stream",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId: SESSION.id }),
+    },
+    {} as never,
+  );
+  return { status: res.status, body: await res.text() };
+}
+
+/** The messages the model was actually sent, by role. */
+function sentMessages(): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
+  return completionCreate.mock.calls[0][0].messages;
+}
+
+function knowledgeBlock(): string | undefined {
+  return sentMessages()
+    .map((m) => (typeof m.content === "string" ? m.content : ""))
+    .find((c) => c.startsWith("The team has shared the following knowledge"));
+}
+
+/** The value 0039 stores alongside the reply. */
+function grounding(): string | undefined {
+  return serviceInsert.mock.calls[0]?.[0]?.grounding as string | undefined;
+}
+
+function citedNames(): string[] {
+  const sources = serviceInsert.mock.calls[0]?.[0]?.sources as
+    Array<{ name: string }> | null | undefined;
+  return (sources ?? []).map((s) => s.name);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  embedTexts.mockResolvedValue({ vectors: [[0.1, 0.2]], tokens: 8 });
+  completionCreate.mockResolvedValue(streamOf("Twenty days."));
+});
+
+const HANDBOOK: Doc = { id: "d1", name: "handbook.md", content: "Vacation is 20 days." };
+const PAYROLL: Doc = { id: "d2", name: "payroll.md", content: "Paid on the 15th." };
+
+describe("citations", () => {
+  it("cites the documents a retrieved passage came from", async () => {
+    const { app } = appWith({
+      question: "How many vacation days do I get?",
+      documents: [HANDBOOK, PAYROLL],
+      matches: [
+        { document_id: "d1", document_name: "handbook.md", content: "Vacation is 20 days." },
+      ],
+    });
+    const res = await ask(app);
+    expect(res.status).toBe(200);
+    expect(citedNames()).toEqual(["handbook.md"]);
+  });
+
+  it("cites one document once, however many of its passages matched", async () => {
+    const { app } = appWith({
+      question: "How many vacation days do I get?",
+      documents: [HANDBOOK],
+      matches: [
+        { document_id: "d1", document_name: "handbook.md", content: "Vacation is 20 days." },
+        { document_id: "d1", document_name: "handbook.md", content: "Accrued monthly." },
+      ],
+    });
+    await ask(app);
+    expect(citedNames()).toEqual(["handbook.md"]);
+  });
+
+  it("does not cite a passage the char budget dropped", async () => {
+    // The narrower half of the same bug as the one below: six chunks come back,
+    // the block only has room for the first, and all six were being recorded as
+    // having grounded the answer.
+    const big = "x".repeat(4000);
+    const { app } = appWith({
+      question: "How many vacation days do I get?",
+      documents: [HANDBOOK, PAYROLL],
+      matches: [
+        { document_id: "d1", document_name: "handbook.md", content: big },
+        { document_id: "d2", document_name: "payroll.md", content: big },
+      ],
+    });
+    await ask(app);
+    expect(citedNames()).toEqual(["handbook.md"]);
+  });
+
+  it("cites nothing when nothing grounded the answer", async () => {
+    const { app } = appWith({
+      question: "write me a limerick",
+      documents: [HANDBOOK, PAYROLL],
+      matches: [],
+    });
+    await ask(app);
+    expect(citedNames()).toEqual([]);
+    expect(serviceInsert.mock.calls[0][0].sources).toBeNull();
+  });
+});
+
+describe("the no-match fallback", () => {
+  it("reads the documents when the question is about them", async () => {
+    const { app } = appWith({
+      question: "Can you summarize the file for me?",
+      documents: [HANDBOOK],
+      matches: [],
+    });
+    await ask(app);
+    expect(knowledgeBlock()).toContain("Vacation is 20 days.");
+    expect(citedNames()).toEqual(["handbook.md"]);
+  });
+
+  it("stays out of the way when the question is not", async () => {
+    // Every miss used to land in the fallback: "thanks" pulled the agent's
+    // whole library into the prompt, paid for it, and hung a row of source
+    // chips under a reply that came from the persona alone.
+    const { app } = appWith({
+      question: "thanks, that's all",
+      documents: [HANDBOOK, PAYROLL],
+      matches: [],
+    });
+    await ask(app);
+    expect(knowledgeBlock()).toBeUndefined();
+    expect(citedNames()).toEqual([]);
+  });
+
+  it("puts the document the question names first, not the newest one", async () => {
+    // The budget fills from the front. Newest-first is the right default and
+    // the wrong answer when someone asks about a file by name.
+    const filler = { id: "d9", name: "notes.md", content: "y".repeat(4000) };
+    const { app } = appWith({
+      question: "what does handbook.md say?",
+      documents: [filler, HANDBOOK],
+      matches: [],
+    });
+    await ask(app);
+    expect(knowledgeBlock()).toContain("Vacation is 20 days.");
+    expect(citedNames()[0]).toBe("handbook.md");
+  });
+
+  it("is never reached when the agent has no documents at all", async () => {
+    const { app } = appWith({ question: "summarize the file", documents: [], matches: [] });
+    await ask(app);
+    expect(knowledgeBlock()).toBeUndefined();
+    expect(embedTexts).not.toHaveBeenCalled();
+  });
+});
+
+describe("what gets embedded", () => {
+  it("embeds a self-contained question on its own", async () => {
+    const question = "What does the handbook say about parental leave in Istanbul?";
+    const { app } = appWith({ question, documents: [HANDBOOK] });
+    await ask(app);
+    expect(embedTexts.mock.calls[0][1]).toEqual([question]);
+  });
+
+  it("carries the previous question into a follow-up", async () => {
+    const { app } = appWith({
+      question: "peki ikinci maddesi?",
+      history: [
+        { role: "user", content: "Summarize the vacation policy in handbook.md" },
+        { role: "assistant", content: "Twenty days, accrued monthly." },
+      ],
+      documents: [HANDBOOK],
+    });
+    await ask(app);
+    const [embedded] = embedTexts.mock.calls[0][1];
+    expect(embedded).toContain("handbook.md");
+    expect(embedded).toContain("peki ikinci maddesi?");
+  });
+});
+
+describe("what grounded the reply (0039)", () => {
+  it("records a matched passage as chunks", async () => {
+    const { app } = appWith({
+      question: "How many vacation days do I get?",
+      documents: [HANDBOOK],
+      matches: [
+        { document_id: "d1", document_name: "handbook.md", content: "Vacation is 20 days." },
+      ],
+    });
+    await ask(app);
+    expect(grounding()).toBe("chunks");
+  });
+
+  it("records the fallback as documents", async () => {
+    const { app } = appWith({
+      question: "summarize the file",
+      documents: [HANDBOOK],
+      matches: [],
+    });
+    await ask(app);
+    expect(grounding()).toBe("documents");
+  });
+
+  it("records a question nothing was close to as none", async () => {
+    // The value this column exists to count, and the one it was getting wrong:
+    // the fallback ran on every miss, so a turn like this was stored as
+    // `documents` — grounded, by a path that had fired on a question about
+    // nothing.
+    const { app } = appWith({
+      question: "write me a limerick",
+      documents: [HANDBOOK],
+      matches: [],
+    });
+    await ask(app);
+    expect(grounding()).toBe("none");
+  });
+
+  it("records none when the agent has nothing to be close with", async () => {
+    const { app } = appWith({ question: "summarize the file", documents: [] });
+    await ask(app);
+    expect(grounding()).toBe("none");
+  });
+});
+
+describe("a reply that ran out of room", () => {
+  it("says so, ahead of the terminal event", async () => {
+    // A reply cut off at `maxTokensFor` stops mid-thought and otherwise looks
+    // finished. Nothing on screen said the end was missing.
+    completionCreate.mockResolvedValue(streamOf("A long list that stops at 3.", "length"));
+    const { app } = appWith({ question: "list every public holiday" });
+    const { body } = await ask(app);
+    expect(body).toContain('data: {"type":"truncated"}');
+    expect(body.indexOf('"truncated"')).toBeLessThan(body.indexOf('"done"'));
+  });
+
+  it("stays quiet when the model simply finished", async () => {
+    const { app } = appWith({ question: "hello" });
+    const { body } = await ask(app);
+    expect(body).not.toContain("truncated");
+  });
+});
+
+describe("the assembled prompt", () => {
+  it("keeps retrieved knowledge out of the cacheable prefix", async () => {
+    const { app } = appWith({
+      question: "How many vacation days do I get?",
+      documents: [HANDBOOK],
+      matches: [
+        { document_id: "d1", document_name: "handbook.md", content: "Vacation is 20 days." },
+      ],
+    });
+    await ask(app);
+    const sent = sentMessages();
+    // The persona prefix comes first and must not carry the volatile block;
+    // the block rides immediately before the question it grounds.
+    expect(sent[0].role).toBe("system");
+    expect(sent[0].content).not.toContain("Vacation is 20 days.");
+    expect(sent[sent.length - 2].content).toContain("Vacation is 20 days.");
+    expect(sent[sent.length - 1].content).toBe("How many vacation days do I get?");
+  });
+
+  it("names the agent's documents whether or not anything was retrieved", async () => {
+    const { app } = appWith({ question: "hello", documents: [HANDBOOK], matches: [] });
+    await ask(app);
+    expect(sentMessages()[0].content).toContain("handbook.md");
+  });
+});

--- a/worker/src/routes/chat.ts
+++ b/worker/src/routes/chat.ts
@@ -7,7 +7,8 @@ import { serviceClient } from "../lib/supabase";
 import { resolveModel } from "../lib/models";
 import { createOpenAI } from "../lib/openai";
 import { embedTexts } from "../lib/embeddings";
-import { buildContextBlock, ragMinSimilarity } from "../lib/rag";
+import { buildContextBlock, ragMinSimilarity, retrievalQuery } from "../lib/rag";
+import { refersToDocuments, namesDocument } from "../lib/doc-question";
 import { selectHistory } from "../lib/history";
 import { buildSystemPrefix, temperatureFor, maxTokensFor } from "../lib/prompt";
 import { effectiveMode } from "../lib/session-mode";
@@ -134,6 +135,17 @@ chat.post("/chat/stream", async (c) => {
    * agent with no documents, a retrieval that threw, a fallback that found
    * nothing with content — lands on the truthful value without needing its own
    * assignment.
+   *
+   * `"none"` covers one more case than it did when 0039 landed, and the report
+   * should read it as the wider fact rather than as a setup problem. The
+   * fallback used to run on *every* miss, so "thanks" and "merhaba" were
+   * recorded as `documents` — grounded, by a path that had fired on a turn
+   * about nothing. It now runs only when the question is about the documents
+   * (`refersToDocuments`), which leaves an ordinary question that cleared no
+   * passage recording `none`. That is what `none` should have meant all along:
+   * nothing the team wrote was close to this. The two populations it now mixes
+   * — no usable documents at all, and none close enough — are told apart by
+   * whether the agent has any documents, which the report can ask separately.
    */
   let grounding: "chunks" | "documents" | "none" = "none";
   // Embedding the question costs tokens too. Carried to the end of the turn and
@@ -176,7 +188,16 @@ chat.post("/chat/stream", async (c) => {
   // caught, at boot, before anybody asks anything.
   if (hasKnowledge) {
     try {
-      const embedded = await embedTexts(c.env, [lastMessage.content]);
+      // Not `lastMessage.content` alone: a follow-up carries its subject in the
+      // turn before it, and a pasted wall of text is longer than the embedding
+      // model's own context window. See `retrievalQuery`.
+      const query = retrievalQuery(
+        rows.map((m: { role: string; content: string }) => ({
+          role: m.role === "assistant" ? ("assistant" as const) : ("user" as const),
+          content: m.content,
+        })),
+      );
+      const embedded = await embedTexts(c.env, [query]);
       embeddingTokens += embedded.tokens;
       const [queryEmbedding] = embedded.vectors;
       if (queryEmbedding) {
@@ -194,13 +215,19 @@ chat.post("/chat/stream", async (c) => {
             document_name: string;
             content: string;
           }>;
-          ragBlock = buildContextBlock(
-            typed.map((m) => ({ documentName: m.document_name, content: m.content })),
+          // Cited from `used`, not from `typed`: the block has a char budget and
+          // drops what does not fit, and a document whose passage was dropped
+          // did not ground anything.
+          const block = buildContextBlock(
+            typed.map((m) => ({
+              documentId: m.document_id,
+              documentName: m.document_name,
+              content: m.content,
+            })),
           );
-          if (ragBlock) {
-            grounding = "chunks";
-            for (const m of typed) addSource(m.document_id ?? null, m.document_name);
-          }
+          ragBlock = block.text;
+          if (ragBlock) grounding = "chunks";
+          for (const m of block.used) addSource(m.documentId ?? null, m.documentName);
         }
       }
     } catch (e) {
@@ -208,12 +235,18 @@ chat.post("/chat/stream", async (c) => {
     }
   }
 
-  // Fallback: no chunk matched (common for "summarize the file" / "what's in
-  // the doc" style questions that don't embed close to any single passage), yet
-  // the agent does have documents. Ground on their stored content directly —
-  // newest first, capped by the same char budget — so it answers from the file
-  // instead of claiming it can't read it.
-  if (!ragBlock && hasKnowledge) {
+  // Fallback: no chunk matched, the agent does have documents, and the question
+  // is about them — "summarize the file", "what's in the doc", or anything that
+  // names one. Those don't embed close to any single passage, so retrieval
+  // misses them however the floor is set; grounding on the documents' stored
+  // text directly is what stops the agent claiming it can't read a file it was
+  // just handed.
+  //
+  // `refersToDocuments` is the guard, and it is the whole point of the branch.
+  // Without it every miss landed here — "thanks", "merhaba", "say that again" —
+  // and each one pulled the agent's files into the prompt, paid for them, and
+  // hung a row of source chips under an answer they had nothing to do with.
+  if (!ragBlock && hasKnowledge && refersToDocuments(lastMessage.content, docNames)) {
     const { data: docRows, error: docError } = await db
       .from("documents")
       .select("id,name,content")
@@ -224,14 +257,26 @@ chat.post("/chat/stream", async (c) => {
       : ((docRows ?? []) as Array<{ id: string; name: string; content: string | null }>).filter(
           (d) => d.content && d.content.trim().length > 0,
         );
-    if (withContent.length > 0) {
-      ragBlock = buildContextBlock(
-        withContent.map((d) => ({ documentName: d.name, content: d.content as string })),
+    // Newest-first is the right default and the wrong answer when the user
+    // named a file: the budget fills from the front, so "what does handbook.md
+    // say?" against a dozen documents could ground on the three most recent
+    // uploads and never reach the one that was asked about. A document the
+    // question names goes first.
+    const ordered = [
+      ...withContent.filter((d) => namesDocument(lastMessage.content, d.name)),
+      ...withContent.filter((d) => !namesDocument(lastMessage.content, d.name)),
+    ];
+    if (ordered.length > 0) {
+      const block = buildContextBlock(
+        ordered.map((d) => ({
+          documentId: d.id,
+          documentName: d.name,
+          content: d.content as string,
+        })),
       );
-      if (ragBlock) {
-        grounding = "documents";
-        for (const d of withContent) addSource(d.id ?? null, d.name);
-      }
+      ragBlock = block.text;
+      if (ragBlock) grounding = "documents";
+      for (const d of block.used) addSource(d.documentId ?? null, d.documentName);
     }
   }
 
@@ -290,6 +335,12 @@ chat.post("/chat/stream", async (c) => {
       // shows up nowhere. Unlike the transcription usage field, `cached_tokens`
       // is properly typed by the pinned SDK, so no fallback is needed here.
       let cachedTokens: number | null = null;
+      // Why the model stopped. "length" means it ran into `maxTokensFor` and
+      // the answer is cut off mid-thought — which looks, on screen, exactly
+      // like an answer that finished. Carried out to the client so it can say
+      // so instead of leaving someone to work out that the last sentence has
+      // no end.
+      let finishReason: string | null = null;
 
       let persisted = false;
       let spendRecorded = false;
@@ -357,11 +408,13 @@ chat.post("/chat/stream", async (c) => {
         );
 
         for await (const chunk of completion) {
-          const delta = chunk.choices[0]?.delta?.content;
+          const choice = chunk.choices[0];
+          const delta = choice?.delta?.content;
           if (delta) {
             full += delta;
             send({ type: "delta", text: delta });
           }
+          if (choice?.finish_reason) finishReason = choice.finish_reason;
           if (chunk.usage) {
             promptTokens = chunk.usage.prompt_tokens ?? null;
             completionTokens = chunk.usage.completion_tokens ?? null;
@@ -395,6 +448,8 @@ chat.post("/chat/stream", async (c) => {
             controller.close();
             return;
           }
+          // Before `done`, which is the client's terminal event.
+          if (finishReason === "length") send({ type: "truncated" });
           send({ type: "done", message: mapMessage(inserted) });
         } else {
           await recordSpend();

--- a/worker/src/routes/messages.test.ts
+++ b/worker/src/routes/messages.test.ts
@@ -1,0 +1,89 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import type { AppEnv } from "../types";
+import { fakeDb, type FakeDbSpec, type QueryContext } from "../test-support/fake-db";
+import { messages } from "./messages";
+
+const USER = { id: "user-1", email: "a@example.com" };
+const ANCHOR = { id: "msg-1", session_id: "sess-1", created_at: "2026-09-01T10:00:00Z" };
+
+/**
+ * @param sessionOwner who owns the conversation the anchor message belongs to.
+ * `null` stands for a session the caller cannot see at all.
+ */
+function appWith(spec: { sessionOwner: string | null; anchorFound?: boolean }) {
+  const deleted: QueryContext[] = [];
+  const dbSpec: FakeDbSpec = {
+    tables: {
+      messages: {
+        select: () => ({
+          data: (spec.anchorFound ?? true) ? ANCHOR : null,
+          error: null,
+        }),
+        delete: (ctx) => {
+          deleted.push(ctx);
+          return { data: null, error: null };
+        },
+      },
+      chat_sessions: {
+        select: () => ({
+          data: spec.sessionOwner ? { user_id: spec.sessionOwner } : null,
+          error: null,
+        }),
+      },
+    },
+  };
+  const { db } = fakeDb(dbSpec);
+
+  const app = new Hono<AppEnv>();
+  app.use("/*", async (c, next) => {
+    c.set("user", USER as never);
+    c.set("db", db as never);
+    await next();
+  });
+  app.route("/", messages);
+  return { app, deleted };
+}
+
+async function deleteAfter(app: Hono<AppEnv>) {
+  const res = await app.request(`/messages/after/${ANCHOR.id}`, { method: "DELETE" }, {} as never);
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe("DELETE /messages/after/:id", () => {
+  it("trims the conversation for the owner", async () => {
+    const { app, deleted } = appWith({ sessionOwner: USER.id });
+    const res = await deleteAfter(app);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(deleted).toHaveLength(1);
+    expect(deleted[0].filters).toContainEqual({
+      column: "created_at",
+      value: ANCHOR.created_at,
+      kind: "gt",
+    });
+  });
+
+  it("refuses a member of a shared conversation instead of quietly doing nothing", async () => {
+    // `messages_delete_owner` is keyed to the session's owner, and RLS refuses
+    // a delete it has no policy for by matching no rows and reporting no error.
+    // So this used to answer `{ ok: true }`, delete nothing, and hand the
+    // client a Regenerate that then failed with "no user message to respond
+    // to" — the reply it was meant to replace still on screen.
+    const { app, deleted } = appWith({ sessionOwner: "someone-else" });
+    const res = await deleteAfter(app);
+    expect(res.status).toBe(403);
+    expect(deleted).toHaveLength(0);
+  });
+
+  it("404s when the anchor message is not visible", async () => {
+    const { app } = appWith({ sessionOwner: USER.id, anchorFound: false });
+    expect((await deleteAfter(app)).status).toBe(404);
+  });
+
+  it("404s when the session behind the anchor is not visible", async () => {
+    const { app, deleted } = appWith({ sessionOwner: null });
+    expect((await deleteAfter(app)).status).toBe(404);
+    expect(deleted).toHaveLength(0);
+  });
+});

--- a/worker/src/routes/messages.ts
+++ b/worker/src/routes/messages.ts
@@ -85,6 +85,7 @@ messages.patch("/messages/:id", async (c) => {
 // DELETE /messages/after/:id
 messages.delete("/messages/after/:id", async (c) => {
   const db = c.get("db");
+  const user = c.get("user");
   const id = c.req.param("id");
 
   const { data: anchor, error: anchorError } = await db
@@ -98,6 +99,29 @@ messages.delete("/messages/after/:id", async (c) => {
   }
   if (!anchor) {
     return c.json({ error: "not found" }, 404);
+  }
+
+  // Checked here even though `messages_delete_owner` already refuses it,
+  // because of *how* it refuses: RLS answers a delete it has no policy for by
+  // matching no rows and reporting no error. So a member of a shared session
+  // who pressed Regenerate got `{ ok: true }`, nothing deleted, and then a
+  // stream that failed with "no user message to respond to" — the reply they
+  // were trying to replace still sitting at the end of the conversation. An
+  // honest 403 is what the interface can act on.
+  const { data: session, error: sessionError } = await db
+    .from("chat_sessions")
+    .select("user_id")
+    .eq("id", anchor.session_id)
+    .maybeSingle();
+
+  if (sessionError) {
+    return c.json({ error: "failed to load session" }, 500);
+  }
+  if (!session) {
+    return c.json({ error: "not found" }, 404);
+  }
+  if (session.user_id !== user.id) {
+    return c.json({ error: "only the owner of a conversation can rewrite it" }, 403);
   }
 
   const { error } = await db


### PR DESCRIPTION
A sweep over the chat: the answer's grounding on the API side, and six
places where the screen said something that was not so.

## The one you can see

An agent with a dozen files answered almost every question with a dozen
source chips. Two bugs put them there.

`buildContextBlock` has a char budget and drops whatever does not fit,
but `chat.ts` recorded sources from the *candidates* rather than from
what was admitted — six retrieved chunks became six citations even when
only the first reached the model. The block now returns what it used,
and that list is the only thing that can be cited. Its budget covers its
own framing too, so a block asked for 4000 chars stops at 4000 rather
than 4300, and a leftover forty characters is dropped rather than
admitted as a fragment claiming a citation it cannot support.

The louder half was the no-match fallback. It exists for "summarize the
file" — a real question that embeds near no single passage, so retrieval
misses it however the floor is set — but it fired on *every* miss.
"thanks", "merhaba", "say that again in English" all miss, and each one
pulled the agent's whole library into the prompt, paid for it, and hung
those chips under a reply that came from the persona alone. It now needs
a reason (`refersToDocuments`, Turkish and English, because the product
is used in both). When someone names a file, that file also moves to the
front of the budget — newest-first is the right default and the wrong
answer to "what does handbook.md say?".

### This changes what `grounding` counts, for the better

0039 landed while this was in progress, and the fallback's old behaviour
was feeding it: a turn like "thanks" was recorded as `documents` —
grounded, by a path that had fired on a question about nothing. Those
turns now record `none`, which is what `none` should have meant all
along: nothing the team wrote was close to this. The comment on the
variable says so, and there are now route tests for all three values,
which the column did not have.

## The rest of the API side

- Retrieval embedded the latest message alone, so "and the second one?"
  / "peki ikinci maddesi?" embedded near nothing and the agent lost a
  document it had been reading correctly one turn earlier. Short turns
  now carry the previous question; long ones are left alone.
- A pasted contract is longer than the embedding model's own context
  window: the call 400s and it surfaces as a silent "retrieval failed".
  Capped.
- The manifest promised "the shared knowledge provided below" on every
  turn, including the ones where nothing was retrieved and nothing
  followed — naming a file, attaching nothing, and leaving the model to
  fill the gap. Reworded (it stays byte-identical for the prompt cache);
  lists longer than forty names are counted rather than named.
- A reply that ran out of `maxTokensFor` stops mid-thought and otherwise
  looks finished. It says so now.
- `DELETE /messages/after/:id` returned `{ ok: true }` having deleted
  nothing, because RLS answers a delete it has no policy for with zero
  rows and no error. It is a 403.

## The screen

- A reply you scrolled up to read dragged you back down on every token.
- A failed send destroyed what you had typed.
- Two taps on a starter card posted the question twice, and the second
  send found the stream already open and returned without answering it.
- Stop belonged to whichever conversation you were looking at rather
  than the one streaming — so it appeared with nothing to stop, and
  pressing it cut off the answer in the tab you had just left.
- Stopping was meant to hold the revealed text until the server's copy
  arrived; the flag that hid the bubble was the same flag that meant "a
  reply is running", so it blinked out and back 700ms later.
- Regenerate was offered to everyone reading a shared conversation — the
  same mistake Edit made and was fixed for — where it deleted nothing,
  said nothing, then failed to answer a question that already had an
  answer under it.

Plus: your own message in a shared session came back over the
subscription and sat next to the optimistic copy until the refetch; and
the thumbs answered "Thanks for the feedback" when nothing stores it and
no endpoint receives it. The mark is all that happens, so it is now all
that is claimed — wiring it to something real needs a table and is a
feature, not a fix.

## Checks

`bun run lint`, both typechecks, and both suites, locally on this branch:
761 API tests (was 695 before this branch) and 445 frontend (was 399).
`worker/src/routes/chat.ts` had no test of its own; it has 18 now.
No migrations, so the RLS job is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)