### PR TITLE
The grant 0043 forgot

### DIFF
--- a/src/lib/migration-grants.test.ts
+++ b/src/lib/migration-grants.test.ts
@@ -50,18 +50,84 @@ const NO_CLIENT_GRANT = new Set(["routine_deliveries"]);
  */
 const GRANTED_LATE = new Map([["0033_a_key_that_is_a_person.sql", "granted by 0034"]]);
 
+/**
+ * Tables no `service_role` will ever touch.
+ *
+ * `feedback` is written in `routes/feedback.ts` through the caller's own
+ * client, so the row is authored by the person who wrote it and RLS is the
+ * whole mechanism rather than something to get past. There is no engine path to
+ * it and no webhook that arrives without a caller — the two shapes that force a
+ * table onto the service role — so the omission in 0041 is a decision.
+ *
+ * The default is the other way round, deliberately. A table that turns out not
+ * to need the grant costs one line here and a sentence saying why; a table that
+ * needed it and did not get one costs an afternoon of reading a third party's
+ * OAuth documentation. That asymmetry is the whole argument for the list being
+ * exemptions rather than opt-ins.
+ */
+const NO_SERVICE_GRANT = new Set(["feedback"]);
+
+/**
+ * The migrations that create a table the service role writes and grant it in a
+ * later file.
+ *
+ * The same kind of entry as `GRANTED_LATE` above and for the same reason: an
+ * applied migration is not rewritten, so the grant lives in a later file and
+ * this list says which.
+ *
+ * 0033 is here as well as in `GRANTED_LATE` — it granted nothing to anybody,
+ * and 0034 supplied both halves. 0043 and 0044 are the second occurrence, three
+ * migrations later, and the narrower one: they did grant, generously, to
+ * `authenticated`, which is precisely why the version of this test that did not
+ * name a role called them correct.
+ *
+ * It is a record of the same mistake twice, not a mechanism. A fourth entry
+ * would mean this file has become a place to register exceptions rather than a
+ * thing that stops them.
+ */
+const SERVICE_GRANTED_LATE = new Map([
+  ["0033_a_key_that_is_a_person.sql", "granted by 0034"],
+  ["0043_a_bundle_that_keeps_itself_current.sql", "granted by 0045"],
+  ["0044_an_agent_you_can_ask_from_a_channel.sql", "granted by 0045"],
+]);
+
 /** `create table [if not exists] [public.]<name>`, across every migration. */
 function tablesCreatedIn(sql: string): string[] {
   const matches = sql.matchAll(/create\s+table\s+(?:if\s+not\s+exists\s+)?(?:public\.)?(\w+)/gi);
   return [...matches].map((m) => m[1]);
 }
 
