### PR TITLE
Two migrations cannot share a number, and today two did

### DIFF
--- a/scripts/migration-numbering.test.mjs
+++ b/scripts/migration-numbering.test.mjs
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * No two migrations in a directory may share a number.
+ *
+ * This is not tidiness. `docker/migrate.sh` records what it has applied by
+ * **filename**, in `covan_meta.migrations`. The Supabase CLI — which is what
+ * `supabase start` and any local reset run — records it by **version**, the
+ * numeric prefix alone, in `supabase_migrations.schema_migrations`. Two files
+ * called `0039_a.sql` and `0039_b.sql` are therefore two migrations to one tool
+ * and one migration to the other: the CLI applies whichever it reaches first,
+ * writes `0039`, and silently skips the other. No error, and a schema that is
+ * missing a migration nothing will ever try to apply again.
+ *
+ * It gets worse from there, because `tests/rls/preflight.ts` treats a file in a
+ * CLI-managed directory as applied if *either* ledger knows it (covan#57, and
+ * the per-directory `cli` flag in covan#82). One `0039` in
+ * `schema_migrations` therefore vouches for both, so the preflight that exists
+ * to catch a database behind the checkout reports everything present. The
+ * suite then runs green against a schema missing a table.
+ *
+ * How it happens is the ordinary way: two branches open at the same time, both
+ * read `ls supabase/migrations | tail -1`, both pick the next number, and
+ * whichever merges second is a collision nobody looked for. It happened on
+ * 2026-09-02 with two `0039`s, and this test is the reason it should not
+ * happen twice.
+ *
+ * **Per directory, not across them.** `supabase/cloud/` is applied by
+ * `migrate.sh` and never by the CLI, and it has held its own `0001` since it
+ * was created — that overlap with `supabase/migrations/0001_init.sql` is
+ * deliberate and covan#82 turned on the flag that makes it safe. Comparing the
+ * two directories to each other would fail on a decision already taken.
+ *
+ * **The fix when this fails** is to renumber, and which file moves is not a
+ * coin toss: the one that has not been applied to production yet moves, and if
+ * both have, the one whose migration is idempotent does. A rename orphans the
+ * ledger row keyed on the old filename, so the file comes back around for a
+ * second application under its new name — harmless for a migration written
+ * with `if not exists` throughout, an error for one that was not.
+ */
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const DIRS = ["supabase/migrations", "supabase/cloud"].filter((d) => existsSync(resolve(root, d)));
+
+function migrationsIn(dir) {
+  return readdirSync(resolve(root, dir))
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+}
+
+/** The CLI's idea of a version: the leading digits, and nothing else. */
+function versionOf(filename) {
+  return /^(\d+)/.exec(filename)?.[1] ?? null;
+}
+
+describe("migration numbering", () => {
+  // A guard on the guard, in the shape `check-rls.mjs` uses: if the paths ever
+  // move, an empty directory list would pass this file as "nothing wrong here".
+  it("found the migration directories at all", () => {
+    expect(DIRS.length).toBeGreaterThan(0);
+    expect(migrationsIn(DIRS[0]).length).toBeGreaterThan(0);
+  });
+
+  it.each(DIRS)("%s numbers every migration exactly once", (dir) => {
+    const byVersion = new Map();
+    for (const file of migrationsIn(dir)) {
+      const version = versionOf(file);
+      if (version === null) continue;
+      byVersion.set(version, [...(byVersion.get(version) ?? []), file]);
+    }
+
+    const collisions = [...byVersion]
+      .filter(([, files]) => files.length > 1)
+      .map(([version, files]) => `${version}: ${files.join(", ")}`);
+
+    expect(collisions).toEqual([]);
+  });
+
+  it.each(DIRS)("%s names every migration so a version can be read off it", (dir) => {
+    const unnumbered = migrationsIn(dir).filter((f) => versionOf(f) === null);
+
+    expect(unnumbered).toEqual([]);
+  });
+});

--- a/supabase/migrations/0040_deletion_you_can_undo.sql
+++ b/supabase/migrations/0040_deletion_you_can_undo.sql
@@ -1,4 +1,4 @@
--- 0039_deletion_you_can_undo.sql
+-- 0040_deletion_you_can_undo.sql
 --
 -- Deleting an agent has been final since 0001, and larger than it looks. The
 -- foreign keys do the rest: every session anybody ever had with that agent,


### PR DESCRIPTION
## What problem does this solve?

`main` currently carries **two migrations numbered 0039** — `0039_whether_anything_came_close.sql` (#90) and `0039_deletion_you_can_undo.sql` (#93). Both are correct on their own. Together they are a silent hole.

### Why it is not cosmetic

The two tools that apply migrations disagree about what a migration *is*:

| | records | keyed on |
|---|---|---|
| `docker/migrate.sh` | `covan_meta.migrations` | the **filename** |
| Supabase CLI (`supabase start`, any local reset) | `supabase_migrations.schema_migrations` | the **version** — the numeric prefix alone |

So two files numbered `0039` are two migrations to one tool and one migration to the other. The CLI applies whichever it reaches first, writes `0039`, and **skips the other permanently**. Nothing raises an error.

It compounds: `tests/rls/preflight.ts` counts a file in a CLI-managed directory as applied if *either* ledger knows it — #57's check, narrowed per-directory in #82. A single `0039` in `schema_migrations` therefore vouches for **both** files, so the preflight built to catch a database behind the checkout reports everything present, and the suite runs green against a schema missing a column.

### Which one moves, and why it is not a coin toss

`0039_deletion_you_can_undo.sql` → `0040_deletion_you_can_undo.sql`.

- `0039_whether_anything_came_close.sql` **has already been applied to the hosted database by hand**, with a ledger row keyed on that exact filename. It is also not idempotent — bare `add column`, bare `add constraint` — so renaming it would orphan the ledger row and then fail when the file came round again under its new name.
- The deletion migration has been applied nowhere yet, is written with `if not exists` throughout, and merged second.

### The part meant to outlive today

`scripts/migration-numbering.test.mjs` asserts, per directory, that no two migrations share a version and that every filename has one.

Proved fail-first — with the collision restored:

```
× supabase/migrations numbers every migration exactly once
  AssertionError: expected [ Array(1) ] to deeply equal []
  + "0039: 0039_deletion_you_can_undo.sql, 0039_whether_anything_came_close.sql"
```

**Per directory, not across them.** `supabase/cloud/` is applied only by `migrate.sh`, never by the CLI, and has held its own `0001` since it was created — #82 is where that overlap was made safe. A check comparing the two directories would fail on a decision already taken.

It runs in the existing unit job (`vitest.config.ts` already includes `scripts/**/*.test.mjs`, next to `web-runtime-config.test.mjs`), so it needs no CI wiring and fails in seconds rather than after a database comes up.

### For the two open pull requests

**#97 and #98 both add a `0040` and a `0041`.** `0040` is taken as of this change, and they collide with each other regardless of it. This test will now say so on whichever merges second, instead of letting a second collision through the way today's went through.

## Checks

- [x] The commands above pass

```
lint        0 errors, 3 warnings (pre-existing)
typecheck   clean
check:rls   ✓ all 21 tables created under 1 directory enable RLS
test        456 passed (3 new)
```

## If you touched the database

- [x] No SQL was edited — the file is renamed and its own first-line comment updated to match. `git` records it as a rename, so the diff is the two characters in the number.
