### PR TITLE
A second provider behind the same model picker

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -28,6 +28,23 @@ OPENAI_API_KEY=
 OPENAI_BASE_URL=
 OPENAI_MODEL=
 
+# ---- Optional: offer Anthropic's models too ----------------------------
+# https://console.anthropic.com/settings/keys
+#
+# Covan needs exactly one provider to answer anything, and OPENAI_API_KEY above
+# is it. Setting this adds three more to the model picker — claude-sonnet-4-6,
+# claude-sonnet-4-5 and claude-haiku-4-5 — and is the *only* thing that makes
+# them appear. Leave it empty and nothing this stack sends ever addresses
+# Anthropic: the ids are not offered, not accepted, and not resolved.
+#
+# It does not replace OPENAI_API_KEY. Document embeddings and audio
+# transcription have no Anthropic equivalent here and stay where they were.
+#
+# ANTHROPIC_BASE_URL is the Anthropic half of OPENAI_BASE_URL — a gateway or
+# proxy in front of api.anthropic.com. Empty means Anthropic directly.
+ANTHROPIC_API_KEY=
+ANTHROPIC_BASE_URL=
+
 # ---- Optional: send documents somewhere other than OpenAI --------------
 # Embedding is where the whole text of every uploaded document is sent, so
 # this is the setting that decides whether self-hosting keeps your files in.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ one.
   the SQL to replay it into a Covan you run yourself. "Nothing is held
   hostage" should be checkable by the team, not only by whoever runs the
   server ([`docs/export.md`](docs/export.md)).
+- **Pick the model per agent.** OpenAI's GPT-4o, GPT-4.1 and GPT-5 families
+  out of the box; add `ANTHROPIC_API_KEY` and Claude Sonnet 4.6, Sonnet 4.5 and
+  Haiku 4.5 join the picker. Leave that key unset and nothing reaches
+  Anthropic — the models are not offered, not accepted, and not resolved.
 - **Bring your own endpoint.** Set `OPENAI_BASE_URL` and completions go to
   Ollama, vLLM, LiteLLM or OpenRouter instead of OpenAI. Set
   `EMBEDDING_BASE_URL` and your documents go there too — a separate variable,
@@ -123,7 +127,7 @@ flowchart LR
   API["API<br/>Hono · Workers or Node"]
   DB[("Postgres<br/>RLS · pgvector")]
   STORE[["Documents<br/>R2 or filesystem"]]
-  LLM["OpenAI"]
+  LLM["Model provider<br/>OpenAI · Anthropic"]
 
   WEB -->|"bearer token"| API
   API -->|"request-scoped client<br/>auth.uid() → RLS"| DB

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -317,6 +317,11 @@ services:
       # what still goes there regardless.
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
       OPENAI_MODEL: ${OPENAI_MODEL:-}
+      # Anthropic, optionally. Empty is the supported default and means the
+      # Claude models are not offered, not accepted and not resolved — nothing
+      # this stack sends reaches Anthropic. Setting it is the opt-in.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-}
       # Documents, separately. Empty means api.openai.com — and it means that
       # even when OPENAI_BASE_URL above is set, which is the point: moving your
       # conversations is not the same decision as moving every file you upload.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -83,9 +83,13 @@ a model and a mode, on a row that belongs to a workspace. It is shared by
 construction — there is no owner column that grants anything, so every member of
 the workspace sees the same agent and can edit it.
 
-The model is one of four OpenAI ids (`gpt-4o`, `gpt-4o-mini`, `gpt-4.1`,
-`gpt-4.1-mini`); anything the API does not recognise resolves to `gpt-4o`, which
-is what keeps an agent created against an older list working. The mode is
+The model is one of seven OpenAI ids (`gpt-4o`, `gpt-4o-mini`, `gpt-4.1`,
+`gpt-4.1-mini`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`), or one of three Anthropic
+ones (`claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-haiku-4-5`) on an
+install whose operator set `ANTHROPIC_API_KEY`. Anything the API does not
+recognise — an id from an older list, or a Claude one on an install with no key
+for it — resolves to `gpt-4o`, which is what keeps every agent answering across
+a change to either list. The mode is
 `normal` or `brainstorm`, and brainstorm layers a facilitation instruction block
 on top of the persona rather than replacing it.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -106,6 +106,8 @@ every line in `.env.docker.example`, in the order it appears there.
 | `OPENAI_API_KEY`                                       | _empty — you must set it_  | Chat completions and `text-embedding-3-small`. Nothing else needs an account.                                                                                                                                                                |
 | `OPENAI_BASE_URL`                                      | _empty — means OpenAI_     | Optional. Sends completions to an OpenAI-compatible endpoint instead. See below — it does not move everything.                                                                                                                               |
 | `OPENAI_MODEL`                                         | _empty_                    | Optional. Forces one model for every completion, overriding the per-agent picker. Needed whenever `OPENAI_BASE_URL` is set.                                                                                                                  |
+| `ANTHROPIC_API_KEY`                                    | _empty — no Claude models_ | Optional. Adds Anthropic's models to the picker. Empty means they are not offered, not accepted and not resolved — nothing reaches Anthropic. See below.                                                                                     |
+| `ANTHROPIC_BASE_URL`                                   | _empty — means Anthropic_  | Optional. Sends Claude completions to a gateway in front of `api.anthropic.com`. The Anthropic half of `OPENAI_BASE_URL`.                                                                                                                    |
 | `EMBEDDING_BASE_URL`                                   | _empty — means OpenAI_     | Optional. Sends document embeddings to an OpenAI-compatible endpoint. Deliberately does **not** follow `OPENAI_BASE_URL`.                                                                                                                    |
 | `EMBEDDING_MODEL`                                      | _empty_                    | Optional. Defaults to `text-embedding-3-small`. Set it whenever `EMBEDDING_BASE_URL` is set.                                                                                                                                                 |
 | `EMBEDDING_DIMENSIONS`                                 | _empty — means 1536_       | Optional. The width `document_chunks.embedding` was declared with. Changing it is a schema change — see below. Refuses to boot on anything but a positive whole number.                                                                      |
@@ -145,6 +147,43 @@ does nothing: the Compose stack passes an explicit list of variables to
 `covan-api`, and this is not on it. To use the endpoint on the Docker stack, add
 `ADMIN_API_KEY: ${ADMIN_API_KEY:-}` to that service's `environment:` block
 first.
+
+### Offering Anthropic's models as well
+
+Covan ships two provider lists. OpenAI's is always there, because
+`OPENAI_API_KEY` is required and embeddings and voice notes go through it
+regardless. Anthropic's exists only if you say so:
+
+```bash
+# in .env, for the Docker stack
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+That one line adds three models to every picker:
+
+| Model               | Roughly       | Good for                                                    |
+| ------------------- | ------------- | ----------------------------------------------------------- |
+| `claude-sonnet-4-6` | $3 / $15 a M  | The default Claude pick — strongest of the three.             |
+| `claude-sonnet-4-5` | $3 / $15 a M  | The previous Sonnet, kept for agents already tuned against it. |
+| `claude-haiku-4-5`  | $1 / $5 a M   | Cheapest here — under half of `gpt-4o` on input.               |
+
+Two properties worth stating plainly, because both are the kind of thing that
+is otherwise discovered later:
+
+- **Leave the key unset and nothing reaches Anthropic.** The ids are not in the
+  picker, `PATCH /workspace` refuses them, and an agent already carrying one
+  falls back to the default rather than failing. That last part matters if you
+  ever remove the key: agents keep answering, on `gpt-4o`.
+- **It does not replace `OPENAI_API_KEY`.** Document embeddings and voice-note
+  transcription have no Anthropic equivalent wired up here and stay exactly
+  where they were.
+
+`OPENAI_MODEL` does not override a Claude pick — that model is not served over
+the OpenAI-compatible endpoint at all. This never surprises a local-model
+install, because such an install has no `ANTHROPIC_API_KEY` and therefore never
+offers a Claude id in the first place. Setting the key is what opts a
+deployment into sending anything to Anthropic; the rest of this section is what
+happens when you don't.
 
 ### Using a model that is not OpenAI's
 
@@ -549,6 +588,10 @@ bunx wrangler secret put RESEND_FROM
 bunx wrangler secret put SUPABASE_JWT_SECRET
 ```
 
+Add `bunx wrangler secret put ANTHROPIC_API_KEY` if you want the Claude models
+in the picker. It is genuinely optional — see [Offering Anthropic's models as
+well](#offering-anthropics-models-as-well) — and the deployment works without it.
+
 `ROUTINE_SECRET_KEY` must decode to 16, 24 or 32 bytes — `openssl rand -base64
 32`. The two `RESEND_*` values cover the two things Covan emails: routine
 deliveries to an email channel, and the note that tells somebody they have been
@@ -673,6 +716,12 @@ Set its secrets the same way, adding `-c wrangler.cron.toml` to each
 `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `ROUTINE_SECRET_KEY`,
 `RESEND_API_KEY` and `RESEND_FROM`. It gets no anon key and no bucket, because
 it never acts on behalf of a user and never touches a document.
+
+If you set `ANTHROPIC_API_KEY` on the API Worker, set it here too. Routines run
+on the agent's own model, so a routine belonging to an agent on Claude has to
+resolve that id in this Worker — and without the key it quietly summarises on
+`gpt-4o` instead, which is a bill in the wrong column and an answer in the wrong
+voice.
 
 **`ROUTINE_SECRET_KEY` must be byte-identical to the API Worker's.** The API
 encrypts every delivery destination with it and this Worker decrypts them. A

--- a/src/components/create-agent-dialog.tsx
+++ b/src/components/create-agent-dialog.tsx
@@ -17,7 +17,7 @@ import {
 import { Upload, X, FileText, ChevronRight, ChevronLeft, Sparkles } from "lucide-react";
 import { useAgentsStore } from "@/lib/agents-store";
 import { GeneratePersonaButton } from "@/components/generate-persona-button";
-import { EMOJIS, MODELS, PERSONA_TEMPLATES } from "@/lib/agent-meta";
+import { EMOJIS, MODELS, PERSONA_TEMPLATES, modelsFor } from "@/lib/agent-meta";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 
@@ -77,6 +77,11 @@ function CreateAgentForm({ onDone }: { onDone: () => void }) {
   // Hold the real File objects picked in the Train step. The agent doesn't
   // exist yet, so they can only be uploaded after createAgent returns an id.
   const [docs, setDocs] = useState<{ id: string; name: string; size: number; file: File }[]>([]);
+
+  // What this deployment can actually serve, from /me — the Claude ids appear
+  // only when the server has a key for them. The current pick is carried in so
+  // a template that named a model still renders while /me is in flight.
+  const models = modelsFor(me?.models, model);
 
   const applyTemplate = (id: string) => {
     const t = PERSONA_TEMPLATES.find((x) => x.id === id);
@@ -235,7 +240,7 @@ function CreateAgentForm({ onDone }: { onDone: () => void }) {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {MODELS.map((m) => (
+                {models.map((m) => (
                   <SelectItem key={m} value={m}>
                     {m}
                   </SelectItem>

--- a/src/components/preferences-section.tsx
+++ b/src/components/preferences-section.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError, type Me } from "@/lib/api-client";
 import { useTheme, type ThemePreference } from "@/lib/theme";
-import { MODELS } from "@/lib/agent-meta";
+import { modelsFor } from "@/lib/agent-meta";
 import { SectionHeading } from "@/components/page-container";
 import { SectionCard } from "@/components/section-card";
 import { Label } from "@/components/ui/label";
@@ -33,6 +33,7 @@ export function PreferencesSection({ me }: { me: Me | undefined }) {
   const [savingModel, setSavingModel] = useState(false);
 
   const defaultModel = me?.workspace.defaultModel ?? null;
+  const models = modelsFor(me?.models, defaultModel);
 
   const saveDefaultModel = async (value: string) => {
     const next = value === NO_DEFAULT ? null : value;
@@ -90,7 +91,7 @@ export function PreferencesSection({ me }: { me: Me | undefined }) {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value={NO_DEFAULT}>No preference</SelectItem>
-              {MODELS.map((m) => (
+              {models.map((m) => (
                 <SelectItem key={m} value={m}>
                   {m}
                 </SelectItem>

--- a/src/lib/agent-meta.test.ts
+++ b/src/lib/agent-meta.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { EMOJIS, MODELS, PERSONA_TEMPLATES } from "./agent-meta";
+import { EMOJIS, MODELS, PERSONA_TEMPLATES, modelsFor } from "./agent-meta";
 
 /**
  * Two invariants that nothing else would catch, because both fail silently.
@@ -29,5 +29,45 @@ describe("persona templates", () => {
     // deselected without appearing to select the other.
     const ids = PERSONA_TEMPLATES.map((t) => t.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+/**
+ * The list above is what this build knows; `modelsFor` is what a given install
+ * may show. They stopped being the same thing when a second provider arrived:
+ * the Claude ids exist only where the server has a key for them, which is a
+ * fact the frontend learns from /me rather than one it can hold in a constant.
+ */
+describe("modelsFor", () => {
+  it("lists what the server says it can serve", () => {
+    expect(modelsFor(["gpt-4o", "claude-haiku-4-5"])).toEqual(["gpt-4o", "claude-haiku-4-5"]);
+  });
+
+  it("shows the OpenAI models alone until /me answers", () => {
+    // Every deployment has an OpenAI key by definition; the Claude ids depend
+    // on one the frontend cannot see. Offering them on a hunch and withdrawing
+    // them a moment later is worse than offering fewer.
+    const fallback = modelsFor(undefined);
+    expect(fallback).toContain("gpt-4o");
+    expect(fallback.filter((m) => m.startsWith("claude-"))).toEqual([]);
+  });
+
+  it("treats an empty list the same way, rather than rendering nothing", () => {
+    expect(modelsFor([])).toEqual(modelsFor(undefined));
+  });
+
+  it("keeps the current pick visible even when the server no longer offers it", () => {
+    // An agent left on a Claude model after the key was rotated out. A <Select>
+    // whose value matches no item renders blank — the same silent blank the
+    // template invariants above exist to prevent, arriving by a different route.
+    expect(modelsFor(["gpt-4o"], "claude-sonnet-4-5")).toEqual(["gpt-4o", "claude-sonnet-4-5"]);
+  });
+
+  it("does not duplicate a current pick that is already offered", () => {
+    expect(modelsFor(["gpt-4o", "gpt-4o-mini"], "gpt-4o")).toEqual(["gpt-4o", "gpt-4o-mini"]);
+  });
+
+  it("ignores a null current pick, which is how 'no preference' arrives", () => {
+    expect(modelsFor(["gpt-4o"], null)).toEqual(["gpt-4o"]);
   });
 });

--- a/src/lib/agent-meta.ts
+++ b/src/lib/agent-meta.ts
@@ -10,7 +10,54 @@
 // `agent-meta.test.ts` pins that.
 export const EMOJIS = ["🎓", "🚀", "🧑‍💻", "📊", "🧠", "✍️", "🎨", "🔬", "⚖️", "💬", "🧭"] as const;
 
-export const MODELS = ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini"] as const;
+/**
+ * Every model this build knows, in picker order.
+ *
+ * This is the fallback, not the source of truth. Which of these a deployment
+ * can actually serve depends on which provider keys it has — the Claude ids
+ * need an `ANTHROPIC_API_KEY` the frontend cannot see — so the real list comes
+ * from `/me` as `me.models`, and `modelsFor` below is what every picker calls.
+ * The constant stays because a picker rendered before /me resolves still has to
+ * render something, and because the self-hosted default (OpenAI only) is the
+ * safe thing to show while waiting.
+ */
+export const MODELS = [
+  "gpt-4o",
+  "gpt-4o-mini",
+  "gpt-4.1",
+  "gpt-4.1-mini",
+  "gpt-5",
+  "gpt-5-mini",
+  "gpt-5-nano",
+  "claude-sonnet-4-6",
+  "claude-sonnet-4-5",
+  "claude-haiku-4-5",
+] as const;
+
+/**
+ * What a model picker should list: what this install offers, plus whatever the
+ * thing being edited is already on.
+ *
+ * The second half matters more than it looks. An agent can be sitting on a
+ * model the deployment has stopped offering — a Claude one after the key was
+ * rotated out, or an id dropped from a later build. A `<Select>` whose value
+ * matches no item renders blank, so the settings page would show an agent with
+ * no model at all and save whatever was picked next. Carrying the current value
+ * in keeps it visible and leaves changing it a decision.
+ */
+export function modelsFor(available: string[] | undefined, current?: string | null): string[] {
+  const offered = available && available.length > 0 ? available : DEFAULT_PICKER_MODELS;
+  const list = [...offered];
+  if (current && !list.includes(current)) list.push(current);
+  return list;
+}
+
+/**
+ * What a picker shows before /me has answered — the OpenAI ids alone, because
+ * those are the ones every deployment has by definition. Showing the Claude ids
+ * on a hunch and removing them a moment later is worse than showing fewer.
+ */
+const DEFAULT_PICKER_MODELS = MODELS.filter((m) => !m.startsWith("claude-"));
 
 // A per-model colour used to live here — emerald for GPT, violet for Llama and
 // so on. The design system allows exactly one saturated colour, so a palette

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -41,6 +41,14 @@ export type Me = {
   user: { id: string; name: string | null; email: string | null; avatarUrl: string | null };
   workspace: Workspace;
   members: WorkspaceMember[];
+  /**
+   * The model ids this deployment can serve, in picker order.
+   *
+   * Optional because it is newer than this client: a frontend deployed ahead of
+   * its API would otherwise render an empty picker rather than the built-in
+   * list. `modelsFor` in `lib/agent-meta` handles the absence.
+   */
+  models?: string[];
   onboarding: { completed: boolean; answers: OnboardingAnswers };
 };
 

--- a/src/routes/_authed.agents.$agentId.settings.tsx
+++ b/src/routes/_authed.agents.$agentId.settings.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
 import { useAgentsStore, type Agent } from "@/lib/agents-store";
 import {
   PageContainer,
@@ -31,7 +33,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { toast } from "sonner";
-import { EMOJIS, MODELS } from "@/lib/agent-meta";
+import { EMOJIS, modelsFor } from "@/lib/agent-meta";
 import { AgentAvatar } from "@/components/avatars";
 import { GeneratePersonaButton } from "@/components/generate-persona-button";
 
@@ -75,6 +77,11 @@ function AgentSettingsForm({ agent }: { agent: Agent }) {
   const [emoji, setEmoji] = useState(agent.emoji);
   const [model, setModel] = useState(agent.model);
   const [persona, setPersona] = useState(agent.persona);
+  // Shares the cache every authed page has already filled, so this costs no
+  // request. `me.models` is the list this deployment can actually serve — the
+  // Claude ids are in it only when the server has a key for them.
+  const { data: me } = useQuery({ queryKey: ["me"], queryFn: () => api.me() });
+  const models = modelsFor(me?.models, model);
   const [mode, setMode] = useState(agent.mode);
 
   const save = () => {
@@ -124,7 +131,7 @@ function AgentSettingsForm({ agent }: { agent: Agent }) {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {MODELS.map((m) => (
+                  {models.map((m) => (
                     <SelectItem key={m} value={m}>
                       {m}
                     </SelectItem>

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -109,8 +109,9 @@ function PrivacyPage() {
 
       <LegalSection title="Where it goes">
         <p>
-          These are the only outside services the software contacts, and the last three are only
-          contacted if the operator configured them.
+          These are the only outside services the software contacts. Everything after the first is
+          contacted only if the operator configured it, or in the case of the last, only because
+          your browser fetches a stylesheet.
         </p>
         <LegalList>
           <LegalItem>
@@ -122,6 +123,14 @@ function PrivacyPage() {
             <code>EMBEDDING_BASE_URL</code> moves the document text, each to any OpenAI-compatible
             endpoint, and they are set independently. Dictation cannot be moved. Ask whoever runs
             this install which of them are set; nothing on this page can tell you.
+          </LegalItem>
+          <LegalItem>
+            <strong className="font-medium text-foreground">Anthropic</strong> — the same message,
+            persona and retrieved passages, when the agent answering you is on a Claude model. Only
+            an install whose operator set <code>ANTHROPIC_API_KEY</code> offers those models at all;
+            without it nothing here is ever contacted. Documents are not indexed there and dictation
+            does not go there — those stay where the paragraph above puts them. Which provider
+            answered you is decided per agent, by whoever picked its model.
           </LegalItem>
           <LegalItem>
             <strong className="font-medium text-foreground">Resend</strong> — invitation emails and
@@ -195,8 +204,9 @@ function PrivacyPage() {
           something one person does from this interface.
         </p>
         <p>
-          What you sent to OpenAI is governed by OpenAI's own retention terms and is not something
-          this software can reach in to delete.
+          What you sent to a model provider — OpenAI, or Anthropic if your agent was on a Claude
+          model — is governed by that provider's own retention terms and is not something this
+          software can reach in to delete.
         </p>
       </LegalSection>
 

--- a/src/routes/terms.tsx
+++ b/src/routes/terms.tsx
@@ -93,11 +93,16 @@ function TermsPage() {
         </p>
       </LegalSection>
 
-      <LegalSection title="The OpenAI key">
+      <LegalSection title="The model provider keys">
         <p>
           A self-hosted Covan uses an OpenAI API key you supply, and your use of that model is
           between you and OpenAI under their terms. The software does not stand between you and that
           agreement.
+        </p>
+        <p>
+          The same goes for an Anthropic key, if the operator added one to offer the Claude models —
+          that use is between you and Anthropic. Neither key is supplied by this software, and
+          neither agreement is one it is party to.
         </p>
       </LegalSection>
 

--- a/worker/bun.lock
+++ b/worker/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "covan-api",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.123.0",
         "@hono/node-server": "^2.1.1",
         "@supabase/supabase-js": "^2.112.3",
         "cron-parser": "^5.10.0",
@@ -23,6 +24,10 @@
     },
   },
   "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.123.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
@@ -203,6 +208,8 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.24", "", {}, "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@supabase/auth-js": ["@supabase/auth-js@2.112.3", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-NA0rsgAlWZPvbhw8aUdmgfpHVgUAcd8zK5ov43l++o1bLIPXZhRiAlRobhwF5AatQuovpqxsMH50F4oyyV4XZw=="],
@@ -267,6 +274,8 @@
 
     "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
     "fast-xml-builder": ["fast-xml-builder@1.3.1", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.11.0", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.2", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw=="],
@@ -280,6 +289,8 @@
     "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
 
     "is-unsafe": ["is-unsafe@2.0.2", "", {}, "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -343,6 +354,8 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
+    "standardwebhooks": ["standardwebhooks@1.1.1", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ=="],
+
     "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "strnum": ["strnum@2.4.2", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw=="],
@@ -356,6 +369,8 @@
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -33,6 +33,7 @@
     "start:node": "bun run src/node.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.123.0",
     "@hono/node-server": "^2.1.1",
     "@supabase/supabase-js": "^2.112.3",
     "cron-parser": "^5.10.0",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -107,7 +107,7 @@ api.use("/*", entitlementsMiddleware);
 //
 // The workspace export stays on `standard` too, and that is the least obvious
 // of these. It buys no completion, so it does not belong in the list above,
-// whose whole claim is derived from `createOpenAI` appearing in a route file.
+// whose whole claim is derived from `lib/completion` appearing in a route file.
 // But it is the one endpoint where a single request fans out into as many
 // object reads as the workspace has documents, so `standard`'s per-minute
 // allowance is an amplified one here in a way it is nowhere else. It bounds a

--- a/worker/src/lib/anthropic.test.ts
+++ b/worker/src/lib/anthropic.test.ts
@@ -1,0 +1,71 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, it, expect } from "vitest";
+import { createAnthropic } from "./anthropic";
+
+const ANTHROPIC = "https://api.anthropic.com";
+
+describe("createAnthropic", () => {
+  it("talks to Anthropic when no endpoint is configured", () => {
+    const client = createAnthropic({ ANTHROPIC_API_KEY: "sk-ant-test" });
+    expect(client.baseURL).toBe(ANTHROPIC);
+  });
+
+  it("talks to the configured endpoint instead", () => {
+    const client = createAnthropic({
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      ANTHROPIC_BASE_URL: "http://gateway.internal:8080",
+    });
+    expect(client.baseURL).toBe("http://gateway.internal:8080");
+  });
+
+  it("treats an empty ANTHROPIC_BASE_URL as unset", () => {
+    // A blank line in a .env file arrives as "", and "" as a baseURL resolves
+    // against the Worker's own origin — every request would come back to us.
+    const client = createAnthropic({ ANTHROPIC_API_KEY: "sk-ant-test", ANTHROPIC_BASE_URL: "" });
+    expect(client.baseURL).toBe(ANTHROPIC);
+  });
+
+  it("carries the api key through", () => {
+    const client = createAnthropic({ ANTHROPIC_API_KEY: "sk-ant-local" });
+    expect(client.apiKey).toBe("sk-ant-local");
+  });
+
+  it("refuses to build a client with no key, naming the variable", () => {
+    // Only reachable through a routing bug — `resolveModel` will not return a
+    // Claude id without this key. A 401 from Anthropic reads like a bad key
+    // rather than a missing one, and would send whoever hit it to the wrong
+    // place entirely.
+    expect(() => createAnthropic({})).toThrow(/ANTHROPIC_API_KEY/);
+  });
+});
+
+/**
+ * The same walk `openai.test.ts` does, for the same reason: the factory only
+ * decides where these requests go if everything goes through it. A later call
+ * site with a bare `new Anthropic({ apiKey })` would silently ignore
+ * ANTHROPIC_BASE_URL for that one feature, and nothing else in the suite would
+ * notice.
+ */
+const SRC = join(import.meta.dirname, "..");
+
+const EXEMPT = new Set(["lib/anthropic.ts"]);
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) return sourceFiles(full);
+    return e.isFile() && e.name.endsWith(".ts") && !e.name.endsWith(".test.ts") ? [full] : [];
+  });
+}
+
+describe("the Anthropic client factory", () => {
+  it("is the only way production code constructs a client", () => {
+    const direct = sourceFiles(SRC)
+      .filter((f) => readFileSync(f, "utf8").includes("new Anthropic("))
+      .map((f) => relative(SRC, f))
+      .filter((f) => !EXEMPT.has(f));
+
+    expect(direct).toEqual([]);
+  });
+});

--- a/worker/src/lib/anthropic.ts
+++ b/worker/src/lib/anthropic.ts
@@ -1,0 +1,38 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+/**
+ * The one place an Anthropic client is constructed.
+ *
+ * The same seam `lib/openai.ts` is, for the same reason: one factory means one
+ * place where the base URL, the key and the timeout are decided, and a sixth
+ * call site cannot quietly reopen a hole by newing up its own. `openai.test.ts`
+ * walks the source to keep that true for OpenAI; `anthropic.test.ts` does it
+ * here.
+ *
+ * `ANTHROPIC_BASE_URL` exists for the same reason `OPENAI_BASE_URL` does — an
+ * Anthropic-compatible gateway (a proxy, a corporate egress point, a recording
+ * middlebox in a regulated environment) is a legitimate place to send these
+ * requests, and a self-hosted deployment should not have to patch the source to
+ * use one. Unset means api.anthropic.com.
+ */
+export function createAnthropic(env: {
+  ANTHROPIC_API_KEY?: string;
+  ANTHROPIC_BASE_URL?: string;
+}): Anthropic {
+  if (!env.ANTHROPIC_API_KEY) {
+    // Reached only by a bug: `resolveModel` will not return a Claude id unless
+    // this key is set, so a request that arrives here without one has routed
+    // itself wrongly. Saying so beats a 401 from Anthropic that reads like a
+    // bad key rather than a missing one.
+    throw new Error(
+      "ANTHROPIC_API_KEY is not set, so no Claude model can be served. " +
+        "This request should never have been routed to Anthropic — see lib/models.ts.",
+    );
+  }
+  return new Anthropic({
+    apiKey: env.ANTHROPIC_API_KEY,
+    // `|| undefined`, not `??`: an unset variable arrives as "" from a .env
+    // file, and "" as a baseURL resolves against the Worker's own origin.
+    baseURL: env.ANTHROPIC_BASE_URL || undefined,
+  });
+}

--- a/worker/src/lib/completion.test.ts
+++ b/worker/src/lib/completion.test.ts
@@ -1,0 +1,453 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  complete,
+  streamCompletion,
+  toAnthropicMessages,
+  extractJsonObject,
+  totalTokens,
+  DEFAULT_MAX_TOKENS,
+  type CompletionEnv,
+  type CompletionEvent,
+} from "./completion";
+
+const openaiCreate = vi.fn();
+const anthropicCreate = vi.fn();
+
+// Both SDKs stubbed: these tests are about the request each provider gets and
+// how its answer is read, not about the SDKs. Classes rather than arrow
+// functions because the call sites are `new OpenAI(...)` / `new Anthropic(...)`
+// and vitest 4 forwards `new` straight to the implementation.
+vi.mock("openai", () => ({
+  default: class {
+    chat = { completions: { create: openaiCreate } };
+  },
+}));
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: anthropicCreate };
+  },
+}));
+
+const env: CompletionEnv = { OPENAI_API_KEY: "sk-test", ANTHROPIC_API_KEY: "sk-ant-test" };
+const openaiOnly: CompletionEnv = { OPENAI_API_KEY: "sk-test" };
+
+/** An async iterable over a fixed list, which is all a stream is here. */
+async function* replay<T>(events: T[]): AsyncGenerator<T> {
+  for (const e of events) yield e;
+}
+
+async function collect(stream: AsyncGenerator<CompletionEvent>): Promise<CompletionEvent[]> {
+  const out: CompletionEvent[] = [];
+  for await (const e of stream) out.push(e);
+  return out;
+}
+
+beforeEach(() => {
+  openaiCreate.mockReset();
+  anthropicCreate.mockReset();
+  openaiCreate.mockResolvedValue({
+    choices: [{ message: { content: "an answer" } }],
+    usage: { prompt_tokens: 100, completion_tokens: 20 },
+  });
+  anthropicCreate.mockResolvedValue({
+    content: [{ type: "text", text: "an answer" }],
+    usage: { input_tokens: 100, output_tokens: 20 },
+  });
+});
+
+describe("toAnthropicMessages", () => {
+  it("lifts the leading system messages into the system field", () => {
+    const { system, messages } = toAnthropicMessages([
+      { role: "system", content: "You are Ada." },
+      { role: "system", content: "Be brief." },
+      { role: "user", content: "Hello" },
+    ]);
+
+    expect(system).toBe("You are Ada.\n\nBe brief.");
+    expect(messages).toEqual([{ role: "user", content: "Hello" }]);
+  });
+
+  it("delivers a mid-conversation system message as a user turn", () => {
+    // routes/chat.ts puts the retrieved-knowledge block in one, deliberately
+    // after the cacheable prefix. Anthropic has no turn type for that on these
+    // models, and dropping it would answer the question ungrounded.
+    const { system, messages } = toAnthropicMessages([
+      { role: "system", content: "You are Ada." },
+      { role: "user", content: "What does the handbook say?" },
+      { role: "assistant", content: "Let me check." },
+      { role: "system", content: "KNOWLEDGE: the handbook says Tuesdays." },
+      { role: "user", content: "Well?" },
+    ]);
+
+    expect(system).toBe("You are Ada.");
+    expect(messages).toEqual([
+      { role: "user", content: "What does the handbook say?" },
+      { role: "assistant", content: "Let me check." },
+      { role: "user", content: "KNOWLEDGE: the handbook says Tuesdays." },
+      { role: "user", content: "Well?" },
+    ]);
+  });
+
+  it("drops a leading assistant turn, which the API refuses outright", () => {
+    // History trimming can cut mid-exchange and leave one first. OpenAI accepts
+    // it; Anthropic returns a 400, so the whole reply would be lost to a
+    // conversation being one message longer than the budget.
+    const { messages } = toAnthropicMessages([
+      { role: "system", content: "You are Ada." },
+      { role: "assistant", content: "…as I was saying." },
+      { role: "user", content: "Go on" },
+    ]);
+
+    expect(messages).toEqual([{ role: "user", content: "Go on" }]);
+  });
+
+  it("drops empty and whitespace-only messages", () => {
+    const { system, messages } = toAnthropicMessages([
+      { role: "system", content: "   " },
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: "" },
+    ]);
+
+    expect(system).toBe("");
+    expect(messages).toEqual([{ role: "user", content: "Hi" }]);
+  });
+
+  it("refuses a request with nothing to answer", async () => {
+    await expect(
+      complete(env, { model: "claude-haiku-4-5", messages: [{ role: "system", content: "Hi" }] }),
+    ).rejects.toThrow(/at least one user message/);
+  });
+});
+
+describe("extractJsonObject", () => {
+  it("leaves a bare object alone", () => {
+    expect(extractJsonObject('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it("unwraps a fenced object, which is how a model asked for JSON in words answers", () => {
+    expect(extractJsonObject('```json\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  it("finds the object inside surrounding prose", () => {
+    expect(extractJsonObject('Sure! Here it is:\n{"a":1}\nHope that helps.')).toBe('{"a":1}');
+  });
+
+  it("returns the text unchanged when there is no object to find", () => {
+    expect(extractJsonObject("I cannot help with that.")).toBe("I cannot help with that.");
+  });
+});
+
+describe("complete, on OpenAI", () => {
+  it("sends the messages through unchanged and reads the reply", async () => {
+    const { text, usage } = await complete(openaiOnly, {
+      model: "gpt-4o",
+      messages: [
+        { role: "system", content: "You are Ada." },
+        { role: "user", content: "Hello" },
+      ],
+    });
+
+    expect(text).toBe("an answer");
+    expect(usage).toEqual({ promptTokens: 100, completionTokens: 20, cachedTokens: null });
+    const call = openaiCreate.mock.calls[0][0];
+    expect(call.messages).toHaveLength(2);
+    expect(call.messages[0]).toEqual({ role: "system", content: "You are Ada." });
+  });
+
+  it("asks for JSON with the parameter, since it has one", () => {
+    return complete(openaiOnly, {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hi" }],
+      json: true,
+    }).then(() => {
+      expect(openaiCreate.mock.calls[0][0].response_format).toEqual({ type: "json_object" });
+    });
+  });
+
+  it("omits max_completion_tokens when the caller named no ceiling", async () => {
+    await complete(openaiOnly, { model: "gpt-4o", messages: [{ role: "user", content: "Hi" }] });
+    expect(openaiCreate.mock.calls[0][0]).not.toHaveProperty("max_completion_tokens");
+  });
+
+  it("drops the temperature for a GPT-5 model, which would 400 on it", async () => {
+    await complete(openaiOnly, {
+      model: "gpt-5-mini",
+      messages: [{ role: "user", content: "Hi" }],
+      temperature: 0.9,
+    });
+    expect(openaiCreate.mock.calls[0][0]).not.toHaveProperty("temperature");
+  });
+
+  it("keeps it for a model that accepts one", async () => {
+    await complete(openaiOnly, {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hi" }],
+      temperature: 0.9,
+    });
+    expect(openaiCreate.mock.calls[0][0].temperature).toBe(0.9);
+  });
+});
+
+describe("complete, on Anthropic", () => {
+  it("splits the system prompt out and sends a max_tokens, which the API requires", async () => {
+    const { text } = await complete(env, {
+      model: "claude-sonnet-4-5",
+      messages: [
+        { role: "system", content: "You are Ada." },
+        { role: "user", content: "Hello" },
+      ],
+    });
+
+    expect(text).toBe("an answer");
+    const call = anthropicCreate.mock.calls[0][0];
+    expect(call.model).toBe("claude-sonnet-4-5");
+    expect(call.system).toBe("You are Ada.");
+    expect(call.messages).toEqual([{ role: "user", content: "Hello" }]);
+    expect(call.max_tokens).toBe(DEFAULT_MAX_TOKENS);
+  });
+
+  it("honours a ceiling the caller did name", async () => {
+    await complete(env, {
+      model: "claude-haiku-4-5",
+      messages: [{ role: "user", content: "Hi" }],
+      maxTokens: 400,
+    });
+    expect(anthropicCreate.mock.calls[0][0].max_tokens).toBe(400);
+  });
+
+  it("asks for JSON in words, because these models have no parameter for it", async () => {
+    anthropicCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: '```json\n{"persona":"You are Ada."}\n```' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+
+    const { text } = await complete(env, {
+      model: "claude-sonnet-4-6",
+      messages: [
+        { role: "system", content: "Draft a persona." },
+        { role: "user", content: "Agent title: Support Agent" },
+      ],
+      json: true,
+    });
+
+    const call = anthropicCreate.mock.calls[0][0];
+    expect(call.system).toContain("Draft a persona.");
+    expect(call.system).toContain("single JSON object");
+    expect(call).not.toHaveProperty("response_format");
+    // The fence is stripped here rather than downstream: every caller does a
+    // bare JSON.parse and reports a throw to the user as "the model failed".
+    expect(JSON.parse(text)).toEqual({ persona: "You are Ada." });
+  });
+
+  it("joins several text blocks into one reply", async () => {
+    anthropicCreate.mockResolvedValueOnce({
+      content: [
+        { type: "text", text: "one " },
+        { type: "text", text: "two" },
+      ],
+      usage: { input_tokens: 1, output_tokens: 2 },
+    });
+
+    const { text } = await complete(env, {
+      model: "claude-haiku-4-5",
+      messages: [{ role: "user", content: "Hi" }],
+    });
+    expect(text).toBe("one two");
+  });
+
+  it("counts cached and cache-written tokens inside promptTokens, the way OpenAI reports them", async () => {
+    // Anthropic's input_tokens excludes both; OpenAI's prompt_tokens includes
+    // them. Everything downstream — the usage view, the quota counter,
+    // lib/pricing — assumes cachedTokens is a subset, and would double-count
+    // the moment it was not.
+    anthropicCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "ok" }],
+      usage: {
+        input_tokens: 40,
+        cache_read_input_tokens: 900,
+        cache_creation_input_tokens: 60,
+        output_tokens: 20,
+      },
+    });
+
+    const { usage } = await complete(env, {
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "Hi" }],
+    });
+
+    expect(usage).toEqual({ promptTokens: 1000, completionTokens: 20, cachedTokens: 900 });
+    expect(totalTokens(usage)).toBe(1020);
+  });
+
+  it("says which key is missing rather than letting Anthropic answer with a 401", async () => {
+    await expect(
+      complete(openaiOnly, {
+        model: "claude-haiku-4-5",
+        messages: [{ role: "user", content: "H" }],
+      }),
+    ).rejects.toThrow(/ANTHROPIC_API_KEY/);
+  });
+});
+
+describe("streamCompletion", () => {
+  it("asks OpenAI for the usage chunk, which is not sent unless requested", async () => {
+    openaiCreate.mockResolvedValueOnce(
+      replay([
+        { choices: [{ delta: { content: "Hel" } }] },
+        { choices: [{ delta: { content: "lo" } }] },
+        { choices: [], usage: { prompt_tokens: 9, completion_tokens: 2 } },
+      ]),
+    );
+
+    const events = await collect(
+      streamCompletion(openaiOnly, {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hi" }],
+      }),
+    );
+
+    expect(openaiCreate.mock.calls[0][0].stream_options).toEqual({ include_usage: true });
+    expect(events).toEqual([
+      { type: "delta", text: "Hel" },
+      { type: "delta", text: "lo" },
+      {
+        type: "end",
+        finishReason: null,
+        usage: { promptTokens: 9, completionTokens: 2, cachedTokens: null },
+      },
+    ]);
+  });
+
+  it("reads Anthropic's two-part usage and emits one event at the end", async () => {
+    // The input half arrives at message_start and the output half at
+    // message_delta, so neither event alone is the answer.
+    anthropicCreate.mockResolvedValueOnce(
+      replay([
+        {
+          type: "message_start",
+          message: { usage: { input_tokens: 9, cache_read_input_tokens: 1, output_tokens: 0 } },
+        },
+        { type: "content_block_delta", delta: { type: "text_delta", text: "Hel" } },
+        { type: "content_block_delta", delta: { type: "text_delta", text: "lo" } },
+        { type: "content_block_delta", delta: { type: "thinking_delta", thinking: "hmm" } },
+        { type: "message_delta", usage: { output_tokens: 2 } },
+      ]),
+    );
+
+    const events = await collect(
+      streamCompletion(env, {
+        model: "claude-haiku-4-5",
+        messages: [{ role: "user", content: "Hi" }],
+      }),
+    );
+
+    expect(anthropicCreate.mock.calls[0][0].stream).toBe(true);
+    expect(events).toEqual([
+      { type: "delta", text: "Hel" },
+      { type: "delta", text: "lo" },
+      {
+        type: "end",
+        finishReason: null,
+        usage: { promptTokens: 10, completionTokens: 2, cachedTokens: 1 },
+      },
+    ]);
+  });
+
+  it("still reports usage when a stream carried no text at all", async () => {
+    // routes/chat.ts records what a turn cost on every way it can end, so an
+    // empty reply must still arrive with numbers attached.
+    anthropicCreate.mockResolvedValueOnce(
+      replay([
+        { type: "message_start", message: { usage: { input_tokens: 5, output_tokens: 0 } } },
+        { type: "message_delta", usage: { output_tokens: 0 } },
+      ]),
+    );
+
+    const events = await collect(
+      streamCompletion(env, {
+        model: "claude-haiku-4-5",
+        messages: [{ role: "user", content: "Hi" }],
+      }),
+    );
+
+    expect(events).toEqual([
+      {
+        type: "end",
+        finishReason: null,
+        usage: { promptTokens: 5, completionTokens: 0, cachedTokens: null },
+      },
+    ]);
+  });
+
+  describe("the truncation signal", () => {
+    // routes/chat.ts sends a `truncated` event when this reads "length", which
+    // is what tells the chat screen the answer was cut off rather than
+    // finished. Both providers can truncate; only one of them calls it that.
+
+    it("passes OpenAI's finish_reason straight through", async () => {
+      openaiCreate.mockResolvedValueOnce(
+        replay([
+          { choices: [{ delta: { content: "Hel" }, finish_reason: null }] },
+          { choices: [{ delta: {}, finish_reason: "length" }] },
+          { choices: [], usage: { prompt_tokens: 9, completion_tokens: 2 } },
+        ]),
+      );
+
+      const events = await collect(
+        streamCompletion(openaiOnly, {
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "Hi" }],
+        }),
+      );
+
+      expect(events.at(-1)).toMatchObject({ type: "end", finishReason: "length" });
+    });
+
+    it("translates Anthropic's max_tokens into it", async () => {
+      // The same event, spelled the other way. Left untranslated, a Claude
+      // agent's answers would be silently cut off with nothing on screen.
+      anthropicCreate.mockResolvedValueOnce(
+        replay([
+          { type: "message_start", message: { usage: { input_tokens: 9, output_tokens: 0 } } },
+          { type: "content_block_delta", delta: { type: "text_delta", text: "Hel" } },
+          {
+            type: "message_delta",
+            delta: { stop_reason: "max_tokens" },
+            usage: { output_tokens: 2 },
+          },
+        ]),
+      );
+
+      const events = await collect(
+        streamCompletion(env, {
+          model: "claude-haiku-4-5",
+          messages: [{ role: "user", content: "Hi" }],
+        }),
+      );
+
+      expect(events.at(-1)).toMatchObject({ type: "end", finishReason: "length" });
+    });
+
+    it("leaves a normal ending under its own name", async () => {
+      anthropicCreate.mockResolvedValueOnce(
+        replay([
+          { type: "message_start", message: { usage: { input_tokens: 9, output_tokens: 0 } } },
+          {
+            type: "message_delta",
+            delta: { stop_reason: "end_turn" },
+            usage: { output_tokens: 2 },
+          },
+        ]),
+      );
+
+      const events = await collect(
+        streamCompletion(env, {
+          model: "claude-haiku-4-5",
+          messages: [{ role: "user", content: "Hi" }],
+        }),
+      );
+
+      expect(events.at(-1)).toMatchObject({ type: "end", finishReason: "end_turn" });
+    });
+  });
+});

--- a/worker/src/lib/completion.ts
+++ b/worker/src/lib/completion.ts
@@ -1,0 +1,331 @@
+import type OpenAI from "openai";
+import type Anthropic from "@anthropic-ai/sdk";
+import { createOpenAI } from "./openai";
+import { createAnthropic } from "./anthropic";
+import { providerFor, acceptsTemperature } from "./models";
+
+/**
+ * The one seam every completion goes through, whichever provider answers it.
+ *
+ * Until Claude models were offered, "the completion seam" was `createOpenAI` —
+ * five call sites, one SDK, and the model id passed straight through. That
+ * stops working the moment two SDKs are in play: the two speak different
+ * request shapes (`system` is a field, not a message; `max_tokens` is required,
+ * not optional; JSON mode is a parameter on one and an instruction on the
+ * other), and pushing those differences out to five call sites would mean five
+ * places to get them wrong.
+ *
+ * So the call sites keep describing what they want in the shape they always
+ * used — a flat list of role/content messages — and everything provider-shaped
+ * lives here. `lib/models.ts` decides *which* provider; this decides how to
+ * ask it.
+ */
+
+export type CompletionMessage = { role: "system" | "user" | "assistant"; content: string };
+
+export type CompletionUsage = {
+  promptTokens: number | null;
+  completionTokens: number | null;
+  /**
+   * How much of `promptTokens` the provider served from its prompt cache — a
+   * subset of that count, not an addition. Both providers report it, by
+   * different names (`prompt_tokens_details.cached_tokens`;
+   * `usage.cache_read_input_tokens`), and it is the only evidence that the
+   * cacheable-prefix assembly in `routes/chat.ts` is working at all.
+   */
+  cachedTokens: number | null;
+};
+
+export type CompletionEnv = {
+  OPENAI_API_KEY: string;
+  OPENAI_BASE_URL?: string;
+  ANTHROPIC_API_KEY?: string;
+  ANTHROPIC_BASE_URL?: string;
+};
+
+export type CompletionRequest = {
+  /** Already through `resolveModel` — this does not decide what to run. */
+  model: string;
+  messages: CompletionMessage[];
+  /**
+   * Upper bound on generated tokens. Optional for OpenAI, where omitting it has
+   * always meant the model's own default and several call sites rely on that.
+   * Anthropic requires the field, so `DEFAULT_MAX_TOKENS` stands in there.
+   */
+  maxTokens?: number;
+  /** Ignored for models that reject one — see `acceptsTemperature`. */
+  temperature?: number;
+  /** Ask for a single JSON object back. */
+  json?: boolean;
+};
+
+/**
+ * What Anthropic gets when a caller named no ceiling. `max_tokens` is required
+ * by that API, so "unbounded" is not a thing that can be sent; this is large
+ * enough for the two callers that omit it (a routine's summary, a routine
+ * draft) and still a real stop.
+ */
+export const DEFAULT_MAX_TOKENS = 4096;
+
+const JSON_ONLY_INSTRUCTION =
+  "Respond with a single JSON object and nothing else: no prose before or after it, " +
+  "and no markdown code fences.";
+
+export const EMPTY_USAGE: CompletionUsage = {
+  promptTokens: null,
+  completionTokens: null,
+  cachedTokens: null,
+};
+
+/** What a turn cost, for the quota counter. Cached prompt tokens are inside `promptTokens`. */
+export function totalTokens(usage: CompletionUsage): number {
+  return (usage.promptTokens ?? 0) + (usage.completionTokens ?? 0);
+}
+
+/**
+ * A JSON object out of a reply that may be wrapped in prose or fences.
+ *
+ * OpenAI's `response_format: {type:"json_object"}` guarantees the body is
+ * already exactly this, so for that path the function returns its input
+ * untouched. Anthropic has no equivalent parameter on the Claude models offered
+ * here — JSON is asked for in words, and words are sometimes answered with a
+ * ```json fence around them. Every caller downstream does a bare `JSON.parse`
+ * and treats a throw as "the model failed", so an otherwise perfect reply
+ * inside a fence would be reported to the user as a failure.
+ */
+export function extractJsonObject(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) return trimmed;
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start === -1 || end <= start) return trimmed;
+  return trimmed.slice(start, end + 1);
+}
+
+// ---- OpenAI ----------------------------------------------------------------
+
+function openaiParams(req: CompletionRequest): OpenAI.Chat.Completions.ChatCompletionCreateParams {
+  return {
+    model: req.model,
+    messages: req.messages as OpenAI.Chat.Completions.ChatCompletionMessageParam[],
+    ...(req.maxTokens !== undefined ? { max_completion_tokens: req.maxTokens } : {}),
+    ...(req.temperature !== undefined && acceptsTemperature(req.model)
+      ? { temperature: req.temperature }
+      : {}),
+    ...(req.json ? { response_format: { type: "json_object" as const } } : {}),
+  };
+}
+
+// ---- Anthropic -------------------------------------------------------------
+
+/**
+ * A flat message list in the shape the Messages API wants.
+ *
+ * Three differences, none of them cosmetic:
+ *
+ * - **System prompts are a field, not a turn.** The leading system messages
+ *   become `system`, which is also where they belong for caching: that block is
+ *   byte-identical turn over turn.
+ * - **A later system message has nowhere to go.** `routes/chat.ts` puts the
+ *   retrieved-knowledge block in one, just before the newest question, so the
+ *   stable prefix in front of it stays cacheable. Mid-conversation system turns
+ *   exist on Anthropic's newest models and on none of the ones offered here, so
+ *   it is delivered as a user turn instead — same position, same effect on the
+ *   answer, and consecutive user turns are merged by the API.
+ * - **The first turn must be a user turn.** History trimming can leave an
+ *   assistant message first; OpenAI accepts that and Anthropic returns a 400.
+ *   Leading assistant turns are dropped rather than sent.
+ */
+export function toAnthropicMessages(messages: CompletionMessage[]): {
+  system: string;
+  messages: Anthropic.MessageParam[];
+} {
+  const systemParts: string[] = [];
+  const out: Anthropic.MessageParam[] = [];
+
+  for (const message of messages) {
+    const content = message.content?.trim();
+    if (!content) continue;
+    if (message.role === "system") {
+      if (out.length === 0) systemParts.push(content);
+      else out.push({ role: "user", content });
+      continue;
+    }
+    // Nothing to answer yet, so an assistant turn here is history that lost its
+    // question. Sending it is a 400; keeping it is a reply to nobody.
+    if (message.role === "assistant" && out.length === 0) continue;
+    out.push({ role: message.role, content });
+  }
+
+  return { system: systemParts.join("\n\n"), messages: out };
+}
+
+// Without `stream`, so the two call sites below can each add their own and get
+// back the overload they want rather than a union of both.
+function anthropicParams(
+  req: CompletionRequest,
+): Omit<Anthropic.MessageCreateParamsNonStreaming, "stream"> {
+  const { system, messages } = toAnthropicMessages(req.messages);
+  if (messages.length === 0) {
+    throw new Error("a completion needs at least one user message");
+  }
+  const systemText = [system, req.json ? JSON_ONLY_INSTRUCTION : ""].filter(Boolean).join("\n\n");
+  return {
+    model: req.model,
+    messages,
+    max_tokens: req.maxTokens ?? DEFAULT_MAX_TOKENS,
+    ...(systemText ? { system: systemText } : {}),
+    ...(req.temperature !== undefined && acceptsTemperature(req.model)
+      ? { temperature: req.temperature }
+      : {}),
+  };
+}
+
+/**
+ * Anthropic's usage numbers in the shape the rest of the app counts in.
+ *
+ * `input_tokens` there excludes anything served from or written to the cache,
+ * where OpenAI's `prompt_tokens` includes it. Adding the three back together is
+ * what makes one number mean the same thing on both providers — the usage view,
+ * the quota counter and `lib/pricing.ts` all assume `cachedTokens` is a subset
+ * of `promptTokens`, and it would be double-counted the moment it was not.
+ */
+function anthropicUsage(usage: Anthropic.Usage | null | undefined): CompletionUsage {
+  if (!usage) return EMPTY_USAGE;
+  const cached = usage.cache_read_input_tokens ?? 0;
+  const written = usage.cache_creation_input_tokens ?? 0;
+  return {
+    promptTokens: (usage.input_tokens ?? 0) + cached + written,
+    completionTokens: usage.output_tokens ?? null,
+    cachedTokens: usage.cache_read_input_tokens ?? null,
+  };
+}
+
+// ---- the seam --------------------------------------------------------------
+
+/** One completion, waited for in full. */
+export async function complete(
+  env: CompletionEnv,
+  req: CompletionRequest,
+  opts: { signal?: AbortSignal } = {},
+): Promise<{ text: string; usage: CompletionUsage }> {
+  if (providerFor(req.model) === "anthropic") {
+    const client = createAnthropic(env);
+    const message = await client.messages.create(
+      { ...anthropicParams(req), stream: false },
+      { signal: opts.signal },
+    );
+    const text = message.content
+      .map((block) => (block.type === "text" ? block.text : ""))
+      .join("")
+      .trim();
+    return {
+      text: req.json ? extractJsonObject(text) : text,
+      usage: anthropicUsage(message.usage),
+    };
+  }
+
+  const client = createOpenAI(env);
+  const completion = await client.chat.completions.create(
+    { ...openaiParams(req), stream: false },
+    { signal: opts.signal },
+  );
+  const text = completion.choices[0]?.message?.content ?? "";
+  return {
+    text: req.json ? extractJsonObject(text) : text,
+    usage: {
+      promptTokens: completion.usage?.prompt_tokens ?? null,
+      completionTokens: completion.usage?.completion_tokens ?? null,
+      cachedTokens: completion.usage?.prompt_tokens_details?.cached_tokens ?? null,
+    },
+  };
+}
+
+export type CompletionEvent =
+  | { type: "delta"; text: string }
+  /**
+   * The last event of every stream: what the turn cost, and why it stopped.
+   *
+   * `finishReason` is normalised to OpenAI's vocabulary, so a caller asking
+   * "was this cut off?" writes one check rather than one per provider. The only
+   * value anything reads today is `"length"` — Anthropic spells that
+   * `"max_tokens"` — and `routes/chat.ts` turns it into the `truncated` event
+   * the chat screen shows.
+   */
+  | { type: "end"; usage: CompletionUsage; finishReason: string | null };
+
+/**
+ * The same completion, streamed.
+ *
+ * Both providers report usage at the end and neither reports it the same way —
+ * OpenAI in a final usage-only chunk that has to be asked for
+ * (`stream_options`), Anthropic across two events (the input half at
+ * `message_start`, the output half at `message_delta`). Callers get one `end`
+ * event either way, after the last delta.
+ */
+export async function* streamCompletion(
+  env: CompletionEnv,
+  req: CompletionRequest,
+  opts: { signal?: AbortSignal } = {},
+): AsyncGenerator<CompletionEvent> {
+  if (providerFor(req.model) === "anthropic") {
+    const client = createAnthropic(env);
+    const stream = await client.messages.create(
+      { ...anthropicParams(req), stream: true },
+      { signal: opts.signal },
+    );
+
+    let usage = EMPTY_USAGE;
+    let finishReason: string | null = null;
+    for await (const event of stream) {
+      if (event.type === "message_start") {
+        usage = anthropicUsage(event.message.usage);
+      } else if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
+        if (event.delta.text) yield { type: "delta", text: event.delta.text };
+      } else if (event.type === "message_delta") {
+        // The final, cumulative output count. `message_start` carried an early
+        // value for the same field; this one replaces it.
+        usage = { ...usage, completionTokens: event.usage.output_tokens ?? usage.completionTokens };
+        // `max_tokens` is Anthropic's spelling of OpenAI's `length`. Translated
+        // here so the truncation check downstream stays provider-agnostic;
+        // every other stop reason passes through under its own name.
+        // Optional-chained: the field is required on the wire, and a stream
+        // that omits it must still yield its usage rather than throw away a
+        // finished reply on the last event.
+        const stop = event.delta?.stop_reason;
+        if (stop) finishReason = stop === "max_tokens" ? "length" : stop;
+      }
+    }
+    yield { type: "end", usage, finishReason };
+    return;
+  }
+
+  const client = createOpenAI(env);
+  const completion = await client.chat.completions.create(
+    {
+      ...openaiParams(req),
+      stream: true,
+      // Without this the usage-only final chunk is never sent, and every reply
+      // is recorded as having cost nothing.
+      stream_options: { include_usage: true },
+    },
+    { signal: opts.signal },
+  );
+
+  let usage = EMPTY_USAGE;
+  let finishReason: string | null = null;
+  for await (const chunk of completion) {
+    const choice = chunk.choices[0];
+    const delta = choice?.delta?.content;
+    if (delta) yield { type: "delta", text: delta };
+    if (choice?.finish_reason) finishReason = choice.finish_reason;
+    if (chunk.usage) {
+      usage = {
+        promptTokens: chunk.usage.prompt_tokens ?? null,
+        completionTokens: chunk.usage.completion_tokens ?? null,
+        cachedTokens: chunk.usage.prompt_tokens_details?.cached_tokens ?? null,
+      };
+    }
+  }
+  yield { type: "end", usage, finishReason };
+}

--- a/worker/src/lib/dto.ts
+++ b/worker/src/lib/dto.ts
@@ -126,6 +126,16 @@ export type MeDTO = {
     avatarUrl: string | null;
   }>;
   /**
+   * The model ids this deployment can actually serve, in picker order.
+   *
+   * The frontend used to hold this list itself, which was true for as long as
+   * every model came from one provider and one key. It does not survive a
+   * second provider: whether the Claude models exist depends on whether
+   * `ANTHROPIC_API_KEY` is set, which is a fact about the server. A picker that
+   * offered them anyway would store a choice the API then quietly ignores.
+   */
+  models: string[];
+  /**
    * Where this account stands with its first run. The `_authed` layout gates on
    * `completed`, which is why this rides along with /me rather than having an
    * endpoint of its own — every page load needs the answer, and this response

--- a/worker/src/lib/env.ts
+++ b/worker/src/lib/env.ts
@@ -107,6 +107,11 @@ export function loadEnv(source: Record<string, string | undefined> = process.env
     // list, which is what an operator who has not thought about it should get.
     OPENAI_BASE_URL: source.OPENAI_BASE_URL,
     OPENAI_MODEL: source.OPENAI_MODEL,
+    // Optional, and deliberately not in REQUIRED: without it the Claude models
+    // are simply not offered and nothing reaches Anthropic. `lib/models.ts`
+    // treats its presence as the opt-in.
+    ANTHROPIC_API_KEY: source.ANTHROPIC_API_KEY,
+    ANTHROPIC_BASE_URL: source.ANTHROPIC_BASE_URL,
     // Separate from the two above on purpose — `lib/openai` explains why an
     // endpoint for completions is not automatically an endpoint for documents.
     EMBEDDING_BASE_URL: source.EMBEDDING_BASE_URL,

--- a/worker/src/lib/models.test.ts
+++ b/worker/src/lib/models.test.ts
@@ -1,9 +1,77 @@
 import { describe, it, expect } from "vitest";
-import { resolveModel, DEFAULT_MODEL } from "./models";
+import {
+  resolveModel,
+  providerFor,
+  acceptsTemperature,
+  availableModels,
+  modelSpec,
+  DEFAULT_MODEL,
+  MODEL_IDS,
+} from "./models";
+
+const WITH_KEY = { ANTHROPIC_API_KEY: "sk-ant-test" };
+
+describe("the catalogue", () => {
+  it("describes every id it offers", () => {
+    // `SPECS` is keyed by ModelId so tsc already enforces this, but the tuple
+    // and the record are two lists and only one of them is what the picker
+    // renders. This is the runtime half of that guarantee.
+    for (const id of MODEL_IDS) expect(modelSpec(id), id).toBeDefined();
+  });
+
+  it("keeps the default servable with no key but OPENAI_API_KEY", () => {
+    expect(availableModels()).toContain(DEFAULT_MODEL);
+    expect(providerFor(DEFAULT_MODEL)).toBe("openai");
+  });
+});
+
+describe("providerFor", () => {
+  it("routes the Claude ids to Anthropic and the GPT ids to OpenAI", () => {
+    expect(providerFor("claude-sonnet-4-5")).toBe("anthropic");
+    expect(providerFor("claude-haiku-4-5")).toBe("anthropic");
+    expect(providerFor("gpt-5-mini")).toBe("openai");
+  });
+
+  it("treats an unknown id as OpenAI's, because that is what a custom endpoint serves", () => {
+    // Under OPENAI_BASE_URL every id is unknown to this list by design.
+    expect(providerFor("llama3.3:70b")).toBe("openai");
+    expect(providerFor(null)).toBe("openai");
+  });
+});
+
+describe("acceptsTemperature", () => {
+  it("refuses one for the GPT-5 family, which rejects any value but its own", () => {
+    // Brainstorm mode is the only caller that sets a temperature. Sending 0.9
+    // to a reasoning model is a 400, so this is the difference between "that
+    // agent brainstorms" and "that agent errors".
+    expect(acceptsTemperature("gpt-5")).toBe(false);
+    expect(acceptsTemperature("gpt-5-mini")).toBe(false);
+    expect(acceptsTemperature("gpt-5-nano")).toBe(false);
+  });
+
+  it("allows one everywhere else, unknown endpoints included", () => {
+    expect(acceptsTemperature("gpt-4o")).toBe(true);
+    expect(acceptsTemperature("claude-sonnet-4-6")).toBe(true);
+    expect(acceptsTemperature("llama3.3:70b")).toBe(true);
+  });
+});
+
+describe("availableModels", () => {
+  it("hides the Claude ids from a deployment with no Anthropic key", () => {
+    const offered = availableModels();
+    expect(offered).toContain("gpt-5-mini");
+    expect(offered.filter((m) => m.startsWith("claude-"))).toEqual([]);
+  });
+
+  it("offers everything once the key is set", () => {
+    expect(availableModels(WITH_KEY)).toEqual([...MODEL_IDS]);
+  });
+});
 
 describe("resolveModel", () => {
   it("keeps a model this build knows", () => {
     expect(resolveModel("gpt-4.1-mini")).toBe("gpt-4.1-mini");
+    expect(resolveModel("gpt-5-nano")).toBe("gpt-5-nano");
   });
 
   it("falls back to the default for a model it does not know", () => {
@@ -12,6 +80,19 @@ describe("resolveModel", () => {
 
   it("falls back to the default when the agent has no model", () => {
     expect(resolveModel(null)).toBe(DEFAULT_MODEL);
+  });
+
+  describe("for a Claude model", () => {
+    it("keeps it when there is a key to serve it with", () => {
+      expect(resolveModel("claude-sonnet-4-5", WITH_KEY)).toBe("claude-sonnet-4-5");
+    });
+
+    it("falls back to the default when there is not, instead of failing the turn", () => {
+      // A key rotated out must not stop every agent that was on Claude from
+      // answering. The pick stops resolving; the conversation continues.
+      expect(resolveModel("claude-sonnet-4-5")).toBe(DEFAULT_MODEL);
+      expect(resolveModel("claude-haiku-4-5", { ANTHROPIC_API_KEY: "" })).toBe(DEFAULT_MODEL);
+    });
   });
 
   describe("with OPENAI_MODEL configured", () => {
@@ -27,6 +108,18 @@ describe("resolveModel", () => {
 
     it("is ignored when empty, so a blank line in .env does not select a nameless model", () => {
       expect(resolveModel("gpt-4o", { OPENAI_MODEL: "" })).toBe("gpt-4o");
+    });
+
+    it("does not reach a Claude pick, which is not served over that endpoint at all", () => {
+      expect(resolveModel("claude-sonnet-4-6", { ...env, ...WITH_KEY })).toBe("claude-sonnet-4-6");
+    });
+
+    it("still catches a Claude pick this deployment cannot serve", () => {
+      // No Anthropic key: the pick is unserveable, so it falls through to the
+      // override rather than to gpt-4o — which the local endpoint has never
+      // heard of either. This ordering is what keeps an Ollama-only install
+      // from ever addressing api.anthropic.com.
+      expect(resolveModel("claude-sonnet-4-6", env)).toBe("llama3.3:70b");
     });
   });
 });

--- a/worker/src/lib/models.ts
+++ b/worker/src/lib/models.ts
@@ -1,24 +1,156 @@
-// Real OpenAI model ids the app supports. The frontend now stores one of these
-// strings on each agent; legacy/unknown values (old "GPT-4", "Claude ...", etc.)
-// resolve to the default so existing agents keep working.
-export const OPENAI_MODELS = ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini"] as const;
+// The model ids this build knows how to talk to, and what each one needs.
+//
+// The list used to be OpenAI's alone, which is why the completion path was one
+// SDK and one base URL. It is now two providers, so a model id is no longer
+// just a string passed through: it decides which client answers the call, and
+// which request fields that client will accept. `lib/completion.ts` is the one
+// place that reads `provider`; everything else keeps passing ids around.
+//
+// Legacy/unknown values (old "GPT-4", "Claude 3 Opus", anything typed by hand
+// into the database before this list existed) resolve to the default so
+// existing agents keep working.
+
+export type ModelProvider = "openai" | "anthropic";
+
+/**
+ * The ids the picker offers and `workspaces.default_model` accepts, in the
+ * order the interface shows them: cheapest-per-family last, so the two
+ * flagships stay at the top where an unchanged install still finds them.
+ *
+ * A tuple rather than an array because `routes/workspace.ts` builds a
+ * `z.enum()` out of it — widening it to `string[]` would quietly stop
+ * validating what gets written to the database.
+ */
+export const MODEL_IDS = [
+  "gpt-4o",
+  "gpt-4o-mini",
+  "gpt-4.1",
+  "gpt-4.1-mini",
+  "gpt-5",
+  "gpt-5-mini",
+  "gpt-5-nano",
+  "claude-sonnet-4-6",
+  "claude-sonnet-4-5",
+  "claude-haiku-4-5",
+] as const;
+
+export type ModelId = (typeof MODEL_IDS)[number];
+
+export type ModelSpec = {
+  provider: ModelProvider;
+  /**
+   * Whether the endpoint accepts a `temperature` other than its own default.
+   *
+   * The GPT-5 family reasons before it answers and rejects any temperature but
+   * 1 with a 400 — not a warning, a failed request. Brainstorm mode is the only
+   * thing that sets one (0.9, `lib/prompt.ts`), so without this flag picking
+   * gpt-5-mini for a brainstorming agent would break that mode alone, on that
+   * model alone, which is exactly the kind of bug nobody reproduces.
+   */
+  temperature: boolean;
+};
+
+/**
+ * Keyed by `ModelId` rather than typed as a plain record, so adding an id to
+ * the tuple above without describing it here is a type error rather than a
+ * model that reaches `lib/completion.ts` with no provider.
+ */
+const SPECS: Record<ModelId, ModelSpec> = {
+  "gpt-4o": { provider: "openai", temperature: true },
+  "gpt-4o-mini": { provider: "openai", temperature: true },
+  "gpt-4.1": { provider: "openai", temperature: true },
+  "gpt-4.1-mini": { provider: "openai", temperature: true },
+  "gpt-5": { provider: "openai", temperature: false },
+  "gpt-5-mini": { provider: "openai", temperature: false },
+  "gpt-5-nano": { provider: "openai", temperature: false },
+  "claude-sonnet-4-6": { provider: "anthropic", temperature: true },
+  "claude-sonnet-4-5": { provider: "anthropic", temperature: true },
+  "claude-haiku-4-5": { provider: "anthropic", temperature: true },
+};
+
 export const DEFAULT_MODEL = "gpt-4o";
+
+/** The environment a model decision reads. A subset of `RoutineEnv`. */
+export type ModelEnv = {
+  OPENAI_MODEL?: string;
+  ANTHROPIC_API_KEY?: string;
+};
+
+/** What this build knows about `model`, or undefined if it is not one of ours. */
+export function modelSpec(model: string | null | undefined): ModelSpec | undefined {
+  return model ? SPECS[model as ModelId] : undefined;
+}
+
+/**
+ * Whether Claude models can be served at all.
+ *
+ * `ANTHROPIC_API_KEY` is optional and its absence is a supported configuration,
+ * not a misconfiguration: Covan has always needed exactly one key to answer
+ * anything, and that is still true. Without it the Claude ids simply are not
+ * offered and never resolve — see `resolveModel` and `availableModels`.
+ */
+export function anthropicEnabled(env?: ModelEnv): boolean {
+  return Boolean(env?.ANTHROPIC_API_KEY);
+}
+
+/**
+ * Which provider will answer for `model`.
+ *
+ * Unknown ids are OpenAI's, not an error: under `OPENAI_BASE_URL` every id is
+ * unknown to this list by design, and those requests go to the OpenAI-shaped
+ * client that endpoint speaks.
+ */
+export function providerFor(model: string | null | undefined): ModelProvider {
+  return modelSpec(model)?.provider ?? "openai";
+}
+
+/** Whether a temperature may be sent for `model`. Unknown ids: yes, as before. */
+export function acceptsTemperature(model: string | null | undefined): boolean {
+  return modelSpec(model)?.temperature ?? true;
+}
+
+/**
+ * The ids this deployment can actually serve, for the picker to render.
+ *
+ * A list that offers Claude to an install with no Anthropic key is a list that
+ * lies: the pick would be stored, `resolveModel` would drop it, and the agent
+ * would answer on gpt-4o with nothing on screen saying so. So the answer
+ * depends on the environment, and /me carries it to the frontend.
+ */
+export function availableModels(env?: ModelEnv): ModelId[] {
+  const anthropic = anthropicEnabled(env);
+  return MODEL_IDS.filter((id) => SPECS[id].provider === "openai" || anthropic);
+}
 
 /**
  * Which model a completion should ask for.
  *
- * The allowlist above is a list of OpenAI's names, so it only means anything
- * while the requests go to OpenAI. An operator who sets OPENAI_BASE_URL is
- * talking to a server whose catalogue we cannot know, and every agent's stored
- * model would resolve to `gpt-4o` — a name that endpoint has never heard of.
- * OPENAI_MODEL is the answer: set it and it wins outright, per-agent picker
- * included. The picker in the UI still lists OpenAI's models; that it has no
- * effect under a custom endpoint is noted in docs/self-hosting.md.
+ * Three rules, in this order:
+ *
+ * 1. A Claude pick wins when there is a key for it. It has to come first: an
+ *    Anthropic model is not served over the OpenAI-compatible endpoint, so
+ *    `OPENAI_MODEL` has no say in it.
+ * 2. `OPENAI_MODEL` wins over everything else, per-agent picker included. The
+ *    allowlist above is a list of OpenAI's names, so it only means anything
+ *    while the requests go to OpenAI. An operator who sets `OPENAI_BASE_URL` is
+ *    talking to a server whose catalogue we cannot know, and every agent's
+ *    stored model would otherwise resolve to `gpt-4o` — a name that endpoint
+ *    has never heard of.
+ * 3. Otherwise: the stored model if this build knows it, else the default.
+ *
+ * The ordering is also what keeps a private deployment private. An operator
+ * running everything through Ollama has no `ANTHROPIC_API_KEY`, so rule 1
+ * cannot fire, the Claude ids are never offered, and a stored one falls through
+ * to rule 2 — the conversation stays on their endpoint. Setting the key is the
+ * act that opts a deployment into sending anything to Anthropic.
  */
-export function resolveModel(
-  model: string | null | undefined,
-  env?: { OPENAI_MODEL?: string },
-): string {
+export function resolveModel(model: string | null | undefined, env?: ModelEnv): string {
+  const spec = modelSpec(model);
+  if (spec?.provider === "anthropic" && anthropicEnabled(env)) return model as string;
+  // A Claude pick with no key for it falls through from here rather than
+  // failing: an unserveable pick is the default, not a lost answer. Nobody's
+  // agent stops replying because a key was rotated out.
   if (env?.OPENAI_MODEL) return env.OPENAI_MODEL;
-  return model && (OPENAI_MODELS as readonly string[]).includes(model) ? model : DEFAULT_MODEL;
+  if (spec?.provider === "openai") return model as string;
+  return DEFAULT_MODEL;
 }

--- a/worker/src/lib/pricing.test.ts
+++ b/worker/src/lib/pricing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { estimateCostUsd } from "./pricing";
+import { MODEL_IDS } from "./models";
 
 describe("estimateCostUsd", () => {
   it("prices prompt and completion tokens per the model's rate", () => {
@@ -45,5 +46,31 @@ describe("estimateCostUsd", () => {
   it("defaults to no caching when the count is omitted", () => {
     // Every pre-existing caller passes three arguments; they must not change price.
     expect(estimateCostUsd("gpt-4o", 1_000_000, 0)).toBeCloseTo(2.5, 6);
+  });
+
+  it("prices the Claude models, which bill in the same two dimensions", () => {
+    // claude-haiku-4-5: $1/M in, $5/M out.
+    expect(estimateCostUsd("claude-haiku-4-5", 1_000_000, 1_000_000)).toBeCloseTo(6, 6);
+    // claude-sonnet-4-5: $3/M in, $15/M out, cache reads at a tenth.
+    expect(estimateCostUsd("claude-sonnet-4-5", 1_000_000, 0, 1_000_000)).toBeCloseTo(0.3, 6);
+  });
+
+  it("prices the GPT-5 family below the 4o default it replaces", () => {
+    const perMillionIn = (model: string) => estimateCostUsd(model, 1_000_000, 0);
+    expect(perMillionIn("gpt-5")).toBeLessThan(perMillionIn("gpt-4o"));
+    expect(perMillionIn("gpt-5-mini")).toBeLessThan(perMillionIn("gpt-5"));
+    expect(perMillionIn("gpt-5-nano")).toBeLessThan(perMillionIn("gpt-5-mini"));
+  });
+
+  it("has a rate for every model the picker offers", () => {
+    // Falling back to gpt-4o's rate is the right answer for a self-hosted
+    // endpoint whose catalogue we cannot know. It is the wrong answer for a
+    // model we ship: the usage view would quote 2.5x for haiku and stay silent
+    // about it. So an id added to the catalogue without a price fails here.
+    const fallback = estimateCostUsd("mystery-model", 1_000_000, 0);
+    for (const id of MODEL_IDS) {
+      if (id === "gpt-4o") continue; // the fallback itself
+      expect(estimateCostUsd(id, 1_000_000, 0), id).not.toBe(fallback);
+    }
   });
 });

--- a/worker/src/lib/pricing.ts
+++ b/worker/src/lib/pricing.ts
@@ -1,16 +1,30 @@
-// Approximate OpenAI list prices in USD per 1,000,000 tokens.
-// Used only for a rough cost estimate in the usage view — not billing-accurate,
-// and historical replies are priced at the agent's current model.
+// Approximate list prices in USD per 1,000,000 tokens, for every model in
+// `lib/models.ts`. Used only for a rough cost estimate in the usage view — not
+// billing-accurate, and historical replies are priced at the agent's current
+// model.
 //
-// `cachedIn` is the rate for prompt tokens OpenAI served from its automatic
-// prompt cache. The discount is not uniform across families — the 4o models
-// cache at half price, the 4.1 models at a quarter — so it is a per-model
+// `cachedIn` is the rate for prompt tokens the provider served from its prompt
+// cache. The discount is not uniform — the 4o models cache at half price, the
+// 4.1 models at a quarter, GPT-5 and Claude at a tenth — so it is a per-model
 // figure rather than one multiplier applied to `in`.
+//
+// One thing this deliberately does not model: Anthropic charges a *premium*
+// (1.25x input) for the tokens it writes into the cache, where OpenAI's
+// automatic caching is free to populate. Those show up here at the plain `in`
+// rate, so a Claude estimate runs slightly low on the first turn of a
+// conversation and is right for every turn after it. Naming it beats a fourth
+// rate on every row for an error that rounds to nothing over a month.
 const PRICES: Record<string, { in: number; cachedIn: number; out: number }> = {
   "gpt-4o": { in: 2.5, cachedIn: 1.25, out: 10 },
   "gpt-4o-mini": { in: 0.15, cachedIn: 0.075, out: 0.6 },
   "gpt-4.1": { in: 2, cachedIn: 0.5, out: 8 },
   "gpt-4.1-mini": { in: 0.4, cachedIn: 0.1, out: 1.6 },
+  "gpt-5": { in: 1.25, cachedIn: 0.125, out: 10 },
+  "gpt-5-mini": { in: 0.25, cachedIn: 0.025, out: 2 },
+  "gpt-5-nano": { in: 0.05, cachedIn: 0.005, out: 0.4 },
+  "claude-sonnet-4-6": { in: 3, cachedIn: 0.3, out: 15 },
+  "claude-sonnet-4-5": { in: 3, cachedIn: 0.3, out: 15 },
+  "claude-haiku-4-5": { in: 1, cachedIn: 0.1, out: 5 },
 };
 
 const DEFAULT_PRICE = PRICES["gpt-4o"];
@@ -20,7 +34,8 @@ const DEFAULT_PRICE = PRICES["gpt-4o"];
  *
  * `cachedTokens` is a *subset* of `promptTokens`, which is how OpenAI reports
  * it (`usage.prompt_tokens_details.cached_tokens` counts tokens already
- * included in `usage.prompt_tokens`). It is therefore subtracted out and
+ * included in `usage.prompt_tokens`) and what `lib/completion.ts` normalises
+ * Anthropic's numbers into. It is therefore subtracted out and
  * re-priced, never added — adding it would bill the same tokens twice.
  * Omitting it prices the whole prompt as fresh, which is what every caller
  * written before caching was measured means.

--- a/worker/src/lib/routines/dispatcher.ts
+++ b/worker/src/lib/routines/dispatcher.ts
@@ -3,7 +3,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { RoutineEnv } from "../../types";
 import { serviceClient } from "../supabase";
 import { runRoutine as defaultRunRoutine, type ExecutorDeps, type RoutineRow } from "./executor";
-import { summariseWithOpenAI } from "./summarise";
+import { summariseWithModel } from "./summarise";
 import { ownHostsFrom } from "./url-guard";
 import { entitlementsFor } from "../entitlements";
 
@@ -50,7 +50,7 @@ function executorDeps(env: RoutineEnv, db: SupabaseClient): ExecutorDeps {
 
   return {
     db,
-    summarise: summariseWithOpenAI(env),
+    summarise: summariseWithModel(env),
     entitlements: entitlementsFor(env),
     fetchDeps: { fetchImpl: boundFetch, ownHosts },
     deliveryDeps: {

--- a/worker/src/lib/routines/summarise.test.ts
+++ b/worker/src/lib/routines/summarise.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DEFAULT_MODEL } from "../models";
 import type { FeedItem } from "./feed";
-import { summariseWithOpenAI } from "./summarise";
+import { summariseWithModel } from "./summarise";
 
 const createMock = vi.fn();
 
@@ -10,7 +10,11 @@ const createMock = vi.fn();
 // how we read its response, not about the SDK itself. This is the one file
 // on the branch where money is actually spent, so the call shape matters.
 // vi.mock calls are hoisted above imports by vitest, so this applies before
-// `./summarise` constructs its `new OpenAI(...)` client above.
+// `lib/completion` constructs its `new OpenAI(...)` client.
+//
+// OpenAI's SDK rather than Anthropic's because a routine's env here has no
+// ANTHROPIC_API_KEY, so `resolveModel` cannot route one to Anthropic — the
+// Claude request shape is covered in `lib/completion.test.ts` instead.
 //
 // A class, not `vi.fn().mockImplementation(() => ...)`. The call site is `new
 // OpenAI(...)`, and vitest 4 forwards `new` straight to the implementation
@@ -33,17 +37,17 @@ const item = (n: number): FeedItem => ({
   summary: `summary body ${n}`,
 });
 
-describe("summariseWithOpenAI", () => {
+describe("summariseWithModel", () => {
   beforeEach(() => {
     createMock.mockReset();
     createMock.mockResolvedValue({
       choices: [{ message: { content: "the summary" } }],
-      usage: { total_tokens: 42 },
+      usage: { prompt_tokens: 30, completion_tokens: 12 },
     });
   });
 
   it("puts the persona in the system message and the instruction plus item titles in the user message", async () => {
-    const summarise = summariseWithOpenAI(env);
+    const summarise = summariseWithModel(env);
     await summarise({
       persona: "You are Ada, a rigorous research assistant.",
       model: "gpt-4o",
@@ -62,7 +66,7 @@ describe("summariseWithOpenAI", () => {
   });
 
   it("makes exactly one completion call for a batch of items, not one per item", async () => {
-    const summarise = summariseWithOpenAI(env);
+    const summarise = summariseWithModel(env);
     await summarise({
       persona: null,
       model: "gpt-4o",
@@ -74,7 +78,7 @@ describe("summariseWithOpenAI", () => {
   });
 
   it("truncates pageText at 20,000 characters for a web-watch routine", async () => {
-    const summarise = summariseWithOpenAI(env);
+    const summarise = summariseWithModel(env);
     const bigText = "x".repeat(25_000);
     await summarise({
       persona: null,
@@ -91,7 +95,7 @@ describe("summariseWithOpenAI", () => {
   });
 
   it("resolves an unrecognised model to the default via resolveModel", async () => {
-    const summarise = summariseWithOpenAI(env);
+    const summarise = summariseWithModel(env);
     await summarise({
       persona: null,
       model: "not-a-real-model",
@@ -104,7 +108,7 @@ describe("summariseWithOpenAI", () => {
   });
 
   it("sends OPENAI_MODEL instead of the routine's own model, so a routine reaches a self-hosted endpoint's catalogue too", async () => {
-    const summarise = summariseWithOpenAI({
+    const summarise = summariseWithModel({
       OPENAI_API_KEY: "sk-test",
       OPENAI_BASE_URL: "http://localhost:11434/v1",
       OPENAI_MODEL: "llama3.3:70b",
@@ -119,8 +123,8 @@ describe("summariseWithOpenAI", () => {
     expect(createMock.mock.calls[0][0].model).toBe("llama3.3:70b");
   });
 
-  it("reads tokens from usage.total_tokens, defaulting to 0 when usage is absent", async () => {
-    const summarise = summariseWithOpenAI(env);
+  it("bills prompt plus completion tokens, and 0 when the endpoint reports no usage at all", async () => {
+    const summarise = summariseWithModel(env);
 
     const withUsage = await summarise({
       persona: null,

--- a/worker/src/lib/routines/summarise.ts
+++ b/worker/src/lib/routines/summarise.ts
@@ -1,7 +1,7 @@
 // worker/src/lib/routines/summarise.ts
 import type { RoutineEnv } from "../../types";
 import { resolveModel } from "../models";
-import { createOpenAI } from "../openai";
+import { complete, totalTokens } from "../completion";
 import type { SummariseInput } from "./executor";
 
 /**
@@ -9,9 +9,7 @@ import type { SummariseInput } from "./executor";
  * instead of eight. The agent's persona is applied exactly as it is in chat —
  * a routine is the same colleague, reporting instead of answering.
  */
-export function summariseWithOpenAI(env: RoutineEnv) {
-  const client = createOpenAI(env);
-
+export function summariseWithModel(env: RoutineEnv) {
   return async (input: SummariseInput): Promise<{ text: string; tokens: number }> => {
     const body = input.pageText
       ? `Watched page content:\n\n${input.pageText.slice(0, 20_000)}`
@@ -19,7 +17,7 @@ export function summariseWithOpenAI(env: RoutineEnv) {
           .map((i) => `- ${i.title}\n  ${i.link}\n  ${i.summary.slice(0, 1_000)}`)
           .join("\n\n");
 
-    const completion = await client.chat.completions.create({
+    const { text, usage } = await complete(env, {
       model: resolveModel(input.model, env),
       messages: [
         {
@@ -32,9 +30,6 @@ export function summariseWithOpenAI(env: RoutineEnv) {
       ],
     });
 
-    return {
-      text: completion.choices[0]?.message?.content ?? "",
-      tokens: completion.usage?.total_tokens ?? 0,
-    };
+    return { text, tokens: totalTokens(usage) };
   };
 }

--- a/worker/src/ratelimit.static.test.ts
+++ b/worker/src/ratelimit.static.test.ts
@@ -13,6 +13,17 @@ import { describe, it, expect } from "vitest";
  * client: the risk is not this commit, it is the next one.
  */
 
+/**
+ * The imports that mean a file spends money.
+ *
+ * `lib/completion.ts` is the seam every completion goes through, on either
+ * provider; `transcribeAudio` is transcription's own module, which is routed to
+ * OpenAI on purpose. `openai.test.ts` and `anthropic.test.ts` guarantee no
+ * client is constructed outside those two, so a file cannot buy a completion
+ * without naming one of these.
+ */
+const SPENDING_IMPORTS = ["../lib/completion", "transcribeAudio"];
+
 const SRC = import.meta.dirname;
 const ROUTES = join(SRC, "routes");
 
@@ -31,14 +42,14 @@ function routeFiles(): string[] {
 
 /**
  * Route files that buy a completion, found by the seam every completion goes
- * through, plus transcription's own module. `lib/openai.test.ts` already
- * guarantees nothing reaches OpenAI for a completion any other way, so this
- * cannot be dodged by constructing a client directly.
+ * through, plus transcription's own module. The client-factory tests already
+ * guarantee nothing reaches a provider any other way, so this cannot be dodged
+ * by constructing a client directly.
  */
 function paidRouteFiles(): string[] {
   return routeFiles().filter((f) => {
     const src = readFileSync(join(ROUTES, f), "utf8");
-    return src.includes("createOpenAI") || src.includes("transcribeAudio");
+    return SPENDING_IMPORTS.some((marker) => src.includes(marker));
   });
 }
 
@@ -112,9 +123,9 @@ describe("the expensive rate limit", () => {
   });
 
   it("knows about every route file that spends, so a new one cannot arrive unnoticed", () => {
-    // This is the tripwire. If a route file starts importing createOpenAI, this
-    // fails and whoever added it has to decide — deliberately — whether its
-    // endpoints belong behind the limit.
+    // This is the tripwire. If a route file starts importing the completion
+    // seam, this fails and whoever added it has to decide — deliberately —
+    // whether its endpoints belong behind the limit.
     expect(paidRouteFiles().sort()).toEqual(Object.keys(PAID_ENDPOINTS).sort());
   });
 

--- a/worker/src/routes/brainstorm.ts
+++ b/worker/src/routes/brainstorm.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { AppEnv } from "../types";
 import { resolveModel } from "../lib/models";
-import { createOpenAI } from "../lib/openai";
+import { complete, totalTokens } from "../lib/completion";
 import { buildIdeaExtractionMessages, parseIdeaSuggestions } from "../lib/idea-suggest";
 import { guardQuota, recordQuota } from "../lib/entitlements/guard";
 
@@ -68,17 +68,15 @@ brainstorm.post("/brainstorm/ideas/suggest", async (c) => {
     )
     .join("\n");
 
-  const openai = createOpenAI(c.env);
   try {
-    const completion = await openai.chat.completions.create({
+    const { text, usage } = await complete(c.env, {
       model: resolveModel(agent?.model ?? null, c.env),
       messages: buildIdeaExtractionMessages(transcript),
-      response_format: { type: "json_object" },
-      max_completion_tokens: 800,
+      json: true,
+      maxTokens: 800,
     });
-    await recordQuota(c, completion.usage?.total_tokens ?? 0);
-    const raw = completion.choices[0]?.message?.content ?? "";
-    return c.json({ ideas: parseIdeaSuggestions(raw) });
+    await recordQuota(c, totalTokens(usage));
+    return c.json({ ideas: parseIdeaSuggestions(text) });
   } catch (err) {
     console.error("idea extraction failed", err);
     return c.json({ error: "failed to extract ideas" }, 502);

--- a/worker/src/routes/chat.ts
+++ b/worker/src/routes/chat.ts
@@ -1,11 +1,10 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import type OpenAI from "openai";
 import type { AppEnv } from "../types";
 import { mapMessage } from "../lib/dto";
 import { serviceClient } from "../lib/supabase";
 import { resolveModel } from "../lib/models";
-import { createOpenAI } from "../lib/openai";
+import { streamCompletion, type CompletionMessage } from "../lib/completion";
 import { retrieveForAgent } from "../lib/retrieval";
 import { selectHistory } from "../lib/history";
 import { buildSystemPrefix, temperatureFor, maxTokensFor } from "../lib/prompt";
@@ -132,7 +131,7 @@ chat.post("/chat/stream", async (c) => {
   // latest user turn, where it grounds the answer without breaking that prefix.
   const priorTurns = history.slice(0, -1);
   const latestTurn = history[history.length - 1];
-  const openaiMessages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
+  const messages: CompletionMessage[] = [
     { role: "system", content: systemPrefix },
     ...priorTurns,
     ...(ragBlock ? [{ role: "system" as const, content: ragBlock }] : []),
@@ -140,7 +139,6 @@ chat.post("/chat/stream", async (c) => {
   ];
 
   const model = resolveModel(agent.model, c.env);
-  const openai = createOpenAI(c.env);
   const signal = c.req.raw.signal;
   const service = serviceClient(c.env);
 
@@ -152,16 +150,16 @@ chat.post("/chat/stream", async (c) => {
       };
 
       let full = "";
-      // Token usage arrives in a final usage-only chunk (empty choices) when
-      // stream_options.include_usage is set. Captured for the usage dashboard.
+      // Token usage arrives once, after the last delta, whichever provider
+      // answered — `lib/completion.ts` normalises the two shapes into one
+      // event. Captured for the usage dashboard.
       let promptTokens: number | null = null;
       let completionTokens: number | null = null;
-      // How much of `promptTokens` OpenAI served from its automatic prompt
-      // cache — a subset of that count, not an addition. This is the only
-      // evidence that the cacheable-prefix assembly above is actually working;
-      // without it a change that silently breaks the cache costs real money and
-      // shows up nowhere. Unlike the transcription usage field, `cached_tokens`
-      // is properly typed by the pinned SDK, so no fallback is needed here.
+      // How much of `promptTokens` the provider served from its prompt cache —
+      // a subset of that count, not an addition. This is the only evidence that
+      // the cacheable-prefix assembly above is actually working; without it a
+      // change that silently breaks the cache costs real money and shows up
+      // nowhere.
       let cachedTokens: number | null = null;
       // Why the model stopped. "length" means it ran into `maxTokensFor` and
       // the answer is cut off mid-thought — which looks, on screen, exactly
@@ -223,30 +221,28 @@ chat.post("/chat/stream", async (c) => {
         return inserted;
       };
       try {
-        const completion = await openai.chat.completions.create(
+        const events = streamCompletion(
+          c.env,
           {
             model,
-            messages: openaiMessages,
-            stream: true,
-            stream_options: { include_usage: true },
-            max_completion_tokens: maxTokensFor(mode),
-            ...(temperatureFor(mode) !== undefined ? { temperature: temperatureFor(mode) } : {}),
+            messages,
+            maxTokens: maxTokensFor(mode),
+            temperature: temperatureFor(mode),
           },
           { signal },
         );
 
-        for await (const chunk of completion) {
-          const choice = chunk.choices[0];
-          const delta = choice?.delta?.content;
-          if (delta) {
-            full += delta;
-            send({ type: "delta", text: delta });
-          }
-          if (choice?.finish_reason) finishReason = choice.finish_reason;
-          if (chunk.usage) {
-            promptTokens = chunk.usage.prompt_tokens ?? null;
-            completionTokens = chunk.usage.completion_tokens ?? null;
-            cachedTokens = chunk.usage.prompt_tokens_details?.cached_tokens ?? null;
+        for await (const event of events) {
+          if (event.type === "delta") {
+            full += event.text;
+            send({ type: "delta", text: event.text });
+          } else {
+            promptTokens = event.usage.promptTokens;
+            completionTokens = event.usage.completionTokens;
+            cachedTokens = event.usage.cachedTokens;
+            // Already normalised to OpenAI's vocabulary by `lib/completion.ts`,
+            // so `"length"` means truncated on either provider.
+            finishReason = event.finishReason;
           }
         }
 

--- a/worker/src/routes/me.ts
+++ b/worker/src/routes/me.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { AppEnv } from "../types";
 import type { MeDTO } from "../lib/dto";
 import { getActiveWorkspaceId } from "../lib/workspace";
+import { availableModels } from "../lib/models";
 
 const me = new Hono<AppEnv>();
 
@@ -130,6 +131,7 @@ me.get("/me", async (c) => {
       defaultModel: (workspace.default_model as string | null) ?? null,
     },
     members,
+    models: availableModels(c.env),
     onboarding: {
       completed: Boolean(onboardingRow?.completed_at),
       answers: {

--- a/worker/src/routes/persona.ts
+++ b/worker/src/routes/persona.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { AppEnv } from "../types";
 import { resolveModel } from "../lib/models";
-import { createOpenAI } from "../lib/openai";
+import { complete, totalTokens } from "../lib/completion";
 import { buildPersonaMessages, parsePersonaSuggestion } from "../lib/persona-suggest";
 import { guardQuota, recordQuota } from "../lib/entitlements/guard";
 
@@ -26,17 +26,15 @@ persona.post("/persona/suggest", async (c) => {
   }
   const { name, model } = parsed.data;
 
-  const openai = createOpenAI(c.env);
   try {
-    const completion = await openai.chat.completions.create({
+    const { text, usage } = await complete(c.env, {
       model: resolveModel(model ?? null, c.env),
       messages: buildPersonaMessages(name),
-      response_format: { type: "json_object" },
-      max_completion_tokens: 400,
+      json: true,
+      maxTokens: 400,
     });
-    await recordQuota(c, completion.usage?.total_tokens ?? 0);
-    const raw = completion.choices[0]?.message?.content ?? "";
-    const drafted = parsePersonaSuggestion(raw);
+    await recordQuota(c, totalTokens(usage));
+    const drafted = parsePersonaSuggestion(text);
     if (!drafted) {
       return c.json({ error: "failed to draft persona" }, 502);
     }

--- a/worker/src/routes/routines.ts
+++ b/worker/src/routes/routines.ts
@@ -13,7 +13,7 @@ import { encryptSecret } from "../lib/secret-box";
 import { maskSecret } from "../lib/routines/crypto";
 import { insertErrorStatus } from "../lib/routines/insert-error";
 import { resolveModel } from "../lib/models";
-import { createOpenAI } from "../lib/openai";
+import { complete, totalTokens } from "../lib/completion";
 import { guardQuota, recordQuota } from "../lib/entitlements/guard";
 
 const routines = new Hono<AppEnv>();
@@ -36,25 +36,24 @@ routines.post("/routines/draft", async (c) => {
   const parsed = draftBodySchema.safeParse(await c.req.json().catch(() => ({})));
   if (!parsed.success) return c.json({ error: parsed.error.flatten() }, 400);
 
-  const client = createOpenAI(c.env);
   // parseDraft may call the model more than once. Totalled here and recorded
   // once, whether the draft parses or is rejected — a failed parse still spent.
   let spent = 0;
-  const complete = async (prompt: string) => {
-    const res = await client.chat.completions.create({
+  const completeOne = async (prompt: string) => {
+    const { text, usage } = await complete(c.env, {
       // Drafting has no agent behind it, so there is no per-agent model to
       // honour — `null` takes the default, or OPENAI_MODEL when one is set.
       model: resolveModel(null, c.env),
-      response_format: { type: "json_object" },
       messages: [{ role: "user", content: prompt }],
+      json: true,
     });
-    spent += res.usage?.total_tokens ?? 0;
-    return res.choices[0]?.message?.content ?? "";
+    spent += totalTokens(usage);
+    return text;
   };
 
   try {
     const draft = await parseDraft(parsed.data.text, {
-      complete,
+      complete: completeOne,
       timezone: parsed.data.timezone,
       ownHosts: ownHostsFrom(c.env),
     });

--- a/worker/src/routes/workspace.test.ts
+++ b/worker/src/routes/workspace.test.ts
@@ -168,6 +168,34 @@ describe("PATCH /workspace", () => {
     expect((await json(app, "PATCH", "/workspace", body)).status).toBe(400);
   });
 
+  it("refuses a model this build knows but this deployment cannot serve", async () => {
+    // A Claude id with no ANTHROPIC_API_KEY behind it. Storing it would store a
+    // preference that does nothing: every new agent would take it and every one
+    // of them would answer on the default instead, with nothing on screen
+    // saying so.
+    let patch: Record<string, unknown> | undefined;
+    const { app } = appWith({
+      tables: {
+        workspaces: {
+          update: (ctx) => {
+            patch = ctx.values;
+            return { data: [saved], error: null };
+          },
+        },
+      },
+    });
+
+    const res = await json(app, "PATCH", "/workspace", { defaultModel: "claude-sonnet-4-5" });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "claude-sonnet-4-5 is not configured on this deployment",
+    });
+    // Refused before the write, not after: a stored preference that resolves to
+    // something else is worse than no preference at all.
+    expect(patch).toBeUndefined();
+  });
+
   it("answers 403 when RLS matched no row", async () => {
     // A member who is not an admin. The update succeeds and changes nothing,
     // which must not be reported as a save.

--- a/worker/src/routes/workspace.ts
+++ b/worker/src/routes/workspace.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { AppEnv } from "../types";
 import { getActiveWorkspaceId } from "../lib/workspace";
-import { OPENAI_MODELS } from "../lib/models";
+import { MODEL_IDS, availableModels } from "../lib/models";
 import { canSendEmail } from "../lib/email";
 import { removedFromWorkspaceEmail, roleChangedEmail } from "../lib/emails/membership";
 import { notify } from "../lib/emails/send";
@@ -18,7 +18,11 @@ const updateWorkspaceSchema = z
     // clears the preference. Anything else is refused rather than stored — a
     // typo here would otherwise sit in the database until someone wondered why
     // new agents came out on the wrong model.
-    defaultModel: z.union([z.enum(OPENAI_MODELS), z.null()]).optional(),
+    //
+    // Whether this *deployment* can serve the id is a second question, checked
+    // in the handler: it depends on the environment, and the schema is built
+    // once at import.
+    defaultModel: z.union([z.enum(MODEL_IDS), z.null()]).optional(),
   })
   .refine((body) => Object.keys(body).length > 0, {
     message: "at least one field is required",
@@ -46,6 +50,15 @@ workspace.patch("/workspace", async (c) => {
   // The column is snake_case; the API is not. Mapped explicitly so a future
   // field cannot be forwarded to PostgREST under a name that silently misses.
   const { defaultModel, ...rest } = parsed.data;
+
+  // A model this build knows but this deployment cannot reach — a Claude id
+  // with no ANTHROPIC_API_KEY behind it. Storing it would be storing a
+  // preference that silently does nothing: every new agent would take it and
+  // every one of them would answer on the default instead.
+  if (defaultModel && !availableModels(c.env).includes(defaultModel)) {
+    return c.json({ error: `${defaultModel} is not configured on this deployment` }, 400);
+  }
+
   const patch: Record<string, unknown> = { ...rest };
   if (defaultModel !== undefined) patch.default_model = defaultModel;
 

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -31,8 +31,31 @@ export type RoutineEnv = {
    * Forces one model for every completion, ignoring the per-agent picker.
    * Needed with OPENAI_BASE_URL because `lib/models` allowlists OpenAI's
    * catalogue, and a local endpoint serves names that are not in it.
+   *
+   * It does not reach a Claude pick, which is not served over that endpoint at
+   * all — see `resolveModel`. That is only reachable when the key below is set,
+   * so a deployment that has deliberately moved every completion in-house never
+   * lands there.
    */
   OPENAI_MODEL?: string;
+  /**
+   * Anthropic's key, and the switch that makes the Claude models exist.
+   *
+   * Optional, and its absence is a supported configuration rather than a
+   * misconfiguration: Covan needs exactly one provider to answer anything and
+   * OPENAI_API_KEY above is it. Unset means the Claude ids are not offered in
+   * the picker, not accepted by `PATCH /workspace`, and never resolved — so
+   * nothing this deployment sends can reach Anthropic. Setting it is the act
+   * that opts in. On Cloudflare: `wrangler secret put ANTHROPIC_API_KEY`.
+   */
+  ANTHROPIC_API_KEY?: string;
+  /**
+   * Where Claude completions go. Unset means api.anthropic.com. The Anthropic
+   * half of OPENAI_BASE_URL, for a gateway or proxy in front of it; the two are
+   * separate variables because they are separate endpoints, not two spellings
+   * of one decision.
+   */
+  ANTHROPIC_BASE_URL?: string;
   /** base64 32-byte AES-GCM key for delivery_channels.secret_ciphertext. */
   ROUTINE_SECRET_KEY: string;
   RESEND_API_KEY: string;


### PR DESCRIPTION
Ten models instead of four: the GPT-5 family alongside the 4o and 4.1 ones, and Claude Sonnet 4.6, Sonnet 4.5 and Haiku 4.5 for an install that sets `ANTHROPIC_API_KEY`. `gpt-5-nano` is the cheapest thing in the list and `claude-haiku-4-5` is the cheapest Claude, so the picker now spans a ~50x price range rather than a 16x one.

## The seam

`createOpenAI` was one SDK and one base URL with the model id passed straight through. Two providers do not fit that: the APIs disagree about where a system prompt goes, whether `max_tokens` is optional, and whether JSON mode is a parameter or a sentence. So `worker/src/lib/completion.ts` is the new seam — the five call sites keep describing a flat message list, `lib/models.ts` decides which provider, `lib/completion.ts` decides how to ask it. The rate-limit tripwire in `ratelimit.static.test.ts` follows the new import, so a future route that spends money still cannot arrive unnoticed.

## Three things worth knowing

**Without the key, nothing reaches Anthropic.** The Claude ids are not offered by `/me`, refused by `PATCH /workspace`, and never returned by `resolveModel` — and an agent already carrying one falls back to the default rather than failing, so rotating the key out does not stop anybody's agent answering. This is also what keeps `OPENAI_MODEL` honest: an install running everything through Ollama has no Anthropic key, so it never offers a Claude id and never reaches the branch that would bypass the override.

**The picker is now a server answer.** It used to be a constant in `agent-meta.ts`, which was true while one key implied one list. `/me` carries `models`; the constant is the fallback until it lands, and `modelsFor` also carries the current pick so a `<Select>` never renders blank on an agent whose model was withdrawn.

**Two provider quirks that fail silently if missed.** The GPT-5 family rejects any temperature but its own, which brainstorm mode sets — `acceptsTemperature` drops it for those three. And Anthropic spells truncation `max_tokens` where OpenAI says `length`; `lib/completion.ts` normalises it, so the `truncated` event added in #109 fires on either provider.

## Legal pages

`privacy` names Anthropic as a second destination — per agent, and for messages only: documents are still embedded where they were and dictation still cannot move. `terms` covers the second key.

## Verification

- worker: 945 tests, `tsc --noEmit` clean, `wrangler deploy --dry-run` builds (576 KB gzip)
- frontend: 506 tests, typecheck clean, `bun run build` succeeds
- lint: 0 errors

New suites: `completion.test.ts` (26), `anthropic.test.ts` (6, including the factory walk that keeps `new Anthropic(` out of every other file), plus additions to `models`, `pricing`, `agent-meta` and `workspace`.