### PR TITLE
An answer that reads as Slack writes it

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -208,6 +208,13 @@ workspace is told so rather than answered — the alternative, running every
 question as whoever installed the app, would retrieve with that person's access
 and log every question as theirs.
 
+**Answers are written in Slack's own formatting.** The agent writes Markdown,
+which Slack does not read — its `text` is *mrkdwn*, a different language — so
+replies are translated on the way out: bold, italic, strikethrough, links,
+headings and lists all arrive formatted rather than as visible asterisks and
+brackets. Code blocks are passed through untouched, since both languages spell
+them the same way.
+
 **Each thread becomes a conversation in Covan.** A question asked in a channel
 creates a shared conversation; a direct message creates a private one. Either
 way it is an ordinary conversation afterwards — searchable, exportable, and

--- a/worker/src/lib/slack/handle.test.ts
+++ b/worker/src/lib/slack/handle.test.ts
@@ -198,6 +198,31 @@ describe("answering in a thread", () => {
     expect(posted().text).toContain("Handbook.md");
   });
 
+  // The model writes Markdown because every other surface in Covan renders it.
+  // Slack's `text` is mrkdwn, so an answer posted straight through arrives with
+  // its asterisks and brackets showing. `lib/slack/mrkdwn` covers the language
+  // itself; this is the wiring.
+  it("posts the answer in the language Slack reads", async () => {
+    create.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: "**Twenty days** a year — see [the policy](https://example.com/p).",
+          },
+        },
+      ],
+      usage: { prompt_tokens: 500, completion_tokens: 20 },
+    });
+    const fake = db({ identity: true });
+
+    await handleSlackEvent(await installation(), mention(), deps(fake));
+
+    expect(posted().text).toContain(
+      "*Twenty days* a year — see <https://example.com/p|the policy>.",
+    );
+    expect(posted().text).not.toContain("**");
+  });
+
   it("keeps the exchange in Covan as an ordinary conversation", async () => {
     const fake = db({ identity: true });
 

--- a/worker/src/lib/slack/handle.ts
+++ b/worker/src/lib/slack/handle.ts
@@ -10,6 +10,7 @@ import { resolveModel } from "../models";
 import { createOpenAI } from "../openai";
 import { decryptSecret } from "../secret-box";
 import { lookupEmail, postMessage } from "./api";
+import { toMrkdwn } from "./mrkdwn";
 
 /**
  * A question asked in Slack, answered by the agent, in the thread.
@@ -273,7 +274,12 @@ export async function handleSlackEvent(
   // answer the person paid for and never saw.
   if (replyError) console.error("slack: failed to record the answer", replyError);
 
-  await say(withCitations(answer, retrieval.sources));
+  // The model writes Markdown, because every other surface in Covan renders
+  // Markdown. Slack does not: `text` is mrkdwn, a different language, and an
+  // answer posted straight into it arrives with its own asterisks and brackets
+  // showing. The citation line below has always been mrkdwn — `_From: …_` — and
+  // that is the tell that the answer above it never was.
+  await say(withCitations(toMrkdwn(answer), retrieval.sources));
 }
 
 /**

--- a/worker/src/lib/slack/mrkdwn.test.ts
+++ b/worker/src/lib/slack/mrkdwn.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { toMrkdwn } from "./mrkdwn";
+
+describe("markdown as Slack reads it", () => {
+  it("writes bold the way mrkdwn spells it", () => {
+    // The defect, at its smallest. This arrived in Slack as four visible
+    // asterisks around a word.
+    expect(toMrkdwn("**Deadline** is Friday")).toBe("*Deadline* is Friday");
+    expect(toMrkdwn("__Deadline__ is Friday")).toBe("*Deadline* is Friday");
+  });
+
+  it("writes italic the way mrkdwn spells it, without eating bold", () => {
+    expect(toMrkdwn("*maybe* Friday")).toBe("_maybe_ Friday");
+    expect(toMrkdwn("**definitely** and *maybe*")).toBe("*definitely* and _maybe_");
+  });
+
+  it("leaves an underscore inside a word alone", () => {
+    // mrkdwn italicises on `_`, so a rule that rewrote these would turn half an
+    // identifier into emphasis. Markdown does not italicise them either.
+    expect(toMrkdwn("call some_var_name first")).toBe("call some_var_name first");
+  });
+
+  it("turns a link into one somebody can click", () => {
+    expect(toMrkdwn("See [the policy](https://example.com/p) first")).toBe(
+      "See <https://example.com/p|the policy> first",
+    );
+  });
+
+  it("does not let emphasis rules loose on a URL", () => {
+    // The reason links are cut out before anything else runs: every one of
+    // these characters is meaningful to a rule below.
+    expect(toMrkdwn("[docs](https://example.com/a_b_c)")).toBe("<https://example.com/a_b_c|docs>");
+    expect(toMrkdwn("[x](https://example.com/*star*)")).toBe("<https://example.com/*star*|x>");
+  });
+
+  it("unwraps an autolink rather than escaping it into text", () => {
+    expect(toMrkdwn("<https://example.com/pricing>")).toBe("https://example.com/pricing");
+  });
+
+  it("escapes what Slack would otherwise read as markup", () => {
+    expect(toMrkdwn("a < b && c")).toBe("a &lt; b &amp;&amp; c");
+  });
+
+  it("keeps a blockquote a blockquote", () => {
+    // `>` is the one of the three that is not escaped, because at the start of
+    // a line it means the same thing in both languages.
+    expect(toMrkdwn("> quoted")).toBe("> quoted");
+  });
+
+  it("makes a heading read like one, since mrkdwn has none", () => {
+    expect(toMrkdwn("## Leave policy\nTwenty days.")).toBe("*Leave policy*\nTwenty days.");
+  });
+
+  it("gives a list bullets, since mrkdwn has no lists either", () => {
+    expect(toMrkdwn("- one\n- two\n  - nested")).toBe("• one\n• two\n  • nested");
+  });
+
+  it("bullets a list item that is only a link", () => {
+    expect(toMrkdwn("- [the policy](https://example.com/p)")).toBe(
+      "• <https://example.com/p|the policy>",
+    );
+  });
+
+  it("writes strikethrough with one tilde", () => {
+    expect(toMrkdwn("~~withdrawn~~")).toBe("~withdrawn~");
+  });
+
+  it("leaves a code fence exactly as the model wrote it", () => {
+    const answer = "Run this:\n\n```sql\nselect * from users where a_b = 1\n```\n\nThen **stop**.";
+    expect(toMrkdwn(answer)).toBe(
+      "Run this:\n\n```sql\nselect * from users where a_b = 1\n```\n\nThen *stop*.",
+    );
+  });
+
+  it("leaves an inline code span alone", () => {
+    expect(toMrkdwn("set `**not bold**` in the file")).toBe("set `**not bold**` in the file");
+  });
+
+  it("treats an unclosed fence as code rather than half-converting it", () => {
+    // A model that runs out of room leaves one open. Bullet-pointing the
+    // remains of a code sample is the failure that reads as deliberate.
+    const answer = "Try:\n\n```\n- not a bullet\n**not bold**";
+    expect(toMrkdwn(answer)).toBe("Try:\n\n```\n- not a bullet\n**not bold**");
+  });
+
+  it("leaves an ordinary sentence untouched", () => {
+    expect(toMrkdwn("Twenty days a year, and you ask in advance.")).toBe(
+      "Twenty days a year, and you ask in advance.",
+    );
+  });
+});

--- a/worker/src/lib/slack/mrkdwn.ts
+++ b/worker/src/lib/slack/mrkdwn.ts
@@ -1,0 +1,119 @@
+/**
+ * Markdown, as Slack actually reads it.
+ *
+ * The model writes Markdown. Every other surface in Covan renders Markdown, so
+ * that is the right thing for it to write — but Slack's `text` field is not
+ * Markdown, it is *mrkdwn*, which is a different language that happens to look
+ * similar. `**bold**` is not bold there; it is two asterisks, a word, and two
+ * more asterisks. `[the policy](https://…)` is not a link; it is the label and
+ * then the URL in brackets, both visible.
+ *
+ * So every answer this app posted arrived with its formatting showing. The
+ * citation line underneath it was correct — `_From: …_` is mrkdwn italic — which
+ * is the tell: the language was known and the answer simply never went through
+ * it.
+ *
+ * What is different, in the order it matters:
+ *
+ * | Markdown        | mrkdwn          |
+ * | --------------- | --------------- |
+ * | `**bold**`      | `*bold*`        |
+ * | `*italic*`      | `_italic_`      |
+ * | `~~strike~~`    | `~strike~`      |
+ * | `[a](url)`      | `<url\|a>`      |
+ * | `# Heading`     | `*Heading*`     |
+ * | `- item`        | `• item`        |
+ *
+ * Code fences and inline code are the same in both, and are the reason this is
+ * a small parser rather than a list of replacements: the contents of a fence
+ * must survive untouched, or an answer explaining a Markdown syntax error
+ * rewrites the very thing it is explaining.
+ *
+ * There are no placeholders anywhere below, deliberately. The obvious way to
+ * write this is to swap the awkward constructs for sentinels and swap them back
+ * at the end, and the awkward constructs are exactly the ones a sentinel can be
+ * confused with. Splitting the text and converting only the parts that are
+ * prose has no such failure.
+ */
+
+/** A Markdown link, which is the one construct that must be cut out whole. */
+const LINK = /\[([^\]\n]*)\]\(([^)\s]+)\)/g;
+
+/**
+ * The characters Slack reads as markup.
+ *
+ * `>` is deliberately not escaped: at the start of a line it is a blockquote in
+ * mrkdwn too, and escaping it would turn every quoted passage into a visible
+ * `&gt;`. Mid-sentence it is harmless, which is the trade this makes.
+ */
+function escape(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+}
+
+/** Prose with no links in it, converted. */
+function convertPlain(input: string): string {
+  // A Markdown autolink is already a bare URL to Slack, which linkifies it
+  // itself. Unwrapping it before the escape below is what stops it arriving as
+  // `&lt;https://…&gt;`.
+  let text = escape(input.replace(/<(https?:\/\/[^>\s]+)>/g, "$1"));
+
+  // Italic before bold, which is the ordering the whole function turns on.
+  // mrkdwn spells italic `*`, so converting bold first would produce `*x*` and
+  // leave the italic rule unable to tell what it was looking at. Going the
+  // other way, the lookarounds mean a `**` is never mistaken for a `*`.
+  text = text.replace(/(?<!\*)\*(?!\*)([^*\n]+?)\*(?!\*)/g, "_$1_");
+  text = text.replace(/\*\*([^\n]+?)\*\*/g, "*$1*");
+  text = text.replace(/__([^\n]+?)__/g, "*$1*");
+  text = text.replace(/~~([^\n]+?)~~/g, "~$1~");
+
+  return text
+    .split("\n")
+    .map((line) => {
+      // mrkdwn has no headings at all. Bold is what a heading is for here:
+      // something that reads as a heading in a wall of text.
+      const heading = line.match(/^#{1,6}\s+(.*)$/);
+      if (heading) return heading[1].trim() ? `*${heading[1].trim()}*` : "";
+
+      // Nor lists. A bullet character is what everybody types by hand, and it
+      // keeps the indentation that shows which level an item is at.
+      const bullet = line.match(/^([ \t]*)[-*+]\s+(.*)$/);
+      if (bullet) return `${bullet[1]}• ${bullet[2]}`;
+
+      return line;
+    })
+    .join("\n");
+}
+
+/** Prose, with its links cut out and rebuilt in Slack's spelling. */
+function convertProse(input: string): string {
+  const out: string[] = [];
+  let last = 0;
+
+  for (const match of input.matchAll(LINK)) {
+    const at = match.index ?? 0;
+    out.push(convertPlain(input.slice(last, at)));
+
+    // The label is text and is escaped; the URL is not, because escaping it is
+    // how you hand Slack a link that does not work.
+    const label = escape(match[1]).trim();
+    out.push(label ? `<${match[2]}|${label}>` : `<${match[2]}>`);
+    last = at + match[0].length;
+  }
+
+  out.push(convertPlain(input.slice(last)));
+  return out.join("");
+}
+
+/**
+ * An answer, ready for `chat.postMessage`.
+ *
+ * Code is split out first and passed through untouched — both fenced blocks and
+ * inline spans, since mrkdwn spells them the way Markdown does. An unclosed
+ * fence is matched too, and deliberately: a model that runs out of room leaves
+ * one open, and treating the remainder as code is a far better failure than
+ * turning half a code sample into bullet points.
+ */
+export function toMrkdwn(markdown: string): string {
+  const parts = markdown.split(/(```[\s\S]*?```|```[\s\S]*$|`[^`\n]+`)/g);
+  return parts.map((part, index) => (index % 2 === 1 ? part : convertProse(part))).join("");
+}


### PR DESCRIPTION
The model writes Markdown, because every other surface in Covan renders Markdown. Slack does not: `chat.postMessage`'s `text` is **mrkdwn**, a different language that happens to look similar. `**bold**` is not bold there — it is two asterisks, a word, and two more asterisks. `[the policy](https://…)` is not a link; it is the label and then the URL in brackets, both visible.

So every answer this app has posted arrived with its formatting showing. The citation line underneath it was correct all along — `_From: …_` is mrkdwn italic — which is the tell: the language was known, and the answer above it simply never went through it.

| Markdown | mrkdwn |
| --- | --- |
| `**bold**` | `*bold*` |
| `*italic*` | `_italic_` |
| `~~strike~~` | `~strike~` |
| `[a](url)` | `<url\|a>` |
| `# Heading` | `*Heading*` |
| `- item` | `• item` |

`lib/slack/mrkdwn.ts` translates on the way out. Code fences and inline spans pass through untouched, since both languages spell those the same way.

Three decisions in it worth the reading:

- **No placeholders.** The obvious implementation swaps the awkward constructs for sentinels and swaps them back, and the awkward constructs are exactly what a sentinel can be confused with. Text is split instead, and only the parts that are prose are converted.
- **Italic is converted before bold.** mrkdwn spells italic `*`, so doing bold first produces `*x*` and leaves the italic rule unable to tell what it is looking at.
- **Links are cut out before any of it runs.** A URL is entitled to contain `*`, `_` and `~`, and `example.com/a_b_c` would otherwise come back italicised in the middle. `&` and `<` are escaped in text; `>` is not, because at the start of a line it is a blockquote in mrkdwn too.

An unclosed fence — what a model leaves when it runs out of room — is treated as code to the end of the answer. Bullet-pointing the remains of a code sample is the failure that reads as deliberate.

**Verified:** 882 worker tests (17 new — 16 on the language, one on the wiring), 495 frontend, typecheck and eslint on both trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)