### PR TITLE
A chat that names itself, and a name you can change

### DIFF
--- a/src/components/agent-workspace.tsx
+++ b/src/components/agent-workspace.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { useAgentsStore } from "@/lib/agents-store";
 import { AgentAvatar } from "@/components/avatars";
+import { SessionRow } from "@/components/session-row";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -33,8 +34,16 @@ import {
 } from "@/components/ui/alert-dialog";
 
 export function AgentWorkspace({ agentId, children }: { agentId: string; children?: ReactNode }) {
-  const { agents, sessions, deleteAgent, startSession, startBrainstorm, deleteSession, canWrite } =
-    useAgentsStore();
+  const {
+    agents,
+    sessions,
+    deleteAgent,
+    startSession,
+    startBrainstorm,
+    deleteSession,
+    renameSession,
+    canWrite,
+  } = useAgentsStore();
   const agent = agents.find((a) => a.id === agentId);
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const activeSessionId = useRouterState({
@@ -205,33 +214,14 @@ export function AgentWorkspace({ agentId, children }: { agentId: string; childre
                 </div>
                 <div className="space-y-0.5">
                   {sharedSessions.map((s) => (
-                    <div
+                    <SessionRow
                       key={s.id}
-                      className={cn(
-                        "group flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors duration-200",
-                        s.id === activeSessionId
-                          ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                          : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-foreground",
-                      )}
-                    >
-                      <button
-                        onClick={() => openChat(s.id)}
-                        className="flex min-w-0 flex-1 items-center gap-1.5 truncate text-left"
-                      >
-                        <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                        <span className="min-w-0 flex-1 truncate">
-                          {s.kind === "brainstorm" && <span className="mr-1">🧠</span>}
-                          {s.title || (s.kind === "brainstorm" ? "New brainstorm" : "New chat")}
-                        </span>
-                      </button>
-                      <button
-                        onClick={() => removeSession(s.id)}
-                        className="shrink-0 opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
-                        aria-label="Delete chat"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
+                      session={s}
+                      active={s.id === activeSessionId}
+                      onOpen={openChat}
+                      onRename={renameSession}
+                      onDelete={removeSession}
+                    />
                   ))}
                 </div>
               </div>
@@ -245,30 +235,14 @@ export function AgentWorkspace({ agentId, children }: { agentId: string; childre
                 <p className="px-3 py-1 text-xs text-sidebar-foreground/50">No chats yet.</p>
               ) : (
                 mySessions.map((s) => (
-                  <div
+                  <SessionRow
                     key={s.id}
-                    className={cn(
-                      "group flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors duration-200",
-                      s.id === activeSessionId
-                        ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                        : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-foreground",
-                    )}
-                  >
-                    <button
-                      onClick={() => openChat(s.id)}
-                      className="min-w-0 flex-1 truncate text-left"
-                    >
-                      {s.kind === "brainstorm" && <span className="mr-1">🧠</span>}
-                      {s.title || (s.kind === "brainstorm" ? "New brainstorm" : "New chat")}
-                    </button>
-                    <button
-                      onClick={() => removeSession(s.id)}
-                      className="shrink-0 opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
-                      aria-label="Delete chat"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </button>
-                  </div>
+                    session={s}
+                    active={s.id === activeSessionId}
+                    onOpen={openChat}
+                    onRename={renameSession}
+                    onDelete={removeSession}
+                  />
                 ))
               )}
             </div>

--- a/src/components/session-row.test.tsx
+++ b/src/components/session-row.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SessionRow } from "./session-row";
+import type { ChatSession } from "@/lib/agents-store";
+
+const session = (patch: Partial<ChatSession> = {}): ChatSession =>
+  ({
+    id: "s1",
+    agentId: "a1",
+    title: "Q3 pricing review",
+    visibility: "private",
+    kind: "chat",
+    ownerId: "u1",
+    messages: [],
+    messageCount: 4,
+    updatedAt: Date.now(),
+    ...patch,
+  }) as ChatSession;
+
+function renderRow(
+  patch: Partial<ChatSession> = {},
+  handlers: Partial<Parameters<typeof SessionRow>[0]> = {},
+) {
+  const onOpen = vi.fn();
+  const onRename = vi.fn();
+  const onDelete = vi.fn();
+  render(
+    <SessionRow
+      session={session(patch)}
+      active={false}
+      onOpen={onOpen}
+      onRename={onRename}
+      onDelete={onDelete}
+      {...handlers}
+    />,
+  );
+  return { onOpen, onRename, onDelete };
+}
+
+const renameButton = () => screen.getByRole("button", { name: "Rename chat" });
+const nameField = () => screen.getByRole("textbox", { name: "Chat name" });
+
+describe("a session in the sidebar", () => {
+  it("shows the name it was given", () => {
+    renderRow();
+    expect(screen.getByText("Q3 pricing review")).toBeInTheDocument();
+  });
+
+  it("falls back to a placeholder while the title is still being written", () => {
+    renderRow({ title: null });
+    expect(screen.getByText("New chat")).toBeInTheDocument();
+  });
+
+  it("names an untitled brainstorm as a brainstorm", () => {
+    renderRow({ title: null, kind: "brainstorm" });
+    expect(screen.getByText("New brainstorm")).toBeInTheDocument();
+  });
+
+  it("opens the chat when the name is clicked", async () => {
+    const { onOpen } = renderRow();
+    await userEvent.click(screen.getByText("Q3 pricing review"));
+    expect(onOpen).toHaveBeenCalledWith("s1");
+  });
+});
+
+describe("renaming a session", () => {
+  it("saves the new name", async () => {
+    const { onRename } = renderRow();
+
+    await userEvent.click(renameButton());
+    await userEvent.clear(nameField());
+    await userEvent.type(nameField(), "Pricing v2{Enter}");
+
+    expect(onRename).toHaveBeenCalledWith("s1", "Pricing v2");
+  });
+
+  // The field opens with the current name selected, so the common case —
+  // replacing the machine's guess — is one keystroke rather than a clear first.
+  it("opens on the current name", async () => {
+    renderRow();
+    await userEvent.click(renameButton());
+    expect(nameField()).toHaveValue("Q3 pricing review");
+  });
+
+  it("abandons the edit on Escape", async () => {
+    const { onRename } = renderRow();
+
+    await userEvent.click(renameButton());
+    await userEvent.type(nameField(), " and more{Escape}");
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByText("Q3 pricing review")).toBeInTheDocument();
+  });
+
+  // Clicking away is how most people leave a field, and losing the edit there
+  // reads as the app dropping what you typed.
+  it("saves when the field loses focus", async () => {
+    const { onRename } = renderRow();
+
+    await userEvent.click(renameButton());
+    await userEvent.clear(nameField());
+    await userEvent.type(nameField(), "Pricing v2");
+    await userEvent.tab();
+
+    expect(onRename).toHaveBeenCalledWith("s1", "Pricing v2");
+  });
+
+  it("does not ask the server to store a blank name", async () => {
+    const { onRename } = renderRow();
+
+    await userEvent.click(renameButton());
+    await userEvent.clear(nameField());
+    await userEvent.type(nameField(), "   {Enter}");
+
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it("says nothing to the server when the name did not change", async () => {
+    const { onRename } = renderRow();
+
+    await userEvent.click(renameButton());
+    await userEvent.type(nameField(), "{Enter}");
+
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  // The row is a button; a field inside it is not, and a click meant for the
+  // text must not navigate away mid-edit.
+  it("does not open the chat while the name is being edited", async () => {
+    const { onOpen } = renderRow();
+
+    await userEvent.click(renameButton());
+    await userEvent.click(nameField());
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("deletes on request", async () => {
+    const { onDelete } = renderRow();
+    await userEvent.click(screen.getByRole("button", { name: "Delete chat" }));
+    expect(onDelete).toHaveBeenCalledWith("s1");
+  });
+});

--- a/src/components/session-row.tsx
+++ b/src/components/session-row.tsx
@@ -1,0 +1,124 @@
+import { useRef, useState } from "react";
+import { Pencil, Trash2, Users } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ChatSession } from "@/lib/agents-store";
+
+/**
+ * As wide a name as the API will store. Mirrors TITLE_INPUT_MAX_CHARS in
+ * worker/src/routes/sessions.ts — the field stops accepting characters at the
+ * point where the server would start refusing them, so nobody types a name and
+ * is told afterwards that it was too long.
+ */
+const TITLE_MAX_CHARS = 120;
+
+/**
+ * One conversation in the sidebar: open it, rename it, delete it.
+ *
+ * Extracted because the sidebar draws this twice — once for the team's shared
+ * threads and once for your own — and rename is a small state machine that
+ * would have been written out twice and drifted apart the first time either
+ * copy was touched.
+ */
+export function SessionRow({
+  session,
+  active,
+  onOpen,
+  onRename,
+  onDelete,
+}: {
+  session: ChatSession;
+  active: boolean;
+  onOpen: (id: string) => void;
+  onRename: (id: string, title: string) => void;
+  onDelete: (id: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  // Enter both saves and closes the field, and closing it can fire blur — which
+  // would save again. Whichever of the two arrives first settles the edit and
+  // the other becomes a no-op.
+  const settled = useRef(false);
+
+  const label = session.title || (session.kind === "brainstorm" ? "New brainstorm" : "New chat");
+
+  const startEditing = () => {
+    setDraft(session.title ?? "");
+    settled.current = false;
+    setEditing(true);
+  };
+
+  const commit = () => {
+    if (settled.current) return;
+    settled.current = true;
+    setEditing(false);
+    const next = draft.trim();
+    // Nothing typed, or nothing changed: a rename that would land the session
+    // on the name it already has is a round trip and a re-sort for no reason.
+    if (next.length === 0 || next === (session.title ?? "")) return;
+    onRename(session.id, next);
+  };
+
+  const cancel = () => {
+    settled.current = true;
+    setEditing(false);
+  };
+
+  return (
+    <div
+      className={cn(
+        "group flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors duration-200",
+        active
+          ? "bg-sidebar-accent text-sidebar-accent-foreground"
+          : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-foreground",
+      )}
+    >
+      {editing ? (
+        <input
+          // Focused on open: the field exists because the user just asked to
+          // rename, so anywhere else is the wrong place for the caret.
+          autoFocus
+          aria-label="Chat name"
+          value={draft}
+          maxLength={TITLE_MAX_CHARS}
+          onChange={(e) => setDraft(e.target.value)}
+          onFocus={(e) => e.currentTarget.select()}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") commit();
+            if (e.key === "Escape") cancel();
+          }}
+          className="min-w-0 flex-1 rounded-sm bg-transparent text-sm text-sidebar-foreground outline-none ring-1 ring-sidebar-border focus:ring-ring"
+        />
+      ) : (
+        <>
+          <button
+            onClick={() => onOpen(session.id)}
+            className="flex min-w-0 flex-1 items-center gap-1.5 truncate text-left"
+          >
+            {session.visibility === "shared" && (
+              <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            )}
+            <span className="min-w-0 flex-1 truncate">
+              {session.kind === "brainstorm" && <span className="mr-1">🧠</span>}
+              {label}
+            </span>
+          </button>
+          <button
+            onClick={startEditing}
+            className="shrink-0 opacity-0 transition-opacity hover:text-sidebar-foreground group-hover:opacity-100"
+            aria-label="Rename chat"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+          <button
+            onClick={() => onDelete(session.id)}
+            className="shrink-0 opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+            aria-label="Delete chat"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/agents-store.tsx
+++ b/src/lib/agents-store.tsx
@@ -115,6 +115,7 @@ type Store = {
   updateMessage: (sessionId: string, messageId: string, content: string) => void;
   deleteMessagesAfter: (sessionId: string, messageId: string) => void;
   deleteSession: (id: string) => void;
+  renameSession: (id: string, title: string) => void;
   toggleFavorite: (agentId: string) => void;
 };
 
@@ -289,6 +290,28 @@ export function AgentsProvider({ children }: { children: ReactNode }) {
           .remove(id)
           .then(() => queryClient.invalidateQueries({ queryKey: ["sessions"] }))
           .catch(() => toast.error("Couldn't delete the conversation."));
+      },
+
+      // Optimistic, unlike deleteSession: the name is already on screen in the
+      // field the user just left, and a round trip before it settles reads as
+      // the rename not having taken. A failure puts the old list back and says
+      // so, the same shape as toggleFavorite below.
+      renameSession: (id, title) => {
+        const key = ["sessions"] as const;
+        const previous = queryClient.getQueryData<ChatSession[]>(key);
+        queryClient.setQueryData<ChatSession[]>(key, (old = []) =>
+          old.map((s) => (s.id === id ? { ...s, title } : s)),
+        );
+
+        void api.sessions
+          .rename(id, title)
+          .catch(() => {
+            queryClient.setQueryData<ChatSession[]>(key, previous);
+            toast.error("Couldn't rename the conversation.");
+          })
+          .finally(() => {
+            void queryClient.invalidateQueries({ queryKey: key });
+          });
       },
 
       updateMessage: (sessionId, messageId, content) => {

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -332,6 +332,8 @@ export const api = {
     messages: (id: string): Promise<Message[]> => request("GET", `/sessions/${id}/messages`),
     setVisibility: (id: string, visibility: "private" | "shared"): Promise<ChatSession> =>
       request("PATCH", `/sessions/${id}`, { visibility }),
+    rename: (id: string, title: string): Promise<ChatSession> =>
+      request("PATCH", `/sessions/${id}`, { title }),
   },
   messages: {
     create: (input: { sessionId: string; role: "user"; content: string }): Promise<Message> =>

--- a/worker/src/lib/session-title.test.ts
+++ b/worker/src/lib/session-title.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Titling goes through the provider seam, not an SDK: a workspace on a Claude
+// model must get its titles from Claude and not need an OpenAI key to have a
+// named sidebar.
+const { complete } = vi.hoisted(() => ({ complete: vi.fn() }));
+vi.mock("./completion", async (orig) => ({
+  ...(await orig<typeof import("./completion")>()),
+  complete,
+}));
+
+const { parseTitleSuggestion, buildTitleMessages, generateSessionTitle, TITLE_MAX_CHARS } =
+  await import("./session-title");
+
+describe("parseTitleSuggestion", () => {
+  it("parses well-formed { title: string } JSON", () => {
+    const raw = JSON.stringify({ title: "Q3 pricing review" });
+    expect(parseTitleSuggestion(raw)).toBe("Q3 pricing review");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseTitleSuggestion(JSON.stringify({ title: "  Onboarding email\n" }))).toBe(
+      "Onboarding email",
+    );
+  });
+
+  it("strips the quotes and trailing period models like to add", () => {
+    expect(parseTitleSuggestion(JSON.stringify({ title: '"Onboarding email"' }))).toBe(
+      "Onboarding email",
+    );
+    expect(parseTitleSuggestion(JSON.stringify({ title: "Onboarding email." }))).toBe(
+      "Onboarding email",
+    );
+  });
+
+  it("collapses newlines so a title stays one line in the sidebar", () => {
+    expect(parseTitleSuggestion(JSON.stringify({ title: "Onboarding\nemail copy" }))).toBe(
+      "Onboarding email copy",
+    );
+  });
+
+  it("truncates an over-long title to the column the sidebar can show", () => {
+    const long = "a".repeat(TITLE_MAX_CHARS + 40);
+    const parsed = parseTitleSuggestion(JSON.stringify({ title: long }));
+    expect(parsed).not.toBeNull();
+    expect(parsed!.length).toBe(TITLE_MAX_CHARS);
+  });
+
+  it("returns null for a blank or non-string title", () => {
+    expect(parseTitleSuggestion(JSON.stringify({ title: "" }))).toBeNull();
+    expect(parseTitleSuggestion(JSON.stringify({ title: "   " }))).toBeNull();
+    expect(parseTitleSuggestion(JSON.stringify({ title: 42 }))).toBeNull();
+  });
+
+  it("returns null when stripping leaves nothing behind", () => {
+    expect(parseTitleSuggestion(JSON.stringify({ title: '"."' }))).toBeNull();
+  });
+
+  it("returns null for non-JSON, non-object, or missing title", () => {
+    expect(parseTitleSuggestion("not json")).toBeNull();
+    expect(parseTitleSuggestion("[]")).toBeNull();
+    expect(parseTitleSuggestion(JSON.stringify({}))).toBeNull();
+    expect(parseTitleSuggestion("null")).toBeNull();
+  });
+});
+
+describe("buildTitleMessages", () => {
+  it("includes the message and asks for a JSON title", () => {
+    const msgs = buildTitleMessages("How should we price the team plan?");
+    expect(msgs[0].role).toBe("system");
+    expect(msgs[0].content.toLowerCase()).toContain("json");
+    expect(msgs[1].role).toBe("user");
+    expect(msgs[1].content).toContain("How should we price the team plan?");
+  });
+
+  it("tells the model to answer in the language of the message", () => {
+    // Turkish, deliberately: the title must come back in the asker's own
+    // language, and an English fixture could not tell that apart from a
+    // prompt that always answers in English.
+    const msgs = buildTitleMessages("Takım planını nasıl fiyatlandırmalıyız?");
+    expect(msgs[0].content.toLowerCase()).toContain("language");
+  });
+
+  it("truncates a giant pasted message rather than paying to title all of it", () => {
+    const huge = "x".repeat(5000);
+    const msgs = buildTitleMessages(huge);
+    expect(msgs[1].content.length).toBeLessThan(1200);
+  });
+});
+
+const ENV = { OPENAI_API_KEY: "sk-test" };
+
+/** What the seam gives back: a reply, and what it cost. */
+const answers = (text: string, promptTokens = 60, completionTokens = 10) =>
+  complete.mockResolvedValue({
+    text,
+    usage: { promptTokens, completionTokens, cachedTokens: null },
+  });
+
+describe("generateSessionTitle", () => {
+  // A block body, not a concise one: `mockReset()` returns the mock, and a
+  // function returned from beforeEach is taken as the teardown callback and
+  // called after the test — which would invoke the mock an extra time.
+  beforeEach(() => {
+    complete.mockReset();
+  });
+
+  it("returns the title the model wrote, and what it cost", async () => {
+    answers(JSON.stringify({ title: "Team plan pricing" }), 70, 21);
+
+    const result = await generateSessionTitle(ENV, "gpt-4o", "How do we price teams?");
+
+    expect(result).toEqual({ title: "Team plan pricing", tokens: 91 });
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(complete.mock.calls[0][1]).toMatchObject({ model: "gpt-4o", json: true });
+  });
+
+  // Naming a conversation is shaping, not thinking. A reasoning model left to
+  // deliberate over it spends the whole ceiling on thought and returns nothing
+  // — the same thing that had to be said about the persona drafter.
+  it("asks a reasoning model not to think about it", async () => {
+    answers(JSON.stringify({ title: "Team plan pricing" }));
+
+    await generateSessionTitle(ENV, "gpt-5", "How do we price teams?");
+
+    expect(complete.mock.calls[0][1]).toMatchObject({ reasoningEffort: "minimal" });
+  });
+
+  // The reply is already on screen by the time this is awaited, but the
+  // composer stays disabled until the turn closes — so a titling call that
+  // hangs would hold the user's keyboard hostage. It is given something to be
+  // given up on.
+  it("hands the call a signal so a hung request cannot hold up the turn", async () => {
+    answers(JSON.stringify({ title: "Team plan pricing" }));
+
+    await generateSessionTitle(ENV, "gpt-4o", "How do we price teams?");
+
+    const signal = complete.mock.calls[0][2]?.signal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal.aborted).toBe(false);
+  });
+
+  // The tokens were spent whether or not the reply was usable, so they are
+  // still reported: the caller charges them to the same allowance as the turn.
+  it("reports the cost of a reply it could not parse, with no title", async () => {
+    answers("not json at all", 30, 14);
+
+    await expect(generateSessionTitle(ENV, "gpt-4o", "hi")).resolves.toEqual({
+      title: null,
+      tokens: 44,
+    });
+  });
+
+  // A session title is worth nothing next to the reply it rides along with, so
+  // a failed call is swallowed here rather than left to abort the turn.
+  it("swallows a failed call rather than letting it break the reply", async () => {
+    complete.mockImplementation(() => {
+      throw new Error("the provider is down");
+    });
+
+    await expect(generateSessionTitle(ENV, "gpt-4o", "hi")).resolves.toEqual({
+      title: null,
+      tokens: 0,
+    });
+  });
+});

--- a/worker/src/lib/session-title.ts
+++ b/worker/src/lib/session-title.ts
@@ -1,0 +1,133 @@
+import { complete, totalTokens, type CompletionEnv } from "./completion";
+
+/**
+ * How wide a generated title may be. The sidebar truncates with an ellipsis
+ * anyway, so anything past this is paid for and never read.
+ */
+export const TITLE_MAX_CHARS = 60;
+
+/**
+ * How much of the opening message is worth sending to be titled. A title comes
+ * out of the first sentence or two; the rest of a pasted wall of text only adds
+ * input tokens. Titling is charged against the same monthly allowance as the
+ * reply, so this cap is a real saving and not a stylistic one.
+ */
+const SOURCE_MAX_CHARS = 1000;
+
+/**
+ * How long a titling call may take before it is abandoned.
+ *
+ * The turn waits on this before it closes, so the number is not about the title
+ * — it is about the composer, which stays disabled until the turn closes. Both
+ * SDKs default to minutes, which would be a hung request holding the user's
+ * keyboard for the sake of a label. Ten seconds is generous for a handful of
+ * output tokens and short enough that nobody sits through it twice.
+ */
+const TITLE_TIMEOUT_MS = 10_000;
+
+/**
+ * The ceiling on the title itself.
+ *
+ * Wider than the six words asked for, because it is counted in tokens and the
+ * languages that need the most of them per word are exactly the ones this is
+ * meant to serve — a Turkish title costs more here than its English
+ * translation.
+ */
+const TITLE_MAX_TOKENS = 64;
+
+/**
+ * Parse the model's JSON-mode reply into a session title. Resilient by design:
+ * any malformed / partial / unexpected shape yields null rather than throwing,
+ * so a bad generation leaves the title unset — the sidebar keeps saying "New
+ * chat", which is exactly where it started.
+ */
+export function parseTitleSuggestion(raw: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const title = (parsed as { title?: unknown } | null)?.title;
+  if (typeof title !== "string") return null;
+
+  // Models wrap titles in quotes and end them with a period however plainly the
+  // prompt asks them not to. Strip both here rather than trusting the prompt:
+  // the prompt is a request, this is the guarantee. Newlines collapse too — a
+  // title is one line in a narrow column, whatever the model thought.
+  const cleaned = title
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^["'“”‘’]+|["'“”‘’]+$/g, "")
+    .replace(/[.。]+$/, "")
+    .trim();
+
+  if (cleaned.length === 0) return null;
+  return cleaned.slice(0, TITLE_MAX_CHARS);
+}
+
+/**
+ * Build the titling prompt: name a conversation from the message that opened
+ * it. JSON-only so parseTitleSuggestion can read it. The title is written in
+ * the message's own language, so a Turkish question gets a Turkish title.
+ */
+export function buildTitleMessages(
+  firstMessage: string,
+): { role: "system" | "user"; content: string }[] {
+  return [
+    {
+      role: "system",
+      content:
+        "You name conversations. Given the first message a person sent to an assistant, " +
+        'write a short label for that conversation. Respond ONLY with JSON of the exact shape {"title":string}. ' +
+        "Three to six words, naming the subject the person raised — not the fact that they asked a " +
+        "question, and never a greeting. Write it in the same language as the message. " +
+        "No quotation marks, no trailing period, no markdown, no prose outside the JSON.",
+    },
+    {
+      role: "user",
+      content: `First message: ${firstMessage.slice(0, SOURCE_MAX_CHARS)}`,
+    },
+  ];
+}
+
+/**
+ * Name a conversation from the message that opened it.
+ *
+ * Never throws and never rejects. A title is a convenience riding along with a
+ * reply the user actually asked for, so every way this can go wrong — a
+ * refusal, an outage, a reply that isn't JSON — comes back as `title: null` and
+ * the session keeps the name it had. The caller writes a title only when one
+ * arrives.
+ *
+ * `tokens` is reported separately from `title` and is deliberately not zeroed
+ * when the reply is unusable: OpenAI charged for it either way, and the caller
+ * folds it into the same allowance write as the turn it rode along with.
+ */
+export async function generateSessionTitle(
+  env: CompletionEnv,
+  model: string,
+  firstMessage: string,
+): Promise<{ title: string | null; tokens: number }> {
+  try {
+    const { text, usage } = await complete(
+      env,
+      {
+        model,
+        messages: buildTitleMessages(firstMessage),
+        json: true,
+        // Naming a conversation is shaping, not thinking — the same call the
+        // persona drafter makes, and for the same reason: a reasoning model
+        // left to deliberate spends the ceiling below on thought and returns
+        // an empty answer.
+        reasoningEffort: "minimal",
+        maxTokens: TITLE_MAX_TOKENS,
+      },
+      { signal: AbortSignal.timeout(TITLE_TIMEOUT_MS) },
+    );
+    return { title: parseTitleSuggestion(text), tokens: totalTokens(usage) };
+  } catch (err) {
+    console.error("session titling failed", err);
+    return { title: null, tokens: 0 };
+  }
+}

--- a/worker/src/routes/chat.test.ts
+++ b/worker/src/routes/chat.test.ts
@@ -24,6 +24,7 @@ const AGENT = { id: "agent-1", persona: "You are our PM.", model: null, mode: "n
 const embedTexts = vi.fn();
 const completionCreate = vi.fn();
 const serviceInsert = vi.fn();
+const sessionUpdate = vi.fn();
 
 vi.mock("../lib/embeddings", () => ({
   embedTexts: (...args: unknown[]) => embedTexts(...args),
@@ -62,7 +63,18 @@ vi.mock("../lib/supabase", () => ({
           },
         };
       }
-      return { update: () => ({ eq: async () => ({ error: null }) }) };
+      // chat_sessions, which the route touches twice: the `updated_at` bump
+      // ends at `.eq()`, and the generated title adds `.is("title", null)`
+      // after it so it cannot overwrite a name the user chose mid-stream.
+      return {
+        update: (row: Record<string, unknown>) => {
+          sessionUpdate(row);
+          const settled = Object.assign(Promise.resolve({ error: null }), {
+            is: async () => ({ error: null }),
+          });
+          return { eq: () => settled };
+        },
+      };
     },
   }),
 }));
@@ -81,6 +93,25 @@ function streamOf(text: string, finishReason = "stop") {
   };
 }
 
+/** The unstreamed JSON reply the titler asks for. */
+function titleOf(title: string) {
+  return {
+    choices: [{ message: { content: JSON.stringify({ title }) } }],
+    usage: { prompt_tokens: 20, completion_tokens: 5, prompt_tokens_details: {} },
+  };
+}
+
+/**
+ * Answer both completions a turn makes — the streamed reply and, for an
+ * untitled session, the titling call — from the one mocked client, dispatching
+ * on `stream` the way the two are actually told apart.
+ */
+function answersWith(reply: ReturnType<typeof streamOf>, title = "Vacation days") {
+  completionCreate.mockImplementation(async (body: { stream?: boolean }) =>
+    body.stream ? reply : titleOf(title),
+  );
+}
+
 type Doc = { id: string; name: string; content: string | null };
 type Match = { document_id: string; document_name: string; content: string };
 
@@ -89,6 +120,8 @@ function appWith(spec: {
   history?: Array<{ role: string; content: string }>;
   documents?: Doc[];
   matches?: Match[];
+  /** The name the session already has. Null — the default — is a new chat. */
+  sessionTitle?: string | null;
 }) {
   const documents = spec.documents ?? [];
   const rows = [...(spec.history ?? []), { role: "user", content: spec.question }].map((m, i) => ({
@@ -100,7 +133,9 @@ function appWith(spec: {
 
   const dbSpec: FakeDbSpec = {
     tables: {
-      chat_sessions: { select: () => ({ data: SESSION, error: null }) },
+      chat_sessions: {
+        select: () => ({ data: { ...SESSION, title: spec.sessionTitle ?? null }, error: null }),
+      },
       agents: { select: () => ({ data: AGENT, error: null }) },
       // The route reads newest-first and reverses, so hand it back reversed.
       messages: { select: () => ({ data: [...rows].reverse(), error: null }) },
@@ -149,9 +184,18 @@ async function ask(app: Hono<AppEnv>) {
   return { status: res.status, body: await res.text() };
 }
 
-/** The messages the model was actually sent, by role. */
+/**
+ * The messages the model was actually sent for the REPLY, by role.
+ *
+ * A turn makes more than one completion now: an untitled session is also named
+ * from its opening message, and that call is not streamed. Selecting on
+ * `stream` rather than taking the first call means these assertions keep
+ * pointing at the answer whichever of the two the mock happened to record
+ * first.
+ */
 function sentMessages(): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
-  return completionCreate.mock.calls[0][0].messages;
+  const reply = completionCreate.mock.calls.find((c) => c[0].stream);
+  return reply![0].messages;
 }
 
 function knowledgeBlock(): string | undefined {
@@ -174,7 +218,7 @@ function citedNames(): string[] {
 beforeEach(() => {
   vi.clearAllMocks();
   embedTexts.mockResolvedValue({ vectors: [[0.1, 0.2]], tokens: 8 });
-  completionCreate.mockResolvedValue(streamOf("Twenty days."));
+  answersWith(streamOf("Twenty days."));
 });
 
 const HANDBOOK: Doc = { id: "d1", name: "handbook.md", content: "Vacation is 20 days." };
@@ -356,7 +400,7 @@ describe("a reply that ran out of room", () => {
   it("says so, ahead of the terminal event", async () => {
     // A reply cut off at `maxTokensFor` stops mid-thought and otherwise looks
     // finished. Nothing on screen said the end was missing.
-    completionCreate.mockResolvedValue(streamOf("A long list that stops at 3.", "length"));
+    answersWith(streamOf("A long list that stops at 3.", "length"));
     const { app } = appWith({ question: "list every public holiday" });
     const { body } = await ask(app);
     expect(body).toContain('data: {"type":"truncated"}');
@@ -393,5 +437,58 @@ describe("the assembled prompt", () => {
     const { app } = appWith({ question: "hello", documents: [HANDBOOK], matches: [] });
     await ask(app);
     expect(sentMessages()[0].content).toContain("handbook.md");
+  });
+});
+
+describe("naming the conversation", () => {
+  /** What the route wrote to chat_sessions.title, if anything. */
+  const writtenTitle = () =>
+    sessionUpdate.mock.calls.map((c) => c[0]).find((row) => "title" in row)?.title;
+
+  it("names a session that has no name yet", async () => {
+    const { app } = appWith({ question: "How many vacation days do I get?" });
+
+    await ask(app);
+
+    expect(writtenTitle()).toBe("Vacation days");
+  });
+
+  it("names it from the message that opened the conversation", async () => {
+    const { app } = appWith({ question: "How many vacation days do I get?" });
+
+    await ask(app);
+
+    const titling = completionCreate.mock.calls.find((c) => !c[0].stream);
+    const sent = titling![0].messages.map((m: { content: string }) => m.content).join("\n");
+    expect(sent).toContain("How many vacation days do I get?");
+  });
+
+  // Renaming on every turn would cost money and move a label out from under
+  // somebody reading it.
+  it("leaves a session that already has a name alone", async () => {
+    const { app } = appWith({
+      question: "And what about sick days?",
+      sessionTitle: "Q3 pricing review",
+    });
+
+    await ask(app);
+
+    expect(writtenTitle()).toBeUndefined();
+    expect(completionCreate.mock.calls.filter((c) => !c[0].stream)).toHaveLength(0);
+  });
+
+  // A name is a convenience riding along with an answer somebody asked for.
+  it("still answers when the naming call fails", async () => {
+    const { app } = appWith({ question: "How many vacation days do I get?" });
+    completionCreate.mockImplementation(async (body: { stream?: boolean }) => {
+      if (!body.stream) throw new Error("the provider is down");
+      return streamOf("Twenty days.");
+    });
+
+    const res = await ask(app);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toContain("Twenty days.");
+    expect(writtenTitle()).toBeUndefined();
   });
 });

--- a/worker/src/routes/chat.ts
+++ b/worker/src/routes/chat.ts
@@ -9,6 +9,7 @@ import { retrieveForAgent } from "../lib/retrieval";
 import { selectHistory } from "../lib/history";
 import { buildSystemPrefix, temperatureFor, maxTokensFor } from "../lib/prompt";
 import { effectiveMode } from "../lib/session-mode";
+import { generateSessionTitle } from "../lib/session-title";
 import { deferred } from "../lib/defer";
 import { guardQuota, recordQuota } from "../lib/entitlements/guard";
 import { embeddingCost } from "../lib/entitlements";
@@ -142,6 +143,22 @@ chat.post("/chat/stream", async (c) => {
   const signal = c.req.raw.signal;
   const service = serviceClient(c.env);
 
+  // Name the conversation from the message that opened it, the way every other
+  // chat product does — an untitled sidebar of "New chat, New chat, New chat"
+  // is a list you cannot navigate.
+  //
+  // Started here, before the reply, so it runs alongside the streaming
+  // completion instead of after it: the reply takes seconds and this takes
+  // under one, so in practice the turn never waits. Deliberately *not*
+  // deferred past the response — the frontend refetches the session list when
+  // the stream closes, and a title written after that lands in a sidebar
+  // nobody is going to reload.
+  //
+  // Only for a session with no title. A named session is one the user or an
+  // earlier turn already settled, and re-titling it every turn would both cost
+  // money and move a label out from under someone reading it.
+  const titling = session.title ? null : generateSessionTitle(c.env, model, lastMessage.content);
+
   const stream = new ReadableStream({
     async start(controller) {
       const encoder = new TextEncoder();
@@ -171,15 +188,47 @@ chat.post("/chat/stream", async (c) => {
       let persisted = false;
       let spendRecorded = false;
 
+      // Collect the title started above and write it, returning what it cost so
+      // the caller can charge it with the rest of the turn. Written with the
+      // service client for the same reason `updated_at` is: the bump has to
+      // work whoever drove the reply, owner or not.
+      //
+      // `.is("title", null)` is the whole safety of it. Between the call
+      // starting and this landing, the user may have renamed the session
+      // themselves — the filter means the generated name loses that race
+      // rather than silently overwriting a name somebody chose.
+      const settleTitle = async (): Promise<number> => {
+        if (!titling) return 0;
+        const { title, tokens } = await titling;
+        if (title) {
+          const { error: titleError } = await service
+            .from("chat_sessions")
+            .update({ title })
+            .eq("id", sessionId)
+            .is("title", null);
+          if (titleError) console.error("failed to write session title", titleError);
+        }
+        return tokens;
+      };
+
       // One counter write per turn, on every way this stream can end — a reply
       // that was cut off still cost what it cost. Guarded because several of
       // those endings overlap (an abort mid-loop also lands in the catch).
+      //
+      // The title is settled from in here rather than from each ending, so the
+      // tokens it spent are in the same write and no ending can forget it. That
+      // includes an abort: the titling call had already been made and paid for
+      // by the time the user hit stop.
       const recordSpend = async () => {
         if (spendRecorded) return;
         spendRecorded = true;
+        const titleTokens = await settleTitle();
         await recordQuota(
           c,
-          embeddingCost(embeddingTokens) + (promptTokens ?? 0) + (completionTokens ?? 0),
+          embeddingCost(embeddingTokens) +
+            (promptTokens ?? 0) +
+            (completionTokens ?? 0) +
+            titleTokens,
         );
       };
 

--- a/worker/src/routes/sessions.test.ts
+++ b/worker/src/routes/sessions.test.ts
@@ -1,0 +1,130 @@
+import { Hono } from "hono";
+import { describe, it, expect } from "vitest";
+import type { AppEnv } from "../types";
+import { fakeDb, type FakeDbSpec, type QueryContext } from "../test-support/fake-db";
+import { sessions } from "./sessions";
+
+const SESSION_ROW = {
+  id: "session-1",
+  agent_id: "agent-1",
+  user_id: "user-1",
+  title: null,
+  visibility: "private",
+  kind: "chat",
+  updated_at: "2026-09-05T00:00:00.000Z",
+};
+
+/**
+ * The route under test with a database that answers a PATCH by echoing the row
+ * back with the update applied — which is what PostgREST does, and what lets a
+ * test read the response instead of only the recorded query.
+ */
+function appWith(spec?: FakeDbSpec) {
+  const fake = fakeDb(
+    spec ?? {
+      tables: {
+        chat_sessions: {
+          update: (ctx: QueryContext) => ({
+            data: { ...SESSION_ROW, ...ctx.values, messages: [{ count: 3 }] },
+            error: null,
+          }),
+        },
+      },
+    },
+  );
+  const app = new Hono<AppEnv>();
+  app.use("/*", async (c, next) => {
+    c.set("user", { id: "user-1" } as never);
+    c.set("db", fake.db as never);
+    await next();
+  });
+  app.route("/", sessions);
+  return { app, fake };
+}
+
+const patch = (app: Hono<AppEnv>, body: unknown) =>
+  app.request("/sessions/session-1", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+describe("PATCH /sessions/:id", () => {
+  it("renames a session", async () => {
+    const { app, fake } = appWith();
+
+    const res = await patch(app, { title: "Q3 pricing review" });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ title: "Q3 pricing review" });
+    expect(fake.callsTo("chat_sessions")[0].values).toEqual({ title: "Q3 pricing review" });
+  });
+
+  it("trims the name it was given", async () => {
+    const { app, fake } = appWith();
+
+    await patch(app, { title: "   Q3 pricing review \n" });
+
+    expect(fake.callsTo("chat_sessions")[0].values).toEqual({ title: "Q3 pricing review" });
+  });
+
+  // Sharing a session is still the other thing this route does, and renaming
+  // must not have quietly become a required field on the way in.
+  it("still changes visibility on its own", async () => {
+    const { app, fake } = appWith();
+
+    const res = await patch(app, { visibility: "shared" });
+
+    expect(res.status).toBe(200);
+    expect(fake.callsTo("chat_sessions")[0].values).toEqual({ visibility: "shared" });
+  });
+
+  // A PATCH naming only one of the two must not blank the other. Sending both
+  // columns every time would clear the title of any session someone shared.
+  it("leaves the title alone when only visibility is sent", async () => {
+    const { app, fake } = appWith();
+
+    await patch(app, { visibility: "shared" });
+
+    expect(fake.callsTo("chat_sessions")[0].values).not.toHaveProperty("title");
+  });
+
+  it("refuses a blank name rather than writing one", async () => {
+    const { app, fake } = appWith();
+
+    const res = await patch(app, { title: "   " });
+
+    expect(res.status).toBe(400);
+    expect(fake.callsTo("chat_sessions")).toHaveLength(0);
+  });
+
+  it("refuses a request that asks for nothing", async () => {
+    const { app, fake } = appWith();
+
+    const res = await patch(app, {});
+
+    expect(res.status).toBe(400);
+    expect(fake.callsTo("chat_sessions")).toHaveLength(0);
+  });
+
+  it("refuses a name longer than the column is meant to hold", async () => {
+    const { app } = appWith();
+
+    const res = await patch(app, { title: "x".repeat(500) });
+
+    expect(res.status).toBe(400);
+  });
+
+  // RLS restricts the update to the owner, so a non-owner's PATCH matches no
+  // row and comes back empty rather than as an error. That is a 404, not a 200
+  // reporting a change that never happened.
+  it("reports not found when the database matched no row", async () => {
+    const { app } = appWith({
+      tables: { chat_sessions: { update: () => ({ data: null, error: null }) } },
+    });
+
+    const res = await patch(app, { title: "Q3 pricing review" });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/worker/src/routes/sessions.ts
+++ b/worker/src/routes/sessions.ts
@@ -12,9 +12,23 @@ const createSessionSchema = z.object({
   kind: z.enum(["chat", "brainstorm"]).optional(),
 });
 
-const updateSessionSchema = z.object({
-  visibility: z.enum(["private", "shared"]),
-});
+// How long a name a person may type. Deliberately wider than the ~60 characters
+// a generated title aims for: that cap exists so the model writes a label
+// rather than a sentence, and it has no business limiting someone who knows
+// what they want their own conversation called. The sidebar truncates either
+// way.
+const TITLE_INPUT_MAX_CHARS = 120;
+
+// Both fields optional, at least one required. A PATCH that named both columns
+// unconditionally would blank the title of every session somebody shared.
+const updateSessionSchema = z
+  .object({
+    visibility: z.enum(["private", "shared"]).optional(),
+    title: z.string().trim().min(1).max(TITLE_INPUT_MAX_CHARS).optional(),
+  })
+  .refine((v) => v.visibility !== undefined || v.title !== undefined, {
+    message: "nothing to update",
+  });
 
 // GET /sessions
 sessions.get("/sessions", async (c) => {
@@ -93,10 +107,17 @@ sessions.patch("/sessions/:id", async (c) => {
     return c.json({ error: parsed.error.flatten() }, 400);
   }
 
-  // RLS restricts UPDATE to the session owner.
+  const { visibility, title } = parsed.data;
+
+  // RLS restricts UPDATE to the session owner — so on a shared session, only
+  // the person who started it can rename it, the same rule that already
+  // governs sharing it in the first place.
   const { data, error } = await db
     .from("chat_sessions")
-    .update({ visibility: parsed.data.visibility })
+    .update({
+      ...(visibility !== undefined ? { visibility } : {}),
+      ...(title !== undefined ? { title } : {}),
+    })
     .eq("id", id)
     .select("*, messages(count)")
     .maybeSingle();


### PR DESCRIPTION
The sidebar said "New chat" for every conversation anyone had ever started, so the only way to find one was to open it. `chat_sessions.title` has been there since 0001 and nothing has ever written to it.

## Naming

The first user turn now gets titled, from the message that opened the conversation.

- Goes through the provider seam (`lib/completion.ts`), not an SDK — a workspace on a Claude model gets its titles from Claude and does not need an OpenAI key to have a named sidebar. `reasoningEffort: "minimal"` for the reason the persona drafter sets it: naming a conversation is shaping, not thinking.
- Runs **alongside** the streaming reply rather than after it, so the turn does not wait on it, and is settled before the `done` event — that is what the frontend refetches the session list on, so a title written any later would land in a sidebar nobody is going to reload.
- Its tokens go into the same allowance write as the turn, on every ending including an abort.
- Best-effort throughout: a refusal, an outage, a reply that isn't JSON, and the session keeps the name it had.
- `.is("title", null)` on the write means a user who renamed the session mid-stream wins that race rather than having their name overwritten.

Cost is one extra completion per new conversation — roughly 60 input and under 40 output tokens.

## Renaming

`PATCH /sessions/:id` took only `visibility` and now takes either field, writing only what it was sent. Naming both columns unconditionally would have blanked the title of every session somebody shared.

RLS already restricts the update to the owner, so on a shared thread only the person who started it can rename it — the rule sharing it already followed. **No migration.**

The sidebar row became a component on the way. It was drawn twice, once for shared threads and once for private ones, and rename is a small state machine that would have been written out twice and drifted apart the first time either copy was touched.

## Tests it changed

`chat.test.ts` needed two changes to keep meaning what it said. A turn now makes two completions, so `sentMessages` selects the streamed one instead of the first one recorded, and the service-client stand-in grew the `.is()` the title write ends on. Route-level titling tests were added on top of it.

Verified locally: worker 978 tests, frontend 520 tests, `tsc` clean both sides, `eslint` clean, `check-rls` passing. `test:rls` not run — no policy or migration is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)