### PR TITLE
A shortcut is a file somebody put there

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -165,10 +165,19 @@ browser in a scheduled sync, so an imported PDF would be a document that is
 listed, named to the agent on every turn, and impossible to retrieve a sentence
 of. Upload those by hand.
 
+**Shortcuts are followed.** "Add shortcut to Drive" is how most people get a
+document from a shared drive into the folder they actually work in, so a real
+team folder is often mostly shortcuts. Each one is read as the file it points
+at — the target's name, and the target's modified time, so editing the document
+re-imports it. A shortcut to a subfolder is walked into like any other folder.
+If the folder holds both a file and a shortcut to that same file, it is imported
+once.
+
 Files larger than 10 MB are skipped, the same ceiling the upload form applies.
 
-**Limits.** One folder, two levels of subfolders, and six listing requests per
-sync — enough for a few hundred files in an ordinary folder tree.
+**Limits.** One folder, two levels of subfolders, six listing requests and
+twenty-five resolved shortcuts per sync — enough for a few hundred files in an
+ordinary folder tree.
 
 ### Setting it up
 

--- a/worker/src/lib/connections/google-drive.test.ts
+++ b/worker/src/lib/connections/google-drive.test.ts
@@ -185,6 +185,139 @@ describe("google drive provider", () => {
     });
   });
 