-/** Whether this file grants something on that table to a client role. */
-function grantsFor(sql: string, table: string): boolean {
+type Role = "authenticated" | "service_role";
+
+/**
+ * Whether this file grants something on that table **to this role**.
+ *
+ * The role used to be implicit, and that is the hole 0043 went through. It
+ * grants on `connections` — carefully, with a column list — and it grants to
+ * `authenticated` only. Asking "is there a grant?" got a yes, the suite stayed
+ * green, and on the hosted project the service client got
+ * `42501 permission denied` on the INSERT that ends the OAuth flow. 0045 is the
+ * repair; this parameter is what stops the third occurrence.
+ *
+ * `[^;]` rather than `[\s\S]`, so the match cannot run past the semicolon that
+ * ends the statement. Without it, `grant ... to authenticated;` followed later
+ * in the file by any mention of `service_role` — a policy, a function grant, a
+ * comment — reads as a grant to `service_role`. 0043 contains exactly that
+ * pair, so the loose version would have gone on passing after being taught the
+ * question.
+ */
+function grantsFor(sql: string, table: string, role: Role): boolean {
   // Both shapes count: `grant ... on public.api_keys to authenticated` and
-  // 0023's `grant ... on all tables in schema public`.
-  const specific = new RegExp(`grant[\\s\\S]*?on\\s+(?:table\\s+)?(?:public\\.)?${table}\\b`, "i");
-  const blanket = /grant[\s\S]{0,80}on\s+all\s+tables\s+in\s+schema\s+public/i;
+  // 0023's `grant ... on all tables in schema public to anon, authenticated,
+  // service_role`.
+  const specific = new RegExp(
+    `grant[^;]*?\\bon\\s+(?:table\\s+)?(?:public\\.)?${table}\\b[^;]*?\\b${role}\\b`,
+    "i",
+  );
+  const blanket = new RegExp(
+    `grant[^;]*?\\bon\\s+all\\s+tables\\s+in\\s+schema\\s+public\\b[^;]*?\\b${role}\\b`,
+    "i",
+  );
   return specific.test(sql) || blanket.test(sql);
 }
 
@@ -93,7 +159,9 @@ describe("table grants", () => {
       if (GRANTED_LATE.has(file)) continue;
       for (const table of tablesCreatedIn(sql)) {
         if (NO_CLIENT_GRANT.has(table)) continue;
-        if (!grantsFor(sql, table)) offenders.push(`${file} creates ${table} and grants nothing`);
+        if (!grantsFor(sql, table, "authenticated")) {
+          offenders.push(`${file} creates ${table} and grants nothing to authenticated`);
+        }
       }
     }
 
@@ -115,16 +183,102 @@ describe("table grants", () => {
 
     const ungranted = [...created]
       .filter((t) => !NO_CLIENT_GRANT.has(t))
-      .filter((t) => !all.some(([, sql]) => grantsFor(sql, t)))
+      .filter((t) => !all.some(([, sql]) => grantsFor(sql, t, "authenticated")))
       .sort();
 
     expect(ungranted).toEqual([]);
+  });
+
+  it("is granted to service_role by the same migration that creates the table", () => {
+    // The rule above, asked again about the role that actually broke. Both
+    // halves have to be checked separately or one satisfies the other: 0043
+    // grants generously to `authenticated` and not at all to `service_role`,
+    // and a single combined question calls that a pass.
+    const offenders: string[] = [];
+
+    for (const [file, sql] of migrations()) {
+      if (file < "0023") continue;
+      if (SERVICE_GRANTED_LATE.has(file)) continue;
+      for (const table of tablesCreatedIn(sql)) {
+        if (NO_SERVICE_GRANT.has(table)) continue;
+        if (!grantsFor(sql, table, "service_role")) {
+          offenders.push(`${file} creates ${table} and grants nothing to service_role`);
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      "A table the engine, a webhook, or an OAuth callback writes is reached " +
+        "with the service client, which BYPASSRLS but not the grants — so a " +
+        "missing one is 42501 in production and nothing anywhere else. Add " +
+        "`grant select, insert, update, delete on public.<table> to " +
+        "service_role;` to the same migration, or name the table in " +
+        "NO_SERVICE_GRANT with the reason no service path reaches it.",
+    ).toEqual([]);
+  });
+
+  it("grants service_role for every table that needs one, somewhere", () => {
+    // The whole-set view, as above: 0023's blanket names `service_role` too, so
+    // everything older than it is already satisfied and only a table created
+    // after it and never granted shows up here.
+    const all = migrations();
+    const created = new Set(all.flatMap(([, sql]) => tablesCreatedIn(sql)));
+
+    const ungranted = [...created]
+      .filter((t) => !NO_SERVICE_GRANT.has(t))
+      .filter((t) => !all.some(([, sql]) => grantsFor(sql, t, "service_role")))
+      .sort();
+
+    expect(ungranted).toEqual([]);
+  });
+
+  it("does not read a grant to one role as a grant to another", () => {
+    // The bug in this test, written down as a test. 0043 grants on
+    // `connections` to `authenticated`, and later in the same file grants
+    // EXECUTE on `claim_due_connections` to `service_role` — which is what a
+    // pattern spanning semicolons would have latched onto.
+    const sql = readFileSync(
+      join(MIGRATIONS, "0043_a_bundle_that_keeps_itself_current.sql"),
+      "utf8",
+    );
+
+    expect(grantsFor(sql, "connections", "authenticated")).toBe(true);
+    expect(grantsFor(sql, "connections", "service_role")).toBe(false);
   });
 
   it("keeps the late-grant list to the one mistake it records", () => {
     // The exception above is a record, not a door. If this list grows, the rule
     // it is an exception to has stopped being a rule.
     expect([...GRANTED_LATE.keys()]).toEqual(["0033_a_key_that_is_a_person.sql"]);
+  });
+
+  it("keeps the late service-grant list to the three files it records", () => {
+    // Same door, same reason it stays shut. 0043 and 0044 shipped together and
+    // are repaired together by 0045; a fourth entry means somebody chose to
+    // split a table from its grant again rather than write the grant.
+    expect([...SERVICE_GRANTED_LATE.keys()]).toEqual([
+      "0033_a_key_that_is_a_person.sql",
+      "0043_a_bundle_that_keeps_itself_current.sql",
+      "0044_an_agent_you_can_ask_from_a_channel.sql",
+    ]);
+  });
+
+  it("names the five tables 0045 repairs", () => {
+    // Explicit rather than implied, exactly as the api_keys case below: the
+    // general rules would keep passing if 0045 were reverted and 0043 rewritten
+    // in place, and this would not.
+    const sql = readFileSync(join(MIGRATIONS, "0045_the_grant_0043_forgot.sql"), "utf8");
+
+    for (const table of [
+      "connections",
+      "connection_runs",
+      "slack_installations",
+      "slack_identities",
+      "slack_threads",
+    ]) {
+      expect(grantsFor(sql, table, "service_role"), `0045 grants ${table}`).toBe(true);
+    }
   });
 
   it("names api_keys, which is the table this test exists because of", () => {

--- a/supabase/migrations/0045_the_grant_0043_forgot.sql
+++ b/supabase/migrations/0045_the_grant_0043_forgot.sql
@@ -1,0 +1,97 @@
+-- =========================================================================
+-- The grant 0043 forgot
+--
+-- 0034 wrote this file once already, for 0033. The words were:
+--
+--   "From here on a migration that adds a table grants for it, in the same
+--    file. Forgetting is loud — PostgREST returns 42501 — and a loud failure is
+--    worth more than an inherited grant nobody re-reads."
+--
+-- 0043 and 0044 obeyed the letter of it and still shipped the bug. They grant,
+-- carefully and narrowly, to `authenticated` — column lists, three columns of
+-- UPDATE, no INSERT — and to `service_role` they grant nothing at all. Every
+-- one of their five tables is written by the service client, so on the hosted
+-- project the feature was dead on arrival.
+--
+-- ---- what it looked like -------------------------------------------------
+--
+-- Worse than a 500 on the first click, because the first click worked. The
+-- OAuth round trip completed: Notion showed its picker, returned a code, and
+-- the token exchange succeeded. `GET /connections/callback` then answered 302
+-- like it should. It was the INSERT after the exchange that died —
+--
+--   42501  permission denied for table connections
+--
+-- — so the browser landed on `/integrations?error=save_failed` with a live
+-- grant on Notion's side and no row on ours. Everything a person could see
+-- pointed at Notion. The line that named the real cause was in `wrangler tail`,
+-- which is not where anybody looks when the third-party consent screen is the
+-- last thing they touched.
+--
+-- ---- why nothing caught it -----------------------------------------------
+--
+-- `src/lib/migration-grants.test.ts` exists precisely to catch this, and it
+-- passed. It asked "does this migration grant something on this table?" and
+-- 0043 does — to `authenticated`. The question it was not asking is "to which
+-- role", and that is the whole distance between a green suite and a feature
+-- nobody can turn on. That test is rewritten alongside this file to ask per
+-- role, which is the durable half of this fix; this file is only the repair.
+--
+-- The RLS suite cannot help here for the reason 0023 and 0034 both record: the
+-- compose stack and the Supabase CLI stack still hand out the old permissive
+-- default, so every database we are willing to test against grants what
+-- production withholds.
+--
+-- ---- the grants ----------------------------------------------------------
+--
+-- Table-level and all four verbs, the shape 0034 used. Narrowing them would be
+-- theatre: `service_role` has BYPASSRLS, so a column it cannot select through a
+-- grant is a column it can reach by any other route it likes. The grants are
+-- the gate on *whether* PostgREST will speak to it at all, not on what it may
+-- see, and pretending otherwise would leave a reader thinking these tables are
+-- more constrained than they are.
+--
+-- `anon` gets nothing, and `authenticated` keeps exactly what 0043 and 0044
+-- gave it. Nothing here widens a client's reach by one column.
+--
+-- Deliberately not in this list: `feedback` (0041), which also names no
+-- `service_role` and is right not to. `routes/feedback.ts` inserts through the
+-- caller's own client, so the row is written as the person who wrote it and
+-- RLS is the point rather than an obstacle. It is named in the test's
+-- exemption list instead, where a decision belongs.
+--
+-- Applied by hand to the hosted project on 2026-09-04, before this file
+-- existed, because the alternative was leaving connections broken while a PR
+-- went round. Re-running it there is harmless — a grant is idempotent — and
+-- every other database still needs it.
+-- =========================================================================
+
+-- ---- connections ---------------------------------------------------------
+-- The callback inserts the row (the OAuth exchange and the token encryption
+-- both happen in the worker), and the engine updates it every tick: status,
+-- next_sync_at, last_sync_at, consecutive_failures, and the claim that
+-- `claim_due_connections` hands out.
+grant select, insert, update, delete on public.connections to service_role;
+
+-- ---- connection_runs -----------------------------------------------------
+-- Written only by the engine — one row per sync, from `sync.ts`. A client
+-- reads them and never writes one, which is why 0043's grant to
+-- `authenticated` is SELECT alone and stays that way.
+grant select, insert, update, delete on public.connection_runs to service_role;
+
+-- ---- slack_installations -------------------------------------------------
+-- The install upsert in `routes/slack.ts` runs as the service role: it stores
+-- the bot token, encrypted, which no client may write.
+grant select, insert, update, delete on public.slack_installations to service_role;
+
+-- ---- slack_identities ----------------------------------------------------
+-- Written by the events endpoint on the first message from a Slack user, where
+-- there is no Covan caller yet for RLS to resolve — resolving one is the whole
+-- purpose of the row.
+grant select, insert, update, delete on public.slack_identities to service_role;
+
+-- ---- slack_threads -------------------------------------------------------
+-- Same path, same reason: a thread becomes a `chat_sessions` row and the link
+-- between them is written while answering, by the engine, on behalf of
+-- somebody who is not making an HTTP request to us.
+grant select, insert, update, delete on public.slack_threads to service_role;


### PR DESCRIPTION
0043 and 0044 grant on their five tables to `authenticated` — column lists, three columns of UPDATE, no INSERT — and to `service_role` they grant nothing. Every one of those tables is written by the service client, so on the hosted project connecting Notion completed its OAuth round trip and then died on the INSERT:

```
42501  permission denied for table connections
```

The browser landed on `/integrations?error=save_failed` with a live grant on Notion's side and no row on ours. Everything a person could see pointed at Notion; the line naming the cause was in `wrangler tail`.

**0045** grants the five, table-level and all four verbs — the shape 0034 used for the same mistake three migrations earlier. Narrowing them would be theatre: `service_role` has BYPASSRLS, so the grant decides whether PostgREST will speak to the table at all, not what it may see. `feedback` (0041) is deliberately not in the list — `routes/feedback.ts` writes through the caller's own client, so it is named in the test's exemption list instead.

**`migration-grants.test.ts` is why this shipped, and is the durable half.** It asked "does this migration grant something on this table?" and 0043 does, so it passed. It now asks per role, and its pattern stops at the semicolon — without that, 0043's `grant ... to authenticated;` followed by its `grant execute ... to service_role;` reads as a grant to `service_role`, which is exactly the pair the file contains. That case is asserted directly, in both directions.

Applied by hand to the hosted project on 2026-09-04, before this file existed. Re-running it there is a no-op; every other database still needs it.

**Verified:** 495 frontend tests, typecheck, eslint, `check-rls.mjs`, and the numbering guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)