### PR TITLE
A page that still knew deletion was final

### DIFF
--- a/docs/team.md
+++ b/docs/team.md
@@ -159,7 +159,7 @@ deleting an agent takes every session anybody ever had with it, every message in
 those sessions and every routine pointed at it, and deleting a bundle takes its
 documents and their embeddings. A `viewer` is refused all of it.
 
-Until `0039` none of that was recoverable from inside the product, and this page
+Until `0040` none of that was recoverable from inside the product, and this page
 said so. [Deleting, and taking it back](#deleting-and-taking-it-back) is the
 change: those three deletions now wait thirty days, and
 [the record of who did it](#the-record-of-who-did-it) says whose decision it was

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -27,6 +27,20 @@ import { LegalLayout, LegalSection, LegalList, LegalItem } from "@/components/le
  * months that erasure had no button, which was true when written and became
  * false the day `worker/src/routes/account.ts` shipped. Building a capability
  * puts this page in the change exactly as adding an outbound host does.
+ *
+ * And the third time was the fastest. `0040_deletion_you_can_undo.sql` made
+ * deleting an agent, a bundle or a document reversible for thirty days, and
+ * this page went on saying deletion "removes the rows and the stored file
+ * rather than hiding them" — the one sentence that soft delete exists to
+ * contradict, still standing twenty-six minutes after the migration merged.
+ *
+ * So the rule generalises past outbound hosts and past new routes: **a change
+ * to what deletion means is a change to this page.** It is the claim a person
+ * is relying on when they exercise erasure, and the only one here that is worse
+ * to overstate than to understate. Note what did not save it — every word was
+ * true when written, `docs/team.md` was updated in the same PR, and the tests
+ * passed. Prose has no compiler; only a person reading the diff for this file
+ * would have caught it.
  */
 export const Route = createFileRoute("/privacy")({
   component: PrivacyPage,
@@ -69,6 +83,18 @@ function PrivacyPage() {
             <strong className="font-medium text-foreground">Usage counts</strong> — tokens spent per
             reply, used to show you what you have used and, on a metered install, to apply an
             allowance.
+          </LegalItem>
+          <LegalItem>
+            <strong className="font-medium text-foreground">
+              A record of what people do to each other's work
+            </strong>{" "}
+            — when an agent, a bundle or a document is deleted or restored, and when somebody is
+            invited, has their role changed or is removed, the workspace keeps a line saying who did
+            it, to what, and when. The thing's name is kept alongside it, because thirty days later
+            the row it points at is gone and a log that can only say "an agent was deleted" is not a
+            log. Readable by the workspace's admins and by nobody else. It is written by the
+            database rather than by the API, so it records the action even when the action did not
+            go through the interface.
           </LegalItem>
           <LegalItem>
             <strong className="font-medium text-foreground">Feedback you send</strong> — what you
@@ -130,8 +156,23 @@ function PrivacyPage() {
 
       <LegalSection title="Deleting things">
         <p>
-          A document, a conversation and an agent can each be deleted from the interface, and
-          deleting them removes the rows and the stored file rather than hiding them.
+          Deleting an <strong className="font-medium text-foreground">agent</strong>, a{" "}
+          <strong className="font-medium text-foreground">knowledge bundle</strong> or a{" "}
+          <strong className="font-medium text-foreground">document</strong> puts it in the
+          workspace's trash rather than removing it. It stops being readable everywhere in the
+          product at once — no answer is grounded on it again — but the rows and the uploaded file
+          are still there, and anybody who can write in that workspace can put it back for{" "}
+          <strong className="font-medium text-foreground">thirty days</strong>. After that a sweeper
+          deletes the rows for real and deletes the stored file with them.
+        </p>
+        <p>
+          A <strong className="font-medium text-foreground">conversation</strong> is not like the
+          other three. Deleting one removes it immediately and there is nothing to restore.
+        </p>
+        <p>
+          There is no button that empties the trash sooner. If you need something gone before the
+          thirty days are up, ask whoever runs your install — and closing your account does not wait
+          either: what it deletes, it deletes at once, trash included.
         </p>
         <p>
           Closing your account is in Settings, and it takes your conversations, your API keys, any


### PR DESCRIPTION
`0040_deletion_you_can_undo.sql` made deleting an agent, a bundle or a document reversible for thirty days. `/privacy` went on saying deletion **"removes the rows and the stored file rather than hiding them"** — the one sentence soft delete exists to contradict — and it said it about two of the three things it named.

This is covan-cloud#152 arriving 26 minutes after I filed it as a prediction.

### What the page says now, and where each clause comes from

| Claim | Source |
| --- | --- |
| Agent, bundle and document go to the workspace's trash | `RESTORABLE` in `worker/src/lib/deletion.ts` |
| Restorable for thirty days by anyone who can write in the workspace | `RETENTION_DAYS = 30`; `restore_*` functions gate on `can_write_in_workspace` |
| The rows *and the uploaded file* are still there until then | `purge.ts` deletes objects at purge, not at delete |
| A conversation still goes immediately | `chat_sessions` is not in `RESTORABLE` |
| No button empties the trash early | `trash.ts` registers exactly two routes: list and restore |
| Closing the account does not wait | `account.ts` filters `deleted_at` nowhere, so the cascade takes trashed rows |

The conversation sentence is there deliberately. The old paragraph named all three in one breath, so a reader would carry "thirty days" across to the one case where it is not true.

### `workspace_events` joins "What is stored"

A record of who deleted, restored, invited, removed or re-roled is **new personal data about the people it names**, and a privacy page that lists the documents while omitting the log of who touched them is describing half the table. The disclosure includes the part worth knowing: the subject's label is denormalised on purpose, so it outlives the row it points at.

### The header rule generalises

Third time, and the fastest. Not only new outbound hosts and new routes — **a change to what deletion means is a change to this page.** Worth noting what did not save it: every word was true when written, `docs/team.md` was updated in the same PR as the migration, and the tests passed. Prose has no compiler.

### Also

`docs/team.md` said "until `0039`", which is the migration about answer grounding. The renumbering in #99/#100 moved this one to `0040` and left the reference behind.

### Verification, honestly

495 tests pass; build clean. **Rendering could not be checked**: the Node build on `main` returns 500 on every route before any of this, filed as #101 and bisected to a window that starts after my last merge and does not include this branch (`b449e97` → 200, `ddbc3a6` → 500). What I could check is the artifact — the three new strings are in `.output`, the old sentence is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)