+  // "Add shortcut to Drive" is how somebody puts a document from a shared drive
+  // into the folder they work in. Every one of these used to be skipped without
+  // a word, so a folder of shortcuts synced as an empty bundle.
+  it("follows a shortcut to the file it points at", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/files/doc-1")) {
+        return json({
+          id: "doc-1",
+          name: "Handbook",
+          mimeType: "application/vnd.google-apps.document",
+          // The target's modified time, not the shortcut's. The shortcut never
+          // changes when the document is edited, so using its own would mean an
+          // edited document never re-imported.
+          modifiedTime: "2026-09-02T10:00:00Z",
+          webViewLink: "https://docs.google.com/doc-1",
+        });
+      }
+      return json({
+        files: [
+          {
+            id: "short-1",
+            name: "Handbook shortcut",
+            mimeType: "application/vnd.google-apps.shortcut",
+            modifiedTime: "2026-01-01T00:00:00Z",
+            shortcutDetails: {
+              targetId: "doc-1",
+              targetMimeType: "application/vnd.google-apps.document",
+            },
+          },
+        ],
+      });
+    }) as unknown as typeof fetch;
+
+    const files = await googleDriveProvider.listFiles(ctx(fetchImpl, { folderId: "root" }));
+
+    expect(files).toEqual([
+      {
+        externalId: "doc-1",
+        name: "Handbook.md",
+        version: "2026-09-02T10:00:00Z",
+        url: "https://docs.google.com/doc-1",
+      },
+    ]);
+  });
+
+  it("walks into a shortcut to a folder without spending a request on it", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      const q = url.searchParams.get("q") ?? "";
+      if (q.includes("'root'")) {
+        return json({
+          files: [
+            {
+              id: "short-f",
+              name: "Policies shortcut",
+              mimeType: "application/vnd.google-apps.shortcut",
+              shortcutDetails: {
+                targetId: "sub",
+                targetMimeType: "application/vnd.google-apps.folder",
+              },
+            },
+          ],
+        });
+      }
+      return json({
+        files: [
+          { id: "doc-2", name: "Leave.md", mimeType: "text/markdown", modifiedTime: "2026-08-01" },
+        ],
+      });
+    }) as unknown as typeof fetch;
+
+    const files = await googleDriveProvider.listFiles(ctx(fetchImpl, { folderId: "root" }));
+
+    expect(files.map((f) => f.externalId)).toEqual(["doc-2"]);
+    // Two listings and no metadata read: a folder shortcut carries the only
+    // thing the walk wants, which is an id.
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("imports one document when the folder holds both a file and a shortcut to it", async () => {
+    const fetchImpl = vi.fn(async () =>
+      json({
+        files: [
+          {
+            id: "doc-1",
+            name: "Handbook",
+            mimeType: "application/vnd.google-apps.document",
+            modifiedTime: "2026-09-01T10:00:00Z",
+          },
+          {
+            id: "short-1",
+            name: "Handbook shortcut",
+            mimeType: "application/vnd.google-apps.shortcut",
+            shortcutDetails: {
+              targetId: "doc-1",
+              targetMimeType: "application/vnd.google-apps.document",
+            },
+          },
+        ],
+      }),
+    ) as unknown as typeof fetch;
+
+    const files = await googleDriveProvider.listFiles(ctx(fetchImpl, { folderId: "root" }));
+
+    // `documents` is unique on (connection_id, external_id), so a second copy
+    // would be a constraint fight on every sync rather than a second document.
+    expect(files.map((f) => f.externalId)).toEqual(["doc-1"]);
+    // And the target was recognised without being fetched.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips a shortcut to something it could not read anyway", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/files/scan")) {
+        return json({ id: "scan", name: "contract.pdf", mimeType: "application/pdf" });
+      }
+      return json({
+        files: [
+          {
+            id: "short-p",
+            name: "contract shortcut",
+            mimeType: "application/vnd.google-apps.shortcut",
+            shortcutDetails: { targetId: "scan", targetMimeType: "application/pdf" },
+          },
+        ],
+      });
+    }) as unknown as typeof fetch;
+
+    expect(await googleDriveProvider.listFiles(ctx(fetchImpl, { folderId: "root" }))).toEqual([]);
+  });
+
   it("skips a file bigger than the upload form would have taken", async () => {
     const fetchImpl = vi.fn(async () =>
       json({

--- a/worker/src/lib/connections/google-drive.ts
+++ b/worker/src/lib/connections/google-drive.ts
@@ -75,6 +75,31 @@ const MAX_BYTES = 10 * 1024 * 1024;
 const FOLDER_MIME = "application/vnd.google-apps.folder";
 
 /**
+ * A pointer to a file that lives somewhere else.
+ *
+ * "Add shortcut to Drive" is how a person puts a document from a shared drive
+ * into the folder they actually work in, so in a real team folder these are
+ * ordinary and often most of what is there. Drive returns them as files of
+ * their own with this type, and the first version of this file had no case for
+ * it: `importableName` returned null and every one of them was skipped without
+ * a word. A folder of shortcuts synced as an empty bundle.
+ */
+const SHORTCUT_MIME = "application/vnd.google-apps.shortcut";
+
+/**
+ * How many shortcuts one listing may resolve.
+ *
+ * A shortcut carries its target's id and type but not its `modifiedTime`, and
+ * the modified time is the whole of how this sync decides a file has changed —
+ * using the shortcut's own would mean edits to the target never re-imported it.
+ * So each one costs a metadata request, and this bounds that. Past it the
+ * listing reports itself truncated, the same as any other ceiling here.
+ *
+ * A shortcut to a *folder* costs nothing: its target id is all the walk needs.
+ */
+const MAX_SHORTCUTS = 25;
+
+/**
  * How a Google-native file becomes text, and what it is called afterwards.
  *
  * The extension is chosen to match what the export actually produces, because
@@ -119,6 +144,8 @@ type DriveFile = {
   modifiedTime?: string;
   webViewLink?: string;
   size?: string;
+  /** Present only on a shortcut, and the only thing that makes one useful. */
+  shortcutDetails?: { targetId?: string; targetMimeType?: string };
 };
 
 function withExtension(name: string, extension: string): string {
@@ -173,6 +200,30 @@ export async function listFolders(
   return data.files ?? [];
 }
 
+/**
+ * What a shortcut points at, as though it had been in the folder itself.
+ *
+ * The target's own metadata, not the shortcut's: its name, its type, and above
+ * all its `modifiedTime`, which is what tells the next sync the document has
+ * been edited. Returning null — the target is gone, or is a type nothing can
+ * read — is an ordinary outcome and means the shortcut is skipped, exactly as a
+ * file of that type in the folder would have been.
+ */
+async function resolveShortcut(
+  ctx: ProviderContext,
+  shortcut: DriveFile,
+): Promise<DriveFile | null> {
+  const targetId = shortcut.shortcutDetails?.targetId;
+  if (!targetId) return null;
+
+  const res = await driveFetch(ctx, `/files/${targetId}`, {
+    fields: "id,name,mimeType,modifiedTime,webViewLink,size",
+    supportsAllDrives: "true",
+  });
+  const target = (await res.json()) as DriveFile;
+  return target.id ? target : null;
+}
+
 /** Everything under one folder, following subfolders, within the request budget. */
 async function listTree(
   ctx: ProviderContext,
@@ -180,6 +231,15 @@ async function listTree(
 ): Promise<{ files: DriveFile[]; truncated: boolean }> {
   const files: DriveFile[] = [];
   const queue: Array<{ id: string; depth: number }> = [{ id: rootId, depth: 0 }];
+  // Shortcuts are resolved after the walk rather than during it, so a folder
+  // full of them cannot spend the listing budget before the walk has seen the
+  // rest of the tree.
+  const shortcuts: DriveFile[] = [];
+  // A shortcut and its target can both be in the tree, and after resolution
+  // they are the same file with the same id. Importing it twice would be two
+  // documents of one thing on the first sync and a fight over one row on every
+  // sync after, since `documents` is unique on (connection_id, external_id).
+  const seen = new Set<string>();
   let requests = 0;
   let truncated = false;
 
@@ -193,7 +253,9 @@ async function listTree(
 
       const query: Record<string, string> = {
         q: `'${id.replace(/'/g, "\\'")}' in parents and trashed = false`,
-        fields: "nextPageToken,files(id,name,mimeType,modifiedTime,webViewLink,size)",
+        fields:
+          "nextPageToken,files(id,name,mimeType,modifiedTime,webViewLink,size," +
+          "shortcutDetails(targetId,targetMimeType))",
         pageSize: "100",
         supportsAllDrives: "true",
         includeItemsFromAllDrives: "true",
@@ -204,15 +266,55 @@ async function listTree(
       const data = (await res.json()) as { files?: DriveFile[]; nextPageToken?: string };
 
       for (const file of data.files ?? []) {
+        if (file.mimeType === SHORTCUT_MIME) {
+          // A shortcut to a folder needs nothing fetched: the walk only wants an
+          // id, and the folder's own listing supplies everything about what is
+          // inside it.
+          if (file.shortcutDetails?.targetMimeType === FOLDER_MIME) {
+            const targetId = file.shortcutDetails.targetId;
+            if (!targetId) continue;
+            if (depth < MAX_FOLDER_DEPTH) queue.push({ id: targetId, depth: depth + 1 });
+            else truncated = true;
+            continue;
+          }
+          shortcuts.push(file);
+          continue;
+        }
+
         if (file.mimeType === FOLDER_MIME) {
           if (depth < MAX_FOLDER_DEPTH) queue.push({ id: file.id, depth: depth + 1 });
           else truncated = true;
           continue;
         }
+
+        if (seen.has(file.id)) continue;
+        seen.add(file.id);
         files.push(file);
       }
       pageToken = data.nextPageToken;
     } while (pageToken);
+  }
+
+  // Their own budget rather than the listing one. A tree big enough to spend
+  // all six listing requests would otherwise drop every shortcut in it, and
+  // these are metadata reads of one file each — far cheaper than the page
+  // listings that ceiling exists to bound.
+  let resolved = 0;
+  for (const shortcut of shortcuts) {
+    const targetId = shortcut.shortcutDetails?.targetId;
+    // The target is already in this tree: somebody put both the file and a
+    // shortcut to it in the folder, which is not rare and is not two documents.
+    if (!targetId || seen.has(targetId)) continue;
+    if (resolved >= MAX_SHORTCUTS) {
+      truncated = true;
+      break;
+    }
+    resolved++;
+
+    const target = await resolveShortcut(ctx, shortcut);
+    if (!target || seen.has(target.id)) continue;
+    seen.add(target.id);
+    files.push(target);
   }
 
   return { files, truncated };


### PR DESCRIPTION
`application/vnd.google-apps.shortcut` had no case anywhere in `google-drive.ts`, so `importableName` returned null for every one and the listing dropped it without a word.

That is not an edge. "Add shortcut to Drive" is how a person gets a document out of a shared drive and into the folder they actually work in, so a real team folder is often mostly shortcuts — and it synced as an empty bundle with a healthy-looking run.

A shortcut is now read as the file it points at, and the two kinds are handled differently:

- **To a folder**, nothing is fetched. The walk wants an id and the shortcut carries one, so it is queued like any other subfolder.
- **To a file**, the target's metadata is read. Not for the name — for `modifiedTime`, which is the whole of how this sync decides a document has changed. A shortcut's own modified time never moves when the document behind it is edited, so reusing it would have imported the file once and then never noticed another word of it.

Resolution happens after the walk, on its own budget of twenty-five, so a folder full of shortcuts cannot spend the six listing requests before the walk has seen the rest of the tree — and a tree big enough to spend them all does not lose every shortcut as a consequence. These are single-file metadata reads, much cheaper than the page listings that ceiling exists to bound.

**The tree is deduplicated by id**, which it was not before and now must be: a folder holding both a file and a shortcut to it resolves to the same document twice, and `documents` is unique on `(connection_id, external_id)` — so the second copy would be a constraint fight on every sync rather than a second document. A shortcut whose target is already listed is skipped before it costs a request.

A shortcut to something unreadable — a PDF, a Drawing — is skipped exactly as that file would have been sitting in the folder itself.

**Verified:** 869 worker tests (4 new), 495 frontend, typecheck and eslint on both trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)