### PR TITLE
A Notion page that arrives whole

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -84,23 +84,55 @@ the grant, Notion shows its own page picker; the integration can afterwards see
 exactly what was ticked there and nothing else. A page un-picked later stops
 appearing and is removed on the next sync.
 
-Pages are imported as Markdown — headings, lists, to-dos, quotes, code and
-tables survive, because that shape is what makes a passage retrievable. Child
-pages are not inlined: they are separate pages in their own right, so inlining
-them would index the same text twice.
+**What is imported.** Pages arrive as Markdown, because the shape is the
+meaning: a heading tells the chunker where a section starts, and a list that
+arrives as one run-on paragraph retrieves worse than the same list with its
+bullets. Headings, lists, to-dos, quotes, callouts, toggles, code, equations and
+tables all keep their shape, and **links keep their targets** — a page whose
+value is thirty links to other things is thirty links here too.
 
-**Limits.** 500 pages per connection, 300 blocks per page, and two levels of
-nesting inside a page. These bound what one sync can cost; a curated set of
-pages is well inside all three.
+**Database rows bring their properties.** Status, owner, dates, tags, a
+one-line summary: in a Notion database that is usually the whole of the row, and
+its page body is empty. They arrive as a short list above the body. Relations
+and rollups are skipped — they are ids and nested aggregates, which no question
+can match.
+
+**Images and files contribute their captions, not their links.** A file stored
+in Notion is served from a signed URL that expires about an hour later, so
+writing one into a document that will be read for months produces a link that
+worked once. Captions are text and last. A caption is worth writing.
+
+Child pages are not inlined: they are separate pages in their own right, so
+inlining them would index the same text twice.
+
+**Limits.** 500 pages per connection, 300 blocks per page, two levels of nesting
+inside a page, and 100 rows of any one table. These bound what one sync can
+cost; a curated set of pages is well inside all four. Multi-column layouts do
+not spend a level of nesting — they are layout, not depth.
 
 ### Setting it up
 
-1. Go to <https://www.notion.so/my-integrations> and create a **public**
-   integration.
-2. Set the redirect URI to `<your API URL>/connections/callback` — for example
+Notion has renamed integrations to **connections** and moved them, twice.
+`notion.so/my-integrations` and `notion.so/profile/integrations` both redirect
+to the current home.
+
+1. Go to <https://app.notion.com/developers/connections>. (In the app it is
+   Settings → Connections, which needs Developer mode and workspace ownership
+   before it appears at all.)
+2. **New connection**, and choose **OAuth** as the authentication method. The
+   default, "Access token", is a static workspace-scoped token for one
+   workspace — Covan has no way to accept one, and the connect button will
+   never complete.
+3. Under **OAuth configuration**, add the redirect URI
+   `<your API URL>/connections/callback` — for example
    `https://api.example.com/connections/callback`, or
-   `http://localhost:8787/connections/callback` for a local stack.
-3. Set `NOTION_CLIENT_ID` and `NOTION_CLIENT_SECRET`.
+   `http://localhost:8787/connections/callback` for a local stack. It must match
+   byte for byte; Notion compares it again when the code is exchanged.
+4. Choose the installation scope. **This cannot be changed afterwards** — a
+   connection meant for other people's workspaces needs *Any workspace*, and
+   getting it wrong means deleting the connection and starting again.
+5. Set `NOTION_CLIENT_ID` and `NOTION_CLIENT_SECRET` from the **Configuration**
+   tab. The secret is shown once.
 
 ---
 

--- a/worker/src/lib/connections/notion.test.ts
+++ b/worker/src/lib/connections/notion.test.ts
@@ -87,6 +87,9 @@ describe("notion provider", () => {
         name: "Handbook.md",
         version: "2026-09-01T10:00:00.000Z",
         url: "https://notion.so/page-1",
+        // Carried so `readFile` can render a database row's properties without
+        // asking for a page `search` has already returned in full.
+        listing: page(),
       },
     ]);
   });
