### PR TITLE
A sweeper nothing was ever going to run

### DIFF
--- a/worker/src/node.ts
+++ b/worker/src/node.ts
@@ -2,6 +2,7 @@ import { serve } from "@hono/node-server";
 import { app } from "./index";
 import { loadEnv } from "./lib/env";
 import { runScheduledWork } from "./lib/background";
+import { runPurge } from "./lib/purge";
 
 /**
  * The self-hosted entry point.
@@ -18,10 +19,24 @@ import { runScheduledWork } from "./lib/background";
  * Overlap is safe: both `claim_due_routines` and `claim_due_connections` hand
  * out rows with `for update skip locked`, so a slow tick meeting the next one
  * cannot run the same work twice.
+ *
+ * TWO intervals, because `scheduled` on the Worker side is two `waitUntil`s.
+ * The sweeper is deliberately not inside `runScheduledWork`: that function
+ * exists to spend one Cloudflare invocation's subrequest budget on either
+ * routines or connections, and the sweeper is outside that trade in `index.ts`
+ * for the same reason it is outside it here.
  */
 const env = loadEnv();
 const port = Number(process.env.PORT ?? 8787);
 const tickMs = Number(process.env.ROUTINE_TICK_MS ?? 60_000);
+/**
+ * Hourly, against a thirty-day window — the exact hour a row is swept is not
+ * something anybody can observe. A minute is the right cadence for "is anything
+ * due" and a wasteful one for "has anything expired": on a workspace with an
+ * empty trash, which is nearly all of them nearly all the time, the sweep is
+ * three queries against partial indexes that return nothing.
+ */
+const purgeMs = Number(process.env.PURGE_TICK_MS ?? 3_600_000);
 
 const server = serve({ fetch: (request: Request) => app.fetch(request, env), port }, (info) => {
   console.log(`covan-api listening on http://localhost:${info.port}`);
@@ -30,6 +45,15 @@ const server = serve({ fetch: (request: Request) => app.fetch(request, env), por
 const tick = setInterval(() => {
   runScheduledWork(env).catch((err) => console.error("scheduled tick failed", err));
 }, tickMs);
+
+// Without this the sweeper has no caller on this side at all. `index.ts` runs
+// it from `scheduled`, which is the Cloudflare half; a self-hosted install
+// would mark things deleted forever — the trash filling, the countdown on each
+// row running to zero, and nothing ever collecting the rows or the uploaded
+// files they name.
+const purgeTick = setInterval(() => {
+  runPurge(env).catch((err) => console.error("purge tick failed", err));
+}, purgeMs);
 
 /**
  * Shut down on a signal instead of waiting to be killed.
@@ -51,6 +75,7 @@ const tick = setInterval(() => {
 const shutdown = (signal: NodeJS.Signals) => {
   console.log(`${signal} received, shutting down`);
   clearInterval(tick);
+  clearInterval(purgeTick);
   server.close(() => process.exit(0));
   // Long-lived responses (the SSE chat stream) hold sockets open, and
   // server.close() waits for every one of them. Give them a moment, then go

--- a/worker/src/purge.wiring.test.ts
+++ b/worker/src/purge.wiring.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Does anything actually call the sweeper?
+ *
+ * It shipped wired to nothing. `lib/purge.ts` was written, tested and reviewed;
+ * `index.ts` called it from `scheduled`; and no deployment fired that handler.
+ * The Cloudflare API Worker carried no `[triggers]` — deliberately, and
+ * documented, because the engine's heartbeat lives in a second Worker. The
+ * second Worker runs `cron.ts`, which cannot sweep: it takes `RoutineEnv` and
+ * has no bucket bound, so a purged document's bytes would outlive its row. And
+ * the self-hosted entry point ran `runScheduledWork` on an interval and nothing
+ * else.
+ *
+ * So every unit test passed, the feature demonstrated correctly by hand, and
+ * the promise on the screen — "28 days left" under every row in the trash — was
+ * one nothing was ever going to keep. Deleted rows and their uploaded files
+ * would have accumulated forever, which against a 500 MB ceiling is the failure
+ * that eventually shows up as something else entirely.
+ *
+ * A behavioural test cannot catch this. The gap was not in what any function
+ * did; it was in whether a scheduler existed to call one. That makes it a
+ * question about entry points, which is what this file reads.
+ */
+
+const SRC = `${process.cwd()}/src`;
+const read = (f: string) => readFileSync(join(SRC, f), "utf8");
+
+/**
+ * The CALL, not the identifier.
+ *
+ * The first version of this file asserted `toContain("runPurge")`, which the
+ * import line satisfies on its own — so deleting the call and keeping the
+ * import left the guard green. A wiring test that passes on unwired code is
+ * worse than no wiring test, because it is also a claim that somebody checked.
+ */
+const CALLS_PURGE = /\brunPurge\s*\(\s*env\s*\)/;
+
+describe("the sweeper has a caller in every deployment", () => {
+  it("is run from the Worker's scheduled handler", () => {
+    const index = read("index.ts");
+    expect(index).toMatch(CALLS_PURGE);
+    // Not chained onto the other tick: a failing routine tick must not stop the
+    // sweep, and a failing sweep must not mark the tick broken.
+    expect(index.match(/waitUntil\(/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  it("is run from the self-hosted interval", () => {
+    const node = read("node.ts");
+    expect(node).toMatch(CALLS_PURGE);
+    // Its own interval rather than a call inside the routine tick: an hourly
+    // sweep against a thirty-day window, versus a tick that wants to be a
+    // minute.
+    expect(node.match(/setInterval\(/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    // And cleared on the way out, like the tick beside it.
+    expect(node).toContain("clearInterval(purgeTick)");
+  });
+
+  it("is deliberately absent from the cron Worker", () => {
+    // The one entry point that must NOT sweep, and the reason is a binding it
+    // does not have. If somebody adds `runPurge` here, they have either bound a
+    // document store to that Worker — in which case delete this assertion and
+    // say so — or they have written a sweep that deletes rows and orphans every
+    // file they named.
+    expect(read("cron.ts")).not.toMatch(CALLS_PURGE);
+  });
+});


### PR DESCRIPTION
The thirty-day purge shipped in #93 wired to nothing. `lib/purge.ts` was written, tested and reviewed; `index.ts` called it from `scheduled`; and no deployment fired that handler.

Three entry points, and the sweeper was reachable from none of them in practice:

- **The hosted API Worker** carries no `[triggers]` — deliberately, and documented in `wrangler.toml`, because the engine's heartbeat lives in a second Worker.
- **That second Worker** runs `cron.ts`, which *cannot* sweep: it takes `RoutineEnv` and has no bucket bound, so a purged document's bytes would outlive the row that named them.
- **`node.ts`**, the self-hosted entry point, ran `runScheduledWork` on an interval and nothing else.

So every unit test passed, the feature demonstrated correctly by hand, and the sentence under every row in the trash — *"28 days left"* — was one nothing was going to keep. Deleted rows and their uploaded files would have accumulated forever, which against Supabase's 500 MB surfaces later as something that looks unrelated.

## What this changes

`node.ts` gets its own interval, hourly against a thirty-day window — the exact hour a row is swept is not observable, and on a workspace with an empty trash the sweep is three queries against partial indexes that return nothing.

Deliberately **not** folded into `runScheduledWork`. That function exists to spend one Cloudflare invocation's subrequest budget on either routines or connections, never both; the sweeper sits outside that trade in `index.ts` for exactly the same reason it sits outside it here.

The hosted half is a `[triggers]` block in covan-cloud's `wrangler.toml`, which is where that file lives. It is in the covan-cloud mirror of #93.

## The guard

`purge.wiring.test.ts`. A behavioural test could not have caught this: the gap was not in what any function did, it was in whether a scheduler existed to call one — so the test reads entry points, and asserts the third one must *not* sweep, with the binding-shaped reason written next to it.

Its first draft asserted `toContain("runPurge")`, which the import line satisfies on its own, so deleting the call and keeping the import left it green. It matches the call site now. Verified the way a guard has to be: by deleting the call and watching it go red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
