### PR TITLE
Thinking that fits in the budget it was given

### DIFF
--- a/worker/src/lib/completion.test.ts
+++ b/worker/src/lib/completion.test.ts
@@ -6,6 +6,7 @@ import {
   extractJsonObject,
   totalTokens,
   DEFAULT_MAX_TOKENS,
+  REASONING_HEADROOM,
   type CompletionEnv,
   type CompletionEvent,
 } from "./completion";
@@ -176,6 +177,63 @@ describe("complete, on OpenAI", () => {
       temperature: 0.9,
     });
     expect(openaiCreate.mock.calls[0][0]).not.toHaveProperty("temperature");
+  });
+
+  describe("a reasoning model's budget", () => {
+    // The regression this exists to stop. A GPT-5 model bills its thinking
+    // against max_completion_tokens, so the persona drafter's 400 was spent
+    // deliberating and the reply came back empty with finish_reason "length" —
+    // an HTTP 200 that every caller here reads as "the model failed".
+
+    it("adds headroom when the caller wants the thinking", async () => {
+      await complete(openaiOnly, {
+        model: "gpt-5",
+        messages: [{ role: "user", content: "Hi" }],
+        maxTokens: 1536,
+      });
+      expect(openaiCreate.mock.calls[0][0].max_completion_tokens).toBe(1536 + REASONING_HEADROOM);
+      expect(openaiCreate.mock.calls[0][0]).not.toHaveProperty("reasoning_effort");
+    });
+
+    it("honours the caller's own number when the task does not want thinking", async () => {
+      await complete(openaiOnly, {
+        model: "gpt-5-mini",
+        messages: [{ role: "user", content: "Hi" }],
+        maxTokens: 400,
+        reasoningEffort: "minimal",
+      });
+      const call = openaiCreate.mock.calls[0][0];
+      expect(call.max_completion_tokens).toBe(400);
+      expect(call.reasoning_effort).toBe("minimal");
+    });
+
+    it("leaves a non-reasoning model's ceiling exactly as asked", async () => {
+      // gpt-4o has nothing to make room for, and inflating its ceiling would be
+      // spending someone's money to fix a problem it does not have.
+      await complete(openaiOnly, {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hi" }],
+        maxTokens: 400,
+      });
+      const call = openaiCreate.mock.calls[0][0];
+      expect(call.max_completion_tokens).toBe(400);
+      expect(call).not.toHaveProperty("reasoning_effort");
+    });
+
+    it("sends no reasoning_effort to a model that has no such setting", async () => {
+      await complete(openaiOnly, {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hi" }],
+        maxTokens: 400,
+        reasoningEffort: "minimal",
+      });
+      expect(openaiCreate.mock.calls[0][0]).not.toHaveProperty("reasoning_effort");
+    });
+
+    it("leaves an uncapped request uncapped rather than inventing a ceiling", async () => {
+      await complete(openaiOnly, { model: "gpt-5", messages: [{ role: "user", content: "Hi" }] });
+      expect(openaiCreate.mock.calls[0][0]).not.toHaveProperty("max_completion_tokens");
+    });
   });
 
   it("keeps it for a model that accepts one", async () => {

--- a/worker/src/lib/completion.ts
+++ b/worker/src/lib/completion.ts
@@ -2,7 +2,7 @@ import type OpenAI from "openai";
 import type Anthropic from "@anthropic-ai/sdk";
 import { createOpenAI } from "./openai";
 import { createAnthropic } from "./anthropic";
-import { providerFor, acceptsTemperature } from "./models";
+import { providerFor, acceptsTemperature, reasonsBeforeAnswering } from "./models";
 
 /**
  * The one seam every completion goes through, whichever provider answers it.
@@ -57,6 +57,18 @@ export type CompletionRequest = {
   temperature?: number;
   /** Ask for a single JSON object back. */
   json?: boolean;
+  /**
+   * Set by a caller whose task is shaping, not thinking.
+   *
+   * Drafting a persona from a title or pulling ideas out of a transcript are
+   * writing tasks with a known shape; a reasoning model deliberating over them
+   * buys nothing and costs a multiple. Measured on the persona drafter: default
+   * effort spends 512-1408 tokens thinking before writing ~120 tokens of
+   * answer, and `"minimal"` spends none and writes the same answer.
+   *
+   * Nothing on a non-reasoning model, which has no such setting.
+   */
+  reasoningEffort?: "minimal";
 };
 
 /**
@@ -66,6 +78,27 @@ export type CompletionRequest = {
  * draft) and still a real stop.
  */
 export const DEFAULT_MAX_TOKENS = 4096;
+
+/**
+ * Extra room given to a reasoning model, on top of what the caller asked for.
+ *
+ * `maxTokens` means "how long an answer" everywhere it is set in this codebase
+ * — `maxTokensFor` in `lib/prompt.ts` sizes it for a chat reply. On a reasoning
+ * model the API's ceiling covers thinking too, so passing that number through
+ * unchanged spends the answer's budget on deliberation and truncates, or empties,
+ * the reply.
+ *
+ * 4096 is sized from measurement rather than picked: a chat-shaped request with
+ * retrieved context spent 896 reasoning tokens on gpt-5 and 384 on gpt-5-mini,
+ * and the trivial persona draft — where there is least to think about and it
+ * therefore ran longest relative to the answer — spent 1408. This leaves room
+ * for a harder question than either without turning the ceiling into no ceiling.
+ *
+ * It applies only when the caller wants the thinking. A caller that sets
+ * `reasoningEffort: "minimal"` gets its own number honoured, because there is
+ * then nothing to make room for.
+ */
+export const REASONING_HEADROOM = 4096;
 
 const JSON_ONLY_INSTRUCTION =
   "Respond with a single JSON object and nothing else: no prose before or after it, " +
@@ -105,10 +138,20 @@ export function extractJsonObject(text: string): string {
 // ---- OpenAI ----------------------------------------------------------------
 
 function openaiParams(req: CompletionRequest): OpenAI.Chat.Completions.ChatCompletionCreateParams {
+  const reasons = reasonsBeforeAnswering(req.model);
+  // Two ways to keep thinking from eating the answer, and which one applies is
+  // the caller's call, not the model's: minimal effort when the task does not
+  // want deliberation, headroom when it does. See REASONING_HEADROOM.
+  const minimal = reasons && req.reasoningEffort === "minimal";
+  const cap =
+    req.maxTokens !== undefined && reasons && !minimal
+      ? req.maxTokens + REASONING_HEADROOM
+      : req.maxTokens;
   return {
     model: req.model,
     messages: req.messages as OpenAI.Chat.Completions.ChatCompletionMessageParam[],
-    ...(req.maxTokens !== undefined ? { max_completion_tokens: req.maxTokens } : {}),
+    ...(cap !== undefined ? { max_completion_tokens: cap } : {}),
+    ...(minimal ? { reasoning_effort: "minimal" as const } : {}),
     ...(req.temperature !== undefined && acceptsTemperature(req.model)
       ? { temperature: req.temperature }
       : {}),

--- a/worker/src/lib/models.ts
+++ b/worker/src/lib/models.ts
@@ -48,6 +48,22 @@ export type ModelSpec = {
    * model alone, which is exactly the kind of bug nobody reproduces.
    */
   temperature: boolean;
+  /**
+   * Whether the model thinks before it answers, and bills that thinking against
+   * the same ceiling as the answer.
+   *
+   * This is the difference between `max_completion_tokens` meaning "how long an
+   * answer" and meaning "how long an answer plus however much deliberation the
+   * model decided to do first". Measured on the persona drafter, whose ceiling
+   * is 400: gpt-5 spent 1408 tokens thinking, gpt-5-mini 512, gpt-5-nano 1152.
+   * All three therefore returned an empty string with `finish_reason: "length"`
+   * — a successful HTTP 200 carrying no content, which every caller here reads
+   * as "the model failed".
+   *
+   * `lib/completion.ts` is where this is paid for, in one of two ways depending
+   * on whether the caller wants the thinking at all.
+   */
+  reasoning: boolean;
 };
 
 /**
@@ -56,16 +72,16 @@ export type ModelSpec = {
  * model that reaches `lib/completion.ts` with no provider.
  */
 const SPECS: Record<ModelId, ModelSpec> = {
-  "gpt-4o": { provider: "openai", temperature: true },
-  "gpt-4o-mini": { provider: "openai", temperature: true },
-  "gpt-4.1": { provider: "openai", temperature: true },
-  "gpt-4.1-mini": { provider: "openai", temperature: true },
-  "gpt-5": { provider: "openai", temperature: false },
-  "gpt-5-mini": { provider: "openai", temperature: false },
-  "gpt-5-nano": { provider: "openai", temperature: false },
-  "claude-sonnet-4-6": { provider: "anthropic", temperature: true },
-  "claude-sonnet-4-5": { provider: "anthropic", temperature: true },
-  "claude-haiku-4-5": { provider: "anthropic", temperature: true },
+  "gpt-4o": { provider: "openai", temperature: true, reasoning: false },
+  "gpt-4o-mini": { provider: "openai", temperature: true, reasoning: false },
+  "gpt-4.1": { provider: "openai", temperature: true, reasoning: false },
+  "gpt-4.1-mini": { provider: "openai", temperature: true, reasoning: false },
+  "gpt-5": { provider: "openai", temperature: false, reasoning: true },
+  "gpt-5-mini": { provider: "openai", temperature: false, reasoning: true },
+  "gpt-5-nano": { provider: "openai", temperature: false, reasoning: true },
+  "claude-sonnet-4-6": { provider: "anthropic", temperature: true, reasoning: false },
+  "claude-sonnet-4-5": { provider: "anthropic", temperature: true, reasoning: false },
+  "claude-haiku-4-5": { provider: "anthropic", temperature: true, reasoning: false },
 };
 
 export const DEFAULT_MODEL = "gpt-4o";
@@ -107,6 +123,18 @@ export function providerFor(model: string | null | undefined): ModelProvider {
 /** Whether a temperature may be sent for `model`. Unknown ids: yes, as before. */
 export function acceptsTemperature(model: string | null | undefined): boolean {
   return modelSpec(model)?.temperature ?? true;
+}
+
+/**
+ * Whether `model` bills its own deliberation against the output ceiling.
+ *
+ * Unknown ids are treated as not reasoning, which is the safe answer rather
+ * than the optimistic one: under `OPENAI_BASE_URL` every id is unknown, and
+ * quietly tripling a self-hoster's token ceiling because we could not identify
+ * their model would be a cost decision made on their behalf.
+ */
+export function reasonsBeforeAnswering(model: string | null | undefined): boolean {
+  return modelSpec(model)?.reasoning ?? false;
 }
 
 /**

--- a/worker/src/routes/brainstorm.ts
+++ b/worker/src/routes/brainstorm.ts
@@ -73,6 +73,9 @@ brainstorm.post("/brainstorm/ideas/suggest", async (c) => {
       model: resolveModel(agent?.model ?? null, c.env),
       messages: buildIdeaExtractionMessages(transcript),
       json: true,
+      // Distilling a transcript into cards is the same kind of task as the
+      // persona drafter's, and the same ceiling problem without this.
+      reasoningEffort: "minimal",
       maxTokens: 800,
     });
     await recordQuota(c, totalTokens(usage));

--- a/worker/src/routes/persona.ts
+++ b/worker/src/routes/persona.ts
@@ -31,6 +31,9 @@ persona.post("/persona/suggest", async (c) => {
       model: resolveModel(model ?? null, c.env),
       messages: buildPersonaMessages(name),
       json: true,
+      // A title in, three sentences out: shaping, not thinking. Without this a
+      // reasoning model spends the whole 400 deliberating and returns nothing.
+      reasoningEffort: "minimal",
       maxTokens: 400,
     });
     await recordQuota(c, totalTokens(usage));


### PR DESCRIPTION
Fixes "Write from name", which #110 broke for anyone who had a GPT-5 model selected.

## What happened

GPT-5 models bill their own deliberation against `max_completion_tokens`. The persona drafter's ceiling is 400, so the whole budget went on thinking and the reply came back **empty** with `finish_reason: "length"` — a successful HTTP 200 carrying no content, which `parsePersonaSuggestion` reads as a failed generation and the button reports as "Couldn't write a persona."

Measured against the live API with the drafter's own prompt:

| model | reasoning tokens | content | result |
|---|---|---|---|
| `gpt-4o` | 0 | 533 chars | ok |
| `gpt-5` | 400 (capped) | 0 | `finish_reason: length` |
| `gpt-5-mini` | 400 (capped) | 0 | `finish_reason: length` |
| `gpt-5-nano` | 400 (capped) | 0 | `finish_reason: length` |

Given room, that same call spends **1408** reasoning tokens on gpt-5 and **1152** on gpt-5-nano — to write ~120 tokens of answer.

## The fix

`maxTokens` means "how long an answer" at every call site in this repo. On a reasoning model the API's ceiling means "answer plus however much thinking it decided to do", and `lib/completion.ts` is where that stops being the caller's problem. Two treatments, because there are two kinds of caller:

- **Shaping, not thinking** — persona drafting and idea extraction pass `reasoningEffort: "minimal"` and keep their own ceiling. Verified live: reasoning drops to 0 and all four models return parseable JSON at 400 (and at brainstorm's 800).
- **Thinking that was wanted** — chat asks for 1536, which on gpt-5 was not empty but squeezed: 896 reasoning tokens left 310 characters of answer, where 577 came back with room. `REASONING_HEADROOM` (4096) is added on top, sized from those measurements.

A non-reasoning model gets neither — its ceiling passes through untouched, because inflating it would spend someone's money on a problem it does not have. Unknown ids (every id, under `OPENAI_BASE_URL`) count as non-reasoning for the same reason.

## Verification

- 950 worker tests, typecheck clean, lint 0 errors
- Five new tests pin the branch table, including that gpt-4o's ceiling is untouched and that an uncapped request stays uncapped
- Re-run against the live API after the fix: persona at 400 and ideas at 800 both parse on `gpt-5`, `gpt-5-mini`, `gpt-5-nano` and `gpt-4o`