### PR TITLE
An Anthropic key on its own carries nothing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,11 @@ worker/wrangler.cron.toml
 
 # Internal design docs never ship to the public repository
 docs/superpowers/
+
+# npm lockfiles. This project installs with bun — `bun.lock` and
+# `worker/bun.lock` are the tracked ones, and CI runs
+# `bun install --frozen-lockfile` against them. Anyone who reaches for
+# `npm install` out of habit leaves a second lockfile describing the same tree
+# by different rules, and `git add -A` will commit it without comment. The tool
+# is not wrong; the artifact is just not ours to keep.
+package-lock.json

--- a/docs/team.md
+++ b/docs/team.md
@@ -292,6 +292,14 @@ instead, still per member, so one person spending through theirs first shortens
 nobody else's month. Once set, the key is stored encrypted and is never shown
 again — only a short hint, like `sk-…4f2a`, in its place.
 
+**The OpenAI one is the key that carries it.** Embeddings, dictation and the
+default model all run on OpenAI, so a workspace that sets only the Anthropic key
+has not set up anything — its people keep running out, exactly as before. The
+Anthropic field is optional in the sense that Claude models need it and nothing
+else does, not in the sense that either one will do. Setting it alone is the one
+way to leave this half-done, so the Usage screen says so on the spot rather than
+letting somebody find out from a wall that never lifts.
+
 **The field is there before anybody needs it, and that is deliberate.** The
 allowance is per member, so the person who hits the wall is almost never the
 person who can do anything about it: they tell an admin, and that admin still