@@ -159,7 +162,11 @@ describe("notion provider", () => {
         "# Handbook",
         "",
         "## Leave",
+        "",
         "Twenty days a year.",
+        "",
+        // Two list items in a row and no blank line between them: a blank line
+        // there ends the list and starts a second one.
         "- Ask in advance",
         "- [x] Sign it",
       ].join("\n"),
@@ -201,7 +208,267 @@ describe("notion provider", () => {
       url: null,
     });
 
-    expect(text).toContain("- Parent\n    - Child");
+    // Two spaces, not four. Four is Markdown's code-block marker, and the
+    // version that used it turned every nested block into a monospaced blob.
+    expect(text).toContain("- Parent\n  - Child");
+  });
+
+  /**
+   * Read one page whose top-level blocks are `blocks`, with `children` keyed by
+   * the parent block id. Every failure below was a real defect: the first
+   * version of this converter read `plain_text` and block types and nothing
+   * else, so links, tables, media and database rows all arrived as either
+   * nothing at all or as a code block.
+   */
+  const readWith = async (
+    blocks: unknown[],
+    children: Record<string, unknown[]> = {},
+    listing?: unknown,
+  ) => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const id = String(input).match(/\/blocks\/([^/]+)\/children/)?.[1] ?? "";
+      if (id === "page-1") return json({ results: blocks, has_more: false });
+      return json({ results: children[id] ?? [], has_more: false });
+    }) as unknown as typeof fetch;
+
+    return notionProvider.readFile(ctx(fetchImpl), {
+      externalId: "page-1",
+      name: "P.md",
+      version: "v1",
+      url: null,
+      ...(listing ? { listing: listing as Record<string, unknown> } : {}),
+    });
+  };
+
+  it("keeps the links, which were the whole value of the page", async () => {
+    const text = await readWith([
+      {
+        id: "b1",
+        type: "paragraph",
+        paragraph: {
+          rich_text: [
+            { plain_text: "See " },
+            { plain_text: "the policy", href: "https://example.com/policy" },
+            { plain_text: " and ", annotations: {} },
+            { plain_text: "ask Ayşe", annotations: { bold: true } },
+          ],
+        },
+      },
+    ]);
+
+    expect(text).toContain("See [the policy](https://example.com/policy) and **ask Ayşe**");
+  });
+
+  it("puts the space outside the markers, where it renders", async () => {
+    // Notion routinely ends a bold run with the trailing space inside it, and
+    // `**bold **` is not bold in any parser.
+    const text = await readWith([
+      {
+        id: "b1",
+        type: "paragraph",
+        paragraph: {
+          rich_text: [
+            { plain_text: "Deadline ", annotations: { bold: true } },
+            { plain_text: "is Friday" },
+          ],
+        },
+      },
+    ]);
+
+    expect(text).toContain("**Deadline** is Friday");
+  });
+
+  it("reads a table as a table, not as a code block", async () => {
+    const text = await readWith(
+      [{ id: "t1", type: "table", table: { has_column_header: true }, has_children: true }],
+      {
+        t1: [
+          {
+            id: "r1",
+            type: "table_row",
+            table_row: { cells: [[{ plain_text: "Plan" }], [{ plain_text: "Seats" }]] },
+          },
+          {
+            id: "r2",
+            type: "table_row",
+            table_row: { cells: [[{ plain_text: "Team" }], [{ plain_text: "5" }]] },
+          },
+        ],
+      },
+    );
+
+    expect(text).toContain(["| Plan | Seats |", "| --- | --- |", "| Team | 5 |"].join("\n"));
+    // The four-space indent it used to get is what made it a code block.
+    expect(text).not.toContain("    | Plan");
+  });
+
+  it("gives a headerless table a delimiter anyway", async () => {
+    const text = await readWith(
+      [{ id: "t1", type: "table", table: { has_column_header: false }, has_children: true }],
+      {
+        t1: [
+          {
+            id: "r1",
+            type: "table_row",
+            table_row: { cells: [[{ plain_text: "a" }], [{ plain_text: "b" }]] },
+          },
+        ],
+      },
+    );
+
+    expect(text).toContain(["|  |  |", "| --- | --- |", "| a | b |"].join("\n"));
+  });
+
+  it("passes a column's contents through at the level they read at", async () => {
+    const text = await readWith(
+      [{ id: "cl", type: "column_list", column_list: {}, has_children: true }],
+      {
+        cl: [{ id: "c1", type: "column", column: {}, has_children: true }],
+        c1: [
+          {
+            id: "p1",
+            type: "bulleted_list_item",
+            bulleted_list_item: { rich_text: [{ plain_text: "In a column" }] },
+            has_children: true,
+          },
+        ],
+        // Two structural wrappers deep and the list underneath still nests,
+        // because layout does not spend a level of MAX_BLOCK_DEPTH.
+        p1: [
+          {
+            id: "p2",
+            type: "bulleted_list_item",
+            bulleted_list_item: { rich_text: [{ plain_text: "Nested" }] },
+          },
+        ],
+      },
+    );
+
+    expect(text).toContain("- In a column\n  - Nested");
+  });
+
+  it("keeps a toggle's contents out of a code block", async () => {
+    const text = await readWith(
+      [
+        {
+          id: "t1",
+          type: "toggle",
+          toggle: { rich_text: [{ plain_text: "Details" }] },
+          has_children: true,
+        },
+      ],
+      {
+        t1: [
+          { id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "The body." }] } },
+        ],
+      },
+    );
+
+    expect(text).toContain("Details\n\nThe body.");
+  });
+
+  it("keeps a caption but not a link that expires before anybody clicks it", async () => {
+    const text = await readWith([
+      {
+        id: "i1",
+        type: "image",
+        image: {
+          caption: [{ plain_text: "The org chart" }],
+          type: "file",
+          // Notion-hosted: a signed URL good for about an hour.
+          file: { url: "https://s3.example.com/signed?expires=soon" },
+        },
+      },
+      {
+        id: "i2",
+        type: "image",
+        image: {
+          caption: [{ plain_text: "The logo" }],
+          type: "external",
+          external: { url: "https://example.com/logo.png" },
+        },
+      },
+    ]);
+
+    expect(text).toContain("The org chart");
+    expect(text).not.toContain("s3.example.com");
+    expect(text).toContain("![The logo](https://example.com/logo.png)");
+  });
+
+  it("imports a bookmark, which used to import as nothing", async () => {
+    const text = await readWith([
+      { id: "b1", type: "bookmark", bookmark: { url: "https://example.com/pricing", caption: [] } },
+      {
+        id: "b2",
+        type: "callout",
+        callout: { rich_text: [{ plain_text: "Mind the gap" }], icon: { emoji: "⚠️" } },
+      },
+      { id: "b3", type: "equation", equation: { expression: "e = mc^2" } },
+    ]);
+
+    expect(text).toContain("<https://example.com/pricing>");
+    expect(text).toContain("> ⚠️ Mind the gap");
+    expect(text).toContain("$$e = mc^2$$");
+  });
+
+  it("leaves a code block's contents alone", async () => {
+    // Emphasis inside a fence is not emphasis, it is punctuation somebody now
+    // has to explain to whoever copies the snippet.
+    const text = await readWith([
+      {
+        id: "c1",
+        type: "code",
+        code: {
+          language: "sql",
+          rich_text: [{ plain_text: "select *", annotations: { bold: true } }],
+        },
+      },
+    ]);
+
+    expect(text).toContain("```sql\nselect *\n```");
+  });
+
+  it("imports a database row's properties, which are usually all it has", async () => {
+    const text = await readWith(
+      [],
+      {},
+      {
+        object: "page",
+        id: "page-1",
+        parent: { type: "database_id" },
+        properties: {
+          Name: { type: "title", title: [{ plain_text: "Renew the SOC 2" }] },
+          Status: { type: "status", status: { name: "In review" } },
+          Owner: { type: "people", people: [{ name: "Ayşe" }] },
+          Due: { type: "date", date: { start: "2026-10-01" } },
+          Tags: { type: "multi_select", multi_select: [{ name: "legal" }, { name: "q4" }] },
+          Blocked: { type: "checkbox", checkbox: false },
+          Notes: { type: "rich_text", rich_text: [{ plain_text: "Ask the auditor." }] },
+          // Ids and nested aggregates: nothing a question can match.
+          Parent: { type: "relation", relation: [{ id: "abc" }] },
+        },
+      },
+    );
+
+    expect(text).toContain("- **Status:** In review");
+    expect(text).toContain("- **Owner:** Ayşe");
+    expect(text).toContain("- **Due:** 2026-10-01");
+    expect(text).toContain("- **Tags:** legal, q4");
+    expect(text).toContain("- **Blocked:** No");
+    expect(text).toContain("- **Notes:** Ask the auditor.");
+    expect(text).not.toContain("Parent");
+  });
+
+  it("leaves an ordinary page's properties alone", async () => {
+    // Its only property is the title, which is already the heading. A page that
+    // is not a database row imports exactly as it did before.
+    const text = await readWith(
+      [{ id: "p1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "Body." }] } }],
+      {},
+      { object: "page", id: "page-1", parent: { type: "workspace" }, properties: {} },
+    );
+
+    expect(text).toBe("# P\n\nBody.");
   });
 
   // A revoked grant is not weather. Retrying it every six hours forever is how

--- a/worker/src/lib/connections/notion.ts
+++ b/worker/src/lib/connections/notion.ts
@@ -66,11 +66,35 @@ const SEARCH_PAGE_SIZE = 100;
  */
 const MAX_SEARCH_PAGES = 5;
 
-type NotionRichText = { plain_text?: string };
+/**
+ * How many rows of one table are read.
+ *
+ * A table's rows are children, so reading one costs a request of its own on top
+ * of the page's. 100 is a single request — Notion's page size — and a table
+ * longer than that is a database wearing a table's clothes, which arrives as
+ * its own pages anyway.
+ */
+const MAX_TABLE_ROWS = 100;
+
+type NotionAnnotations = {
+  bold?: boolean;
+  italic?: boolean;
+  strikethrough?: boolean;
+  code?: boolean;
+};
+type NotionRichText = {
+  plain_text?: string;
+  href?: string | null;
+  annotations?: NotionAnnotations;
+};
 type NotionBlock = {
   id: string;
   type: string;
   has_children?: boolean;
+  [key: string]: unknown;
+};
+type NotionProperty = {
+  type?: string;
   [key: string]: unknown;
 };
 type NotionPage = {
@@ -80,7 +104,8 @@ type NotionPage = {
   last_edited_time?: string;
   in_trash?: boolean;
   archived?: boolean;
-  properties?: Record<string, { type?: string; title?: NotionRichText[] }>;
+  parent?: { type?: string };
+  properties?: Record<string, NotionProperty>;
 };
 
 function authHeaders(accessToken: string): Record<string, string> {
@@ -104,12 +129,70 @@ async function notionFetch(
   return res.json();
 }
 
-/** The concatenated plain text of a rich-text array, or "". */
-function richText(value: unknown): string {
-  if (!Array.isArray(value)) return "";
-  return value
-    .map((r) => (r && typeof r === "object" ? ((r as NotionRichText).plain_text ?? "") : ""))
+function runsOf(value: unknown): NotionRichText[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((r): r is NotionRichText => Boolean(r) && typeof r === "object");
+}
+
+/**
+ * The concatenated plain text of a rich-text array, or "".
+ *
+ * For the places where Markdown would be wrong: a filename, a table cell being
+ * measured, a caption used as link text. Titles go through here rather than
+ * `inline` because a document called `**Q3** plan.md` is a document whose name
+ * is now punctuation.
+ */
+function plainText(value: unknown): string {
+  return runsOf(value)
+    .map((r) => r.plain_text ?? "")
     .join("");
+}
+
+/**
+ * One rich-text run as Markdown, styling and link included.
+ *
+ * The old version of this function read `plain_text` and stopped, which threw
+ * away every annotation and — the part that mattered — **every URL**. A
+ * handbook page whose value is thirty links to other things arrived as thirty
+ * words. Notion puts the target in `href` on the run itself rather than in a
+ * block type, so a link is invisible to anything that only reads block types.
+ *
+ * Whitespace is moved outside the markers before they are applied. Notion
+ * commonly ends a bold run with its trailing space still inside it, and
+ * `**bold **` is not bold in any parser — it is two asterisks, a word, and two
+ * more asterisks, which is worse than the plain text we started with.
+ *
+ * Nothing is escaped. An underscore in a Notion sentence is an underscore, and
+ * a converter that backslashes every `*`, `_`, `[` and `` ` `` in ordinary prose
+ * makes the common case ugly to protect the rare one — in a document whose
+ * consumers are a chunker and an embedding model, not a strict renderer.
+ */
+function runToMarkdown(run: NotionRichText): string {
+  const raw = run.plain_text ?? "";
+  if (!raw) return "";
+
+  const leading = raw.match(/^\s*/)?.[0] ?? "";
+  const trailing = raw.length > leading.length ? (raw.match(/\s*$/)?.[0] ?? "") : "";
+  const core = raw.slice(leading.length, raw.length - trailing.length);
+  if (!core) return raw;
+
+  const a = run.annotations ?? {};
+  let text = core;
+  // Code first, so it ends up innermost: `**`code`**` is bold code, while
+  // ``**code**`` is a code span that happens to contain asterisks.
+  if (a.code) text = `\`${text}\``;
+  if (a.strikethrough) text = `~~${text}~~`;
+  if (a.italic) text = `*${text}*`;
+  if (a.bold) text = `**${text}**`;
+  // The link goes outermost, which is the one order that renders: `[**a**](u)`.
+  if (run.href) text = `[${text}](${run.href})`;
+
+  return `${leading}${text}${trailing}`;
+}
+
+/** A rich-text array as Markdown, or "". */
+function inline(value: unknown): string {
+  return runsOf(value).map(runToMarkdown).join("");
 }
 
 /**
@@ -123,7 +206,7 @@ function richText(value: unknown): string {
 function titleOf(page: NotionPage): string {
   for (const prop of Object.values(page.properties ?? {})) {
     if (prop?.type === "title") {
-      const text = richText(prop.title).trim();
+      const text = plainText(prop.title).trim();
       if (text) return text;
     }
   }
@@ -139,9 +222,45 @@ function titleOf(page: NotionPage): string {
  * this does not know about contribute their rich text and lose their styling,
  * which is the correct amount of effort for a block type nobody uses.
  */
+/**
+ * Where a media block points, when saying so is worth anything.
+ *
+ * Only an `external` URL is returned. A Notion-hosted file arrives as a signed
+ * S3 link that expires about an hour later, and this text is stored — so
+ * writing one down produces a document full of links that worked once, on the
+ * afternoon of the sync, for whoever happened to be looking. The caption is
+ * kept either way, because the caption is the part a question can match.
+ */
+function externalUrl(body: unknown): string | null {
+  const value = body as { external?: { url?: string } } | undefined;
+  const url = value?.external?.url;
+  return typeof url === "string" && url ? url : null;
+}
+
+/** A media block: its caption, and its link when the link outlives the sync. */
+function mediaToMarkdown(block: NotionBlock, body: unknown, fallback: string): string {
+  const caption = inline((body as { caption?: unknown } | undefined)?.caption).trim();
+  const url = externalUrl(body);
+  const label = caption || fallback;
+  if (!url) return caption;
+  return block.type === "image" ? `![${label}](${url})` : `[${label}](${url})`;
+}
+
+/**
+ * One block as a line of Markdown.
+ *
+ * Markdown rather than bare text because the shape is meaning: a heading tells
+ * the chunker where a section starts, and a list that arrives as one run-on
+ * paragraph retrieves worse than the same list with its bullets.
+ *
+ * Returning "" means "this block contributes no line of its own". For a
+ * container — a column, a synced block, a table — that is not the same as
+ * contributing nothing: `readBlocks` still reads its children, and for those
+ * types passes them straight through instead of indenting them.
+ */
 function blockToMarkdown(block: NotionBlock): string {
   const body = (block as Record<string, { rich_text?: unknown; [k: string]: unknown }>)[block.type];
-  const text = richText(body?.rich_text);
+  const text = inline(body?.rich_text);
 
   switch (block.type) {
     case "heading_1":
@@ -162,17 +281,66 @@ function blockToMarkdown(block: NotionBlock): string {
     }
     case "quote":
       return text ? `> ${text}` : "";
+    case "callout": {
+      // A callout is a quote with a pictogram, and the pictogram carries
+      // meaning a reader uses — a warning triangle is not a lightbulb. It costs
+      // one character to keep.
+      const icon = (body as { icon?: { emoji?: string } } | undefined)?.icon?.emoji;
+      if (!text) return "";
+      return icon ? `> ${icon} ${text}` : `> ${text}`;
+    }
+    // A toggle's summary is an ordinary line and its contents are its children,
+    // which `readBlocks` appends underneath without indenting — the four spaces
+    // it used to add turned every collapsed section into a code block.
+    case "toggle":
+      return text;
     case "code": {
       const language = (body as { language?: string } | undefined)?.language ?? "";
-      return text ? `\`\`\`${language}\n${text}\n\`\`\`` : "";
+      // Plain text inside a fence. Bold in a code block is not bold, it is two
+      // asterisks somebody now has to explain to a reader copying the snippet.
+      const source = plainText(body?.rich_text);
+      return source ? `\`\`\`${language}\n${source}\n\`\`\`` : "";
+    }
+    case "equation": {
+      const expression = (body as { expression?: string } | undefined)?.expression ?? "";
+      return expression ? `$$${expression}$$` : "";
     }
     case "divider":
       return "---";
+    case "image":
+    case "video":
+    case "audio":
+    case "pdf":
+    case "file":
+      return mediaToMarkdown(block, body, block.type);
+    case "bookmark":
+    case "embed":
+    case "link_preview": {
+      // The URL is the block here — there is no rich text to fall back on, so
+      // the old default branch returned "" and a page of bookmarks imported as
+      // an empty document.
+      const url = (body as { url?: string } | undefined)?.url ?? "";
+      if (!url) return "";
+      const caption = inline((body as { caption?: unknown } | undefined)?.caption).trim();
+      return caption ? `[${caption}](${url})` : `<${url}>`;
+    }
     case "table_row": {
       const cells = (body as { cells?: unknown[] } | undefined)?.cells ?? [];
-      const rendered = cells.map((cell) => richText(cell).trim());
+      const rendered = cells.map((cell) => inline(cell).trim());
       return rendered.some(Boolean) ? `| ${rendered.join(" | ")} |` : "";
     }
+    // Containers with no line of their own. Their children are the content and
+    // are passed through unindented; see `PASSTHROUGH` in `readBlocks`.
+    case "table":
+    case "column_list":
+    case "column":
+    case "synced_block":
+      return "";
+    // Navigation furniture. It means something in Notion's interface and
+    // nothing in a document being read for its sentences.
+    case "table_of_contents":
+    case "breadcrumb":
+      return "";
     // child_page and child_database are deliberately dropped rather than
     // followed: `search` returns them as pages in their own right, so following
     // them here would index the same content twice — once as itself and once
@@ -185,14 +353,86 @@ function blockToMarkdown(block: NotionBlock): string {
   }
 }
 
+/**
+ * The block types whose children are *their* content, indented under them.
+ *
+ * Only lists. A nested bullet has to stay nested or the outline collapses, and
+ * two spaces is what makes it one — not the four the first version used, which
+ * is also Markdown's marker for a code block and turned every nested paragraph,
+ * toggle body and table row into a monospaced blob nobody could retrieve a
+ * sentence from.
+ */
+const INDENTS_CHILDREN = new Set(["bulleted_list_item", "numbered_list_item", "to_do"]);
+
+/**
+ * Containers that are layout, not content.
+ *
+ * Their children are ordinary blocks that happen to sit inside a wrapper, so
+ * they are passed through at the same level and the wrapper costs nothing. They
+ * also do not spend a level of `MAX_BLOCK_DEPTH`: a two-column layout is one
+ * `column_list` and one `column` before any writing starts, and charging two
+ * levels for it would mean a page laid out in columns imports its paragraphs
+ * and loses every list inside them.
+ */
+const PASSTHROUGH = new Set(["column_list", "column", "synced_block"]);
+
+/**
+ * An absolute stop, since `PASSTHROUGH` does not spend depth.
+ *
+ * Notion will not nest columns like this and a malformed reply cannot make it
+ * do so, but "cannot happen" is how a sync ends up recursing until the Worker
+ * is killed, and there is no error to read when it does.
+ */
+const MAX_HOPS = 8;
+
+/**
+ * One table, as a table.
+ *
+ * Rows are children of the `table` block, which is why the first version got
+ * this so wrong: it indented them four spaces like any other nested block, so
+ * every table in Notion arrived as a code block — and it never wrote the
+ * delimiter row, without which the remaining lines are not a table in any
+ * parser. `docs/integrations.md` claimed tables survived. They did not.
+ *
+ * A table with no header row still gets a delimiter, under a row of empty
+ * cells. That is what Notion itself shows for a headerless table, and it is the
+ * only shape that stays a table once written down.
+ */
+async function readTable(ctx: ProviderContext, block: NotionBlock): Promise<string[]> {
+  const body = (block as Record<string, { has_column_header?: boolean } | undefined>)["table"];
+  const query = new URLSearchParams({ page_size: String(MAX_TABLE_ROWS) });
+  const data = (await notionFetch(ctx, `/blocks/${block.id}/children?${query}`)) as {
+    results?: NotionBlock[];
+  };
+
+  const rows = (data.results ?? [])
+    .filter((row) => row.type === "table_row")
+    .map((row) => {
+      const cells = (row as Record<string, { cells?: unknown[] } | undefined>)["table_row"]?.cells;
+      return (cells ?? []).map((cell) => inline(cell).trim());
+    });
+  if (!rows.length) return [];
+
+  const width = Math.max(...rows.map((row) => row.length));
+  const pad = (row: string[]) =>
+    `| ${[...row, ...Array(width - row.length).fill("")].join(" | ")} |`;
+
+  const header = body?.has_column_header ? rows[0] : Array<string>(width).fill("");
+  const rest = body?.has_column_header ? rows.slice(1) : rows;
+
+  return [pad(header), `| ${Array<string>(width).fill("---").join(" | ")} |`, ...rest.map(pad)];
+}
+
 /** Blocks under one parent, flattened to Markdown, following nesting to a depth. */
 async function readBlocks(
   ctx: ProviderContext,
   parentId: string,
   depth: number,
+  hops = 0,
 ): Promise<string[]> {
   const lines: string[] = [];
   let cursor: string | undefined;
+  if (hops >= MAX_HOPS) return lines;
 
   for (let page = 0; page < MAX_BLOCK_PAGES; page++) {
     const query = new URLSearchParams({ page_size: "100" });
@@ -204,12 +444,31 @@ async function readBlocks(
     };
 
     for (const block of data.results ?? []) {
+      // A table's children are its rows, and they are read as one thing rather
+      // than as blocks that happen to be underneath something.
+      if (block.type === "table") {
+        if (block.has_children && depth < MAX_BLOCK_DEPTH) {
+          lines.push(...(await readTable(ctx, block)));
+        }
+        continue;
+      }
+
       const line = blockToMarkdown(block);
       if (line) lines.push(line);
-      if (block.has_children && depth < MAX_BLOCK_DEPTH && block.type !== "child_page") {
-        const nested = await readBlocks(ctx, block.id, depth + 1);
-        // Indented so a nested list stays a nested list once it is Markdown.
-        for (const nestedLine of nested) lines.push(`    ${nestedLine}`);
+
+      if (!block.has_children || block.type === "child_page") continue;
+
+      const passthrough = PASSTHROUGH.has(block.type);
+      if (!passthrough && depth >= MAX_BLOCK_DEPTH) continue;
+
+      const nested = await readBlocks(ctx, block.id, passthrough ? depth : depth + 1, hops + 1);
+      if (INDENTS_CHILDREN.has(block.type)) {
+        for (const nestedLine of nested) lines.push(`  ${nestedLine}`);
+      } else {
+        // A toggle's contents, a callout's second paragraph, a column's whole
+        // body: content that belongs to the flow of the page rather than under
+        // a bullet, and indenting it would only misrepresent it.
+        lines.push(...nested);
       }
     }
 
@@ -217,6 +476,115 @@ async function readBlocks(
     cursor = data.next_cursor;
   }
 
+  return lines;
+}
+
+/** Whether two adjacent blocks are the kind that should stay packed together. */
+function sameRun(a: string, b: string): boolean {
+  const shapes = [/^\s*(?:[-*+]|\d+\.)\s/, /^\s*\|/, /^\s*>/];
+  return shapes.some((shape) => shape.test(a) && shape.test(b));
+}
+
+/**
+ * Blocks into a document, with the blank lines Markdown needs.
+ *
+ * Joining on a single newline — which is what this used to do — glues two
+ * paragraphs into one, because that is precisely what a single newline means in
+ * Markdown. The page read correctly in Notion and arrived here as half as many
+ * paragraphs, each twice as long, which is the shape a chunker splits worst.
+ *
+ * List items, table rows and quote lines are the exception and keep their tight
+ * spacing: a blank line between two bullets ends the list and starts another.
+ */
+function joinBlocks(blocks: string[]): string {
+  const out: string[] = [];
+  for (const block of blocks) {
+    if (out.length && !sameRun(out[out.length - 1], block)) out.push("");
+    out.push(block);
+  }
+  return out.join("\n");
+}
+
+/** One property value as a string, or "" for the shapes worth no line. */
+function propertyValue(prop: NotionProperty): string {
+  const named = (value: unknown) => (value as { name?: string } | undefined)?.name ?? "";
+
+  switch (prop.type) {
+    case "rich_text":
+      return inline(prop.rich_text).trim();
+    case "number":
+      return prop.number === null || prop.number === undefined ? "" : String(prop.number);
+    case "select":
+    case "status":
+      return named(prop[prop.type]);
+    case "multi_select":
+      return (Array.isArray(prop.multi_select) ? prop.multi_select : [])
+        .map(named)
+        .filter(Boolean)
+        .join(", ");
+    case "date": {
+      const date = prop.date as { start?: string; end?: string } | undefined;
+      if (!date?.start) return "";
+      return date.end ? `${date.start} → ${date.end}` : date.start;
+    }
+    case "checkbox":
+      return prop.checkbox ? "Yes" : "No";
+    case "url":
+    case "email":
+    case "phone_number":
+      return typeof prop[prop.type] === "string" ? (prop[prop.type] as string) : "";
+    case "people":
+      return (Array.isArray(prop.people) ? prop.people : []).map(named).filter(Boolean).join(", ");
+    case "files":
+      return (Array.isArray(prop.files) ? prop.files : [])
+        .map((f) => (f as { name?: string } | undefined)?.name ?? "")
+        .filter(Boolean)
+        .join(", ");
+    case "formula": {
+      const formula = prop.formula as Record<string, unknown> | undefined;
+      const inner = formula?.[String(formula?.type)];
+      if (inner === null || inner === undefined) return "";
+      if (typeof inner === "boolean") return inner ? "Yes" : "No";
+      if (typeof inner === "object") return (inner as { start?: string }).start ?? "";
+      return String(inner);
+    }
+    case "created_time":
+    case "last_edited_time":
+      return typeof prop[prop.type] === "string" ? (prop[prop.type] as string) : "";
+    case "unique_id": {
+      const id = prop.unique_id as { prefix?: string | null; number?: number } | undefined;
+      if (id?.number === undefined) return "";
+      return id.prefix ? `${id.prefix}-${id.number}` : String(id.number);
+    }
+    // relation and rollup arrive as ids and nested aggregates — a line of UUIDs
+    // is not something a question can match, and resolving them is a request
+    // per row per property. title is the document's own heading, already there.
+    default:
+      return "";
+  }
+}
+
+/**
+ * A database row's properties, as lines above its body.
+ *
+ * The reason this exists: in Notion a database row's content very often *is*
+ * its properties — status, owner, dates, a one-line summary — and its page body
+ * is empty. Reading only the blocks imported those rows as a title and nothing
+ * else, so a bundle full of them looked synced and answered nothing.
+ *
+ * Only for rows. An ordinary page's sole property is its title, which is
+ * already the heading, so this returns nothing and those pages import exactly
+ * as they did before.
+ */
+function propertiesToMarkdown(page: NotionPage | undefined): string[] {
+  if (page?.parent?.type !== "database_id") return [];
+
+  const lines: string[] = [];
+  for (const [name, prop] of Object.entries(page.properties ?? {})) {
+    if (!prop || prop.type === "title") continue;
+    const value = propertyValue(prop);
+    if (value) lines.push(`- **${name}:** ${value}`);
+  }
   return lines;
 }
 
@@ -313,6 +681,11 @@ export const notionProvider: ConnectionProvider = {
           name: `${titleOf(page)}.md`,
           version: page.last_edited_time ?? "",
           url: page.url ?? null,
+          // `search` has already returned this row's properties. Carrying them
+          // to `readFile` is how a database row's real content — which is its
+          // properties, not its usually-empty body — gets imported without a
+          // `/pages/{id}` call per document per sync.
+          listing: page as unknown as Record<string, unknown>,
         });
       }
 
@@ -324,12 +697,13 @@ export const notionProvider: ConnectionProvider = {
   },
 
   async readFile(ctx: ProviderContext, file: RemoteFile): Promise<string> {
-    const lines = await readBlocks(ctx, file.externalId, 0);
+    const properties = propertiesToMarkdown(file.listing as NotionPage | undefined);
+    const body = await readBlocks(ctx, file.externalId, 0);
     // The title is prepended as a heading because the body does not contain it
     // — in Notion the title is a property, not the first block — and a chunk
     // that never names its own document retrieves badly for the question that
     // uses the document's name.
     const title = file.name.replace(/\.md$/, "");
-    return [`# ${title}`, "", ...lines].join("\n").trim();
+    return `# ${title}\n\n${joinBlocks([...properties, ...body])}`.trim();
   },
 };

--- a/worker/src/lib/connections/types.ts
+++ b/worker/src/lib/connections/types.ts
@@ -56,6 +56,21 @@ export type RemoteFile = {
   version: string;
   /** A link to the original, so a citation can open the source document. */
   url: string | null;
+  /**
+   * Whatever the listing already knew and reading would otherwise ask for again.
+   *
+   * Optional, provider-shaped, and never persisted: `sync.ts` hands `readFile`
+   * the very object `listFiles` returned, in the same run, so this is a way of
+   * not making a second request rather than a second source of truth. Notion
+   * uses it for a database row's properties — `search` returns them, and the
+   * alternative is one `/pages/{id}` call per document per sync, which on a
+   * 500-page connection is 500 requests to learn something already in hand.
+   *
+   * A provider that does not set it loses nothing: `google-drive.ts` never
+   * reads it, and a file rebuilt from anywhere but a listing simply arrives
+   * without it.
+   */
+  listing?: Record<string, unknown>;
 };
 
 /** What a provider needs to talk to its API on one connection's behalf. */


### PR DESCRIPTION
The converter read `plain_text` and block types and nothing else, and six kinds of content went missing on the way in. Every one was invisible from Covan — the document existed, was named to the model on every turn, and simply said less than the page it came from.

- **Links.** Notion puts the target in `href` on the rich-text run, not in a block type, so a converter that only reads block types loses every URL. A page whose value is thirty links to other things arrived as thirty words. Annotations went the same way; they are kept now, with whitespace moved outside the markers because `**bold **` renders as asterisks in every parser.
- **Tables.** Rows are children of the `table` block, so the generic nesting path indented them four spaces — Markdown's code-block marker — and never wrote the delimiter row. `docs/integrations.md` claimed tables survived; they arrived as a monospaced blob. They are read as one thing now, with a delimiter, and a headerless table gets one under an empty header row.
- **The same four spaces** did it to toggles, callouts and multi-column layouts. Indentation is now two spaces and only under a list item, which is the only place it means anything. Columns no longer spend a level of `MAX_BLOCK_DEPTH`, so a page laid out in columns keeps the lists inside them.
- **Media, bookmarks, embeds and equations** have no top-level `rich_text`, so the default branch returned `""` and a page of bookmarks imported as an empty document. Captions and URLs are read from where they live. A Notion-hosted file's URL is deliberately not written down: it is signed and expires in about an hour, so it would be a link that worked once.
- **Paragraphs were glued together.** Blocks were joined on a single newline, which in Markdown is exactly how you write one paragraph. Blank lines now separate blocks, except between list items, table rows and quote lines, where a blank line would end the run.
- **Database rows brought nothing but a title.** In a Notion database the row's content usually *is* its properties and the body is empty. `search` already returns them, so `RemoteFile.listing` carries the page object from the listing to the read — no extra request per document. Relations and rollups are skipped: ids and nested aggregates match no question. An ordinary page has only a title property and imports exactly as before.

**`docs/integrations.md`'s Notion section is rewritten** for both halves — what is imported, and setup steps that described a portal which no longer exists. Notion has renamed integrations to connections and moved them to `app.notion.com/developers/connections`; there is no internal-first conversion step any more, the New connection dialog asks for OAuth or a static access token (only the first can work here), and the installation scope cannot be changed after creation.

**Verified:** 876 worker tests (11 new, one per defect above), 495 frontend, typecheck and eslint on both trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)