--- a/src/components/usage-section.test.tsx
+++ b/src/components/usage-section.test.tsx
@@ -116,6 +116,21 @@ describe("UsageSection", () => {
     expect(screen.getByText(/workspace's own key carries on from here/)).toBeInTheDocument();
   });
 
+  it("still says paused when the only key set is an Anthropic one", () => {
+    // `keysForUser` refuses to take over without an OpenAI key — embeddings,
+    // dictation and the default model all need it, so an Anthropic key alone
+    // funds nothing and the 402 keeps coming. Saying "carries on from here"
+    // here would be the screen telling somebody their wall is gone while they
+    // watch it refuse them.
+    renderWith(usage({ used: 200_000, limit: 200_000, resetsAt: "2026-09-01T00:00:00.000Z" }), {
+      openai: null,
+      anthropic: "sk-ant-…9c1d",
+    });
+
+    expect(screen.getByText(/new replies are paused/)).toBeInTheDocument();
+    expect(screen.queryByText(/carries on from here/)).not.toBeInTheDocument();
+  });
+
   it("shows no allowance at all on an install that does not meter", () => {
     // limit: null is how the API says "self-hosted". The whole card, including
     // the wall itself, would be nonsense to somebody already there.

--- a/src/components/usage-section.tsx
+++ b/src/components/usage-section.tsx
@@ -64,7 +64,14 @@ export function UsageSection() {
     queryFn: () => api.providerKeys.get(),
     enabled: quota !== null,
   });
-  const hasWorkspaceKey = Boolean(keys?.openai || keys?.anthropic);
+  // The OpenAI half alone, not `openai || anthropic`. `keysForUser` refuses to
+  // take over without it — embeddings, dictation and the default model all need
+  // one — so a workspace that set only the optional Anthropic key is still
+  // being refused, and saying "carries on from here" would be this screen
+  // telling somebody their wall is gone while they watch it turn them away.
+  // `workspace-provider-keys.tsx` is where that workspace is told what is
+  // missing; here it is enough not to claim otherwise.
+  const hasWorkspaceKey = Boolean(keys?.openai);
 
   // Share of measured input that OpenAI served from its prompt cache. The
   // denominator is measuredPromptTokens, not promptTokens: replies stored

--- a/src/components/workspace-provider-keys.test.tsx
+++ b/src/components/workspace-provider-keys.test.tsx
@@ -125,6 +125,32 @@ describe("WorkspaceProviderKeys", () => {
     expect(screen.getByRole("button", { name: /remove/i })).toBeInTheDocument();
   });
 
+  it("says an Anthropic key on its own carries nothing", async () => {
+    // The state somebody lands in by setting the optional key and stopping.
+    // `keysForUser` refuses to take over without an OpenAI key, so the wall
+    // keeps refusing them — and until this said so, the only feedback was a
+    // saved hint and a screen that still read "paused", with nothing anywhere
+    // connecting the two.
+    renderKeys({ role: "admin", hints: { openai: null, anthropic: "sk-ant-…9c1d" } });
+
+    expect(await screen.findByText(/Anthropic key on its own/i)).toBeInTheDocument();
+  });
+
+  it("says nothing of the sort once the OpenAI key is there too", async () => {
+    renderKeys({ role: "admin", hints: { openai: "sk-…4f2a", anthropic: "sk-ant-…9c1d" } });
+
+    expect(await screen.findByText("sk-…4f2a")).toBeInTheDocument();
+    expect(screen.queryByText(/Anthropic key on its own/i)).not.toBeInTheDocument();
+  });
+
+  it("says nothing of the sort when no key is set at all", async () => {
+    // The empty state is not a mistake — it is where every workspace starts.
+    renderKeys({ role: "admin", hints: { openai: null, anthropic: null } });
+
+    expect(await screen.findByLabelText(/OpenAI key/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Anthropic key on its own/i)).not.toBeInTheDocument();
+  });
+
   it("does not show the key input before the role is known", async () => {
     // `me` never resolves — the window every load passes through. `isAdmin` is
     // `false` here on purpose, unlike `settings.tsx`'s `me ? … : true`: that

--- a/src/components/workspace-provider-keys.tsx
+++ b/src/components/workspace-provider-keys.tsx
@@ -70,6 +70,26 @@ export function WorkspaceProviderKeys() {
         placeholder="sk-ant-…"
         hint={keyHint(keys.anthropic)}
       />
+
+      {/* The one wrong state this form can be left in, and the only one worth
+          saying out loud. "Optional" is true of the Anthropic field and false
+          of the pair: `keysForUser` refuses to take over without an OpenAI key,
+          because embeddings, dictation and the default model all need one. So
+          an admin who fills in the second field and stops has done something
+          that looks finished, saves cleanly, shows a hint back — and changes
+          nothing. Without this line their only other feedback is a usage screen
+          that still says paused, with nothing anywhere connecting the two.
+
+          Not `text-destructive`: nothing failed, and DESIGN.md keeps that token
+          for engine-level failures. This is a step missing, which is what the
+          amber accent is for. */}
+      {!keys.openai && keys.anthropic && (
+        <p className="text-xs text-accent-orange">
+          An Anthropic key on its own carries nothing. Covan needs the OpenAI key to take over —
+          embeddings, dictation and the default model all run on it — so until that one is set,
+          people here will keep running out.
+        </p>
+      )}
     </div>
   );
 }

--- a/worker/src/lib/emails/support.ts
+++ b/worker/src/lib/emails/support.ts
@@ -13,6 +13,21 @@ import { paragraphs } from "./prose";
  * Plainer than the rest of the set. Nobody is being welcomed or reassured — this
  * is a message arriving on a desk, and what it needs is to be read quickly.
  */
+
+/**
+ * What the `Own key` line says, per state.
+ *
+ * The middle line carries the remedy rather than only the fact, because whoever
+ * reads this inbox should not have to remember that takeover needs an OpenAI
+ * key. It is the one state where the sender has already tried to fix their own
+ * problem and is being refused anyway.
+ */
+const OWN_KEY: Record<"openai" | "anthropic-only" | "none", string> = {
+  openai: "yes",
+  "anthropic-only": "Anthropic only — does not take over; they need an OpenAI key",
+  none: "no",
+};
+
 export function quotaSupportEmail(args: {
   to: string;
   from: { email: string; name: string | null };
@@ -33,7 +48,18 @@ export function quotaSupportEmail(args: {
    * both figures or rejects with neither, so there is no half of it to render.
    */
   quota: { used: number; limit: number | null } | "unknown";
-  hasWorkspaceKey: boolean;
+  /**
+   * Which of three states the workspace's keys are in, rather than whether a
+   * row exists.
+   *
+   * The middle one is why this is not a boolean. `keysForUser` refuses to take
+   * over without an OpenAI key — embeddings, dictation and the default model
+   * all need it — so somebody who set the optional Anthropic key and stopped
+   * believes they are funding their own tokens while the wall keeps refusing
+   * them. That is the person most likely to be writing this message, and
+   * "Own key: yes" would send whoever reads it looking for a different problem.
+   */
+  workspaceKey: "openai" | "anthropic-only" | "none";
   appUrl: string;
   message: string;
 }) {
@@ -49,7 +75,7 @@ export function quotaSupportEmail(args: {
     `Workspace:  ${args.workspace.name} (${args.workspace.id})`,
     `Members:    ${args.workspace.memberCount}`,
     `Allowance:  ${allowance}`,
-    `Own key:    ${args.hasWorkspaceKey ? "yes" : "no"}`,
+    `Own key:    ${OWN_KEY[args.workspaceKey]}`,
     `Deployment: ${args.appUrl}`,
   ];
 

--- a/worker/src/routes/support.test.ts
+++ b/worker/src/routes/support.test.ts
@@ -52,13 +52,18 @@ function appWith(opts: {
   supportEmail?: string;
   allowedOrigin?: string;
   rateLimit?: RateVerdict;
+  /** What `readKeyHints` answers. Defaults to a workspace that has set none. */
+  hints?: { openai: string | null; anthropic: string | null };
 }) {
   const user = opts.user ?? USER;
   const workspace = opts.workspace ?? WORKSPACE;
   const quota = opts.quota ?? { used: 10, limit: 1000 };
 
   canSendEmailMock.mockReturnValue(true);
-  readKeyHints.mockResolvedValue({ openai: null, anthropic: null, updatedAt: null });
+  readKeyHints.mockResolvedValue({
+    ...(opts.hints ?? { openai: null, anthropic: null }),
+    updatedAt: null,
+  });
   rateCheck.mockResolvedValue(opts.rateLimit ?? { allowed: true });
   // `sendEmail` now returns `Promise<Response>` and the route checks `.ok`
   // (it does not throw on a non-2xx — see `lib/email.ts`), so a bare `vi.fn()`
@@ -267,6 +272,41 @@ describe("POST /support/quota", () => {
     const res = await post(app, env, { message: "hello" });
 
     expect(res.status).toBe(502);
+  });
+
+  it("tells us apart the three states a workspace's keys can be in", async () => {
+    // The middle one is the reason this is three states rather than a boolean.
+    // Somebody who set the optional key and stopped believes they have paid for
+    // their own tokens; `keysForUser` refuses to take over without an OpenAI
+    // key, so they are still hitting the wall and do not know why — and they
+    // are exactly the person most likely to write to us. "Own key: yes" would
+    // have sent us looking for a different problem.
+    const cases = [
+      { hints: { openai: "sk-…4f2a", anthropic: null }, expect: /Own key:\s+yes/ },
+      { hints: { openai: null, anthropic: "sk-ant-…9c1d" }, expect: /Own key:\s+Anthropic only/ },
+      { hints: { openai: null, anthropic: null }, expect: /Own key:\s+no/ },
+    ];
+
+    for (const c of cases) {
+      const send = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+      const { app, env } = appWith({ send, hints: c.hints });
+
+      await post(app, env, { message: "hello" });
+
+      expect(send.mock.calls[0][0].text).toMatch(c.expect);
+    }
+  });
+
+  it("says an Anthropic-only key does not take over, not merely that one exists", async () => {
+    const send = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+    const { app, env } = appWith({ send, hints: { openai: null, anthropic: "sk-ant-…9c1d" } });
+
+    await post(app, env, { message: "hello" });
+
+    // The line has to carry what to do about it, not just what is true — the
+    // person reading this inbox should not have to remember that takeover
+    // needs OpenAI.
+    expect(send.mock.calls[0][0].text).toMatch(/does not take over/i);
   });
 
   it("is rate limited", async () => {

--- a/worker/src/routes/support.ts
+++ b/worker/src/routes/support.ts
@@ -151,7 +151,11 @@ support.post("/support/quota", async (c) => {
       memberCount: membersError ? "unknown" : (members ?? []).length,
     },
     quota: quota ? { used: quota.used, limit: quota.limit } : "unknown",
-    hasWorkspaceKey: Boolean(hints.openai || hints.anthropic),
+    // Not `openai || anthropic`. An Anthropic key alone does not carry a
+    // workspace past its allowance — see `keysForUser` — so reporting it as a
+    // key would tell the reader this person is funding themselves when they are
+    // still hitting the wall.
+    workspaceKey: hints.openai ? "openai" : hints.anthropic ? "anthropic-only" : "none",
     appUrl: appUrlOf(c),
     message: parsed.data.message,
   });


### PR DESCRIPTION
## What problem does this solve?

`keysForUser` refuses to take over without an OpenAI key — embeddings, dictation
and the default model all need one — so a workspace that sets only the optional
Anthropic key is still hitting the wall. Three places did not know that, and
#116 shipped all three.

**The usage screen said the wall was gone.** `hasWorkspaceKey` tested
`openai || anthropic`, so an Anthropic-only workspace read "the workspace's own
key carries on from here" while every reply was still being refused.

**The support mail said `Own key: yes`**, for the same reason, and that is worse
than it sounds. Somebody in this state has already tried to fix their own problem
and is being refused anyway — they are the likeliest person to be writing to us,
and that line would send whoever reads the inbox looking for a different problem.
It is now three states rather than a boolean, and the middle one carries the
remedy rather than only the fact:

```
Own key:    Anthropic only — does not take over; they need an OpenAI key
```

**And nothing told the admin.** Filling in the second field looks finished, saves
cleanly and shows a hint back. The only other feedback was a usage screen still
reading "paused", with nothing anywhere connecting the two. The key form now says
what is missing — in amber rather than destructive, because nothing failed, a
step is absent.

`docs/team.md` gains the same distinction: *optional* means Claude models need it
and nothing else does, not that either key will do.

### Also here

`.gitignore` gains `package-lock.json`. This project installs with bun, and an
`npm install` run out of habit leaves a second lockfile describing the same tree
by different rules — which `git add -A` will commit without comment. It happened
while writing this branch.

## Checks

- [x] The commands above pass

Root 75 files / 540 tests (was 536), worker 88 files / 1058 tests (was 1056),
both typechecks clean, lint 0 errors and the same 4 pre-existing warnings in
files this branch never touched.

Four of the six new tests are the ones that were missing: the screen still says
paused on an Anthropic-only workspace, the admin is told why, and the mail
distinguishes all three states. Each was written first and confirmed red.

## If you touched the database

Not touched.

## If you touched `serviceClient()` or the service-role key

Not touched.

## If you touched UI

- [x] It follows [`DESIGN.md`](../DESIGN.md), which is the binding visual
      contract, not a suggestion

`text-accent-orange` rather than `text-destructive`: DESIGN.md keeps the
destructive token for engine-level failures, and this is a missing step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
