### PR TITLE
A routine that remembers what the agent read, and says what it left out

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,9 +211,10 @@ fallback — falls back to a persona-only answer rather than failing the turn.
 
 ## Routines
 
-A routine is: a source (an RSS feed, a web page, or nothing), an instruction, a
-cron expression with a timezone, and a delivery channel (a Slack webhook or an
-email address). The engine wakes up, asks the database what is due, and runs it.
+A routine is: a source (an RSS feed, a web page, a connection, or nothing), an
+instruction, a cron expression with a timezone, and a delivery channel (a Slack
+webhook or an email address). The engine wakes up, asks the database what is
+due, and runs it.
 
 ### Claiming
 
@@ -251,13 +252,14 @@ one rather than run until the invocation is killed.
 
 ### Running one
 
-`lib/routines/executor.ts`, in order: check workspace membership → fetch the
-source through the SSRF guard → diff the fetched items against the routine's
-stored cursor → reserve the new item keys in `routine_deliveries` → summarise
-with the model → deliver → record a `routine_runs` row and advance
+`lib/routines/executor.ts`, in order: check workspace membership → read the
+source (through the SSRF guard for a feed or a page; through `documents` for a
+connection) → diff what it found against the routine's stored cursor → reserve
+the new item keys in `routine_deliveries` → retrieve the agent's own documents →
+summarise with the model → deliver → record a `routine_runs` row and advance
 `next_run_at`.
 
-Two details worth knowing:
+Four details worth knowing:
 
 - **Delivery keys are reserved before the send, not after.** That is what makes
   a retry, an overlapping "run now", or a duplicated tick harmless: whoever gets
@@ -269,6 +271,20 @@ Two details worth knowing:
   so a routine cannot be pointed back at Covan itself. It is explicit in its
   own header comment about what it does not do: it cannot resolve DNS, so a
   hostname that resolves to a private address still passes.
+- **A `connection` source reads the database, not the provider**
+  (`lib/routines/connection-source.ts`). The reconciler has already fetched,
+  versioned and removed; the routine reports the documents it added or changed,
+  keyed by document id _and_ `external_version` so an edited page counts as new.
+  That keeps one substrate — the argument `0043` makes for connections in the
+  first place — and costs the routine no provider call, no second token
+  decrypt, and nothing from the tick's subrequest budget. The connection is
+  looked up scoped to the routine's own workspace, because the executor's
+  service-role client is not filtered by RLS.
+- **Retrieval runs for a routine too**, through the same `retrieveForAgent` that
+  chat and Slack use. The query is the instruction plus what this run found,
+  because a routine has no question; the block rides in its own system message,
+  as it does in `routes/chat.ts`. It happens after the run knows it has
+  something to send, so a tick that will deliver nothing does not pay to embed.
 
 Failures back off, capped at six hours past the natural next run, and a routine
 pauses itself after 5 consecutive failures — or 20 if they are transient (429s

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -224,10 +224,10 @@ whoever administers the database.
 ## Routine
 
 A routine is a standing order attached to an agent: a source (an RSS feed, a web
-page, or nothing at all), an instruction in plain language, a cron expression
-with a timezone, and a delivery channel — a Slack webhook or an email address.
-The engine wakes up, asks the database which routines are due, runs them and
-delivers the result.
+page, a connected Notion or Drive source, or nothing at all), an instruction in
+plain language, a cron expression with a timezone, and a delivery channel — a
+Slack webhook or an email address. The engine wakes up, asks the database which
+routines are due, runs them and delivers the result.
 
 A routine belongs to a workspace and an agent, but it is owned by the person who
 made it, and it follows the same visibility rule as a session: private by

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -48,6 +48,12 @@ over a few runs rather than in one.
 Runs are recorded. `skipped` means it looked and nothing had changed — it is the
 healthy state, not a failure.
 
+That interval is also the ceiling on how fresh anything downstream can be. A
+[routine](routines.md#watching-a-connected-source) can watch a connection and
+report what it added or changed, and because it reads what the sync has already
+imported rather than going to the provider itself, running it more often than
+the connection syncs will not find changes any sooner.
+
 ### When it stops
 
 A connection pauses itself and says why on the row:

--- a/docs/routines.md
+++ b/docs/routines.md
@@ -20,6 +20,11 @@ saved at that point: the second step is the same definition as editable fields,
 and you confirm it before anything is written. "Set it up myself" skips the
 model entirely.
 
+The draft never proposes a connected source, and cannot: it would have to name a
+connection by id, and the model has no way to know one. Pick that kind on the
+second step, where the connections your workspace has are a list you choose
+from.
+
 The draft is validated against the same guards the engine runs on — the cron
 parser and the URL guard — so a routine the engine could never execute is
 refused while you are still looking at it. If the model cannot read the request
@@ -33,13 +38,14 @@ routine behave differently today?" is not a question anyone has to answer.
 
 ## What it can read
 
-Three source kinds, and the difference between them is what counts as new.
+Four source kinds, and the difference between them is what counts as new.
 
-| Source           | What a run does                                                      |
-| ---------------- | -------------------------------------------------------------------- |
-| RSS / Atom feed  | Fetches and parses it, and reports the entries it has not seen       |
-| Web page         | Fetches it and hashes the body, and reports only when the hash moved |
-| Scheduled prompt | Fetches nothing — it runs the instruction on the schedule            |
+| Source           | What a run does                                                             |
+| ---------------- | --------------------------------------------------------------------------- |
+| RSS / Atom feed  | Fetches and parses it, and reports the entries it has not seen              |
+| Web page         | Fetches it and hashes the body, and reports only when the hash moved        |
+| Connected source | Fetches nothing — it reports the documents a connection has synced since    |
+| Scheduled prompt | Fetches nothing — it runs the instruction on the schedule                   |
 
 For the two that fetch, the request carries `If-None-Match` when a previous run
 stored an ETag. A `304` ends the run immediately: no parse, no model call, and a
@@ -66,9 +72,56 @@ between two runs reports ten, and the other thirty are never delivered rather
 than arriving piecemeal later. Poll a busy source often enough that a run rarely
 finds more than ten.
 
+When that happens the run says so, in both places you might look. The delivered
+message ends with a line naming how many entries were left out, and the run's
+row in the history reads "10 new items · 30 skipped". Neither is decoration: a
+message reporting ten of forty looks exactly like a message reporting all ten
+there were, and the number is not recoverable afterwards — by the time anyone
+asks, the seen window has moved past them.
+
 Nothing from the source is stored. The cursor holds fingerprints — seen keys, an
 ETag, a content hash — so a feed your workspace watches is never mirrored into
-the database.
+the database. A connected source is the exception that proves it: those
+documents are in the database already, put there by the sync, and the routine
+reads them rather than copying anything.
+
+### Watching a connected source
+
+A [connection](integrations.md) already re-reads a Notion workspace or a Drive
+folder on a schedule and files what it finds in a bundle. A routine of this kind
+watches that bundle and reports the documents added or changed since its last
+run — so "tell me what changed in the handbook" is a routine, not a thing you
+have to remember to check.
+
+It fetches nothing itself. The reconciler has already done the reading, the
+version comparison and the removals, and a routine that went to Notion directly
+would be a second place deciding what "changed" means, with its own answer to
+get subtly differently wrong. So this reads `documents`, and identity is the
+document _and its version_: a page edited at the source arrives under a key the
+cursor has not seen and is reported again, while a page nobody has touched is
+not.
+
+**The routine cannot see a change sooner than the sync does.** A connection
+syncs every `sync_interval_minutes` — six hours by default — so an hourly
+routine on a six-hourly connection is an hourly routine that finds something
+roughly every six hours. The create dialog says this against the connection you
+picked, in its own interval rather than as a general claim about six hours.
+
+Two more things follow from reading the bundle rather than the provider. A
+document the sync withdrew is not reported, because it has already stopped
+grounding answers everywhere else and announcing it as new here would contradict
+that — which also means a routine reports additions and edits but never
+removals. And a run reads at most 200 documents, newest sync first; a connection
+whose sync changes more than that between two routine runs loses the oldest of
+them, reported the same way as a feed's overflow.
+
+The source is picked from the connections your workspace already has, and the
+setup dialog offers this kind only when there is at least one. A routine may
+only name a connection in its own workspace, enforced by the insert and update
+policies on the table rather than by the API — the scheduled executor holds a
+service-role client, so without that guard a crafted write could have pointed a
+routine here at another workspace's Notion and had the engine mail its contents
+out.
 
 ### What the URL guard refuses
 
@@ -94,6 +147,28 @@ persona and its own model, with one line added saying it is running a scheduled
 routine for the team — a routine is the same colleague, reporting rather than
 answering. Your instruction is the user message, with the new entries or the
 watched page's text beneath it.
+
+The agent also gets what it knows. Before the call, the run retrieves against
+the agent's documents exactly as a chat turn does, and the excerpts ride in
+their own system message ahead of your instruction. Without that the claim above
+was only half true: the same agent could quote the handbook when somebody asked
+it a question and had forgotten it by the time it wrote the Monday digest, so a
+routine watching a competitor could report what happened and never what it meant
+for this company.
+
+A routine has no question, which is what makes the query different from a chat
+turn's. It is built from your instruction _and_ what this particular run found —
+the entry titles, or the first 500 characters of a watched page. The instruction
+alone would return the same passages every run whatever came in; the arrivals
+alone would lose the reason the routine exists.
+
+Retrieval happens after the run has established it has something to report, so
+a tick that will send nothing does not pay to embed a query — which on a healthy
+feed is most ticks. It is best-effort: an agent with no documents, a retrieval
+that finds nothing above the similarity floor and a retrieval that fails all
+produce the same thing, which is the prompt as it was before this existed. The
+embedding tokens are charged to the routine's owner with the completion's, in
+one write.
 
 Two truncations apply on the way in: a watched page contributes its first 20,000
 characters, and each feed entry contributes 1,000 characters of its own summary

--- a/src/components/routines/create-routine-dialog.tsx
+++ b/src/components/routines/create-routine-dialog.tsx
@@ -16,9 +16,28 @@ import {
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api-client";
 import { useDeliveryChannels, useCreateRoutine } from "@/hooks/use-routines";
+import { useConnections } from "@/hooks/use-connections";
 import { SchedulePicker, scheduleError } from "@/components/routines/schedule-picker";
+import type { RoutineSourceKind } from "@/lib/routines-api";
 
-type SourceKind = "rss" | "web" | "none";
+/**
+ * Says what a connection routine can and cannot see, in the units the person
+ * setting the schedule is already thinking in.
+ *
+ * Written from the connection's own interval rather than as a fixed sentence
+ * about "six hours", because the default is only a default and somebody who has
+ * turned theirs down to fifteen minutes should not be told otherwise.
+ */
+function syncCaveat(intervalMinutes: number | undefined): string {
+  if (intervalMinutes === undefined) {
+    return "A routine reports what the connection has already synced, so it sees a change no sooner than the next sync does.";
+  }
+  const every =
+    intervalMinutes % 60 === 0
+      ? `${intervalMinutes / 60} ${intervalMinutes === 60 ? "hour" : "hours"}`
+      : `${intervalMinutes} minutes`;
+  return `This connection syncs every ${every}, and the routine reports what the sync has already imported — so running it more often than that will not find changes any sooner.`;
+}
 
 const browserTimezone = () => {
   try {
@@ -31,6 +50,12 @@ const browserTimezone = () => {
 export function CreateRoutineDialog({ agentId }: { agentId: string }) {
   const { data: channels = [] } = useDeliveryChannels();
   const createRoutine = useCreateRoutine();
+  // A connection that has never finished setting itself up has no documents to
+  // report, so offering it here would create a routine that can only ever skip.
+  // Paused ones are still offered: a pause is usually temporary and the routine
+  // outlives it.
+  const { data: connectionData } = useConnections();
+  const connections = (connectionData?.connections ?? []).filter((c) => !c.needsFolder);
 
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState<1 | 2>(1);
@@ -38,8 +63,9 @@ export function CreateRoutineDialog({ agentId }: { agentId: string }) {
   const [drafting, setDrafting] = useState(false);
 
   const [name, setName] = useState("");
-  const [sourceKind, setSourceKind] = useState<SourceKind>("rss");
+  const [sourceKind, setSourceKind] = useState<RoutineSourceKind>("rss");
   const [sourceUrl, setSourceUrl] = useState("");
+  const [connectionId, setConnectionId] = useState("");
   const [instruction, setInstruction] = useState("");
   const [scheduleCron, setScheduleCron] = useState("0 * * * *");
   const [timezone, setTimezone] = useState(browserTimezone());
@@ -55,6 +81,7 @@ export function CreateRoutineDialog({ agentId }: { agentId: string }) {
     setName("");
     setSourceKind("rss");
     setSourceUrl("");
+    setConnectionId("");
     setInstruction("");
     setScheduleCron("0 * * * *");
     setTimezone(browserTimezone());
@@ -105,7 +132,8 @@ export function CreateRoutineDialog({ agentId }: { agentId: string }) {
         agentId,
         name: name.trim(),
         sourceKind,
-        sourceUrl: sourceKind === "none" ? null : sourceUrl.trim(),
+        sourceUrl: sourceKind === "rss" || sourceKind === "web" ? sourceUrl.trim() : null,
+        connectionId: sourceKind === "connection" ? connectionId : null,
         instruction: instruction.trim(),
         deliveryChannelId: channelId,
         scheduleCron: scheduleCron.trim(),
@@ -143,7 +171,8 @@ export function CreateRoutineDialog({ agentId }: { agentId: string }) {
     // "the user cleared the interval and has not typed the new one yet".
     scheduleCron.trim() !== "" &&
     scheduleError(scheduleCron) === null &&
-    (sourceKind === "none" || sourceUrl.trim() !== "");
+    (sourceKind === "none" ||
+      (sourceKind === "connection" ? connectionId !== "" : sourceUrl.trim() !== ""));
 
   return (
     <>
@@ -183,19 +212,29 @@ export function CreateRoutineDialog({ agentId }: { agentId: string }) {
 
               <div className="space-y-2">
                 <Label htmlFor="routine-source">Source</Label>
-                <Select value={sourceKind} onValueChange={(v) => setSourceKind(v as SourceKind)}>
+                <Select
+                  value={sourceKind}
+                  onValueChange={(v) => setSourceKind(v as RoutineSourceKind)}
+                >
                   <SelectTrigger id="routine-source">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="rss">RSS / Atom feed</SelectItem>
                     <SelectItem value="web">Web page</SelectItem>
+                    {/* Offered only when there is something to point at. An
+                        option that opens onto an empty list reads as a broken
+                        feature rather than as one nobody has set up yet — the
+                        Integrations page is where a connection is made. */}
+                    {connections.length > 0 && (
+                      <SelectItem value="connection">A connected source</SelectItem>
+                    )}
                     <SelectItem value="none">Scheduled prompt (no source)</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
 
-              {sourceKind !== "none" && (
+              {(sourceKind === "rss" || sourceKind === "web") && (
                 <div className="space-y-2">
                   <Label htmlFor="routine-url">URL</Label>
                   <Input
@@ -207,6 +246,37 @@ export function CreateRoutineDialog({ agentId }: { agentId: string }) {
                   {fieldError?.field === "url" && (
                     <p className="text-xs text-destructive">{fieldError.message}</p>
                   )}
+                </div>
+              )}
+
+              {sourceKind === "connection" && (
+                <div className="space-y-2">
+                  <Label htmlFor="routine-connection">Connected source</Label>
+                  <Select value={connectionId} onValueChange={setConnectionId}>
+                    <SelectTrigger id="routine-connection">
+                      <SelectValue placeholder="Pick a connection" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {connections.map((c) => (
+                        <SelectItem key={c.id} value={c.id}>
+                          {c.accountLabel}
+                          {c.folderName ? ` · ${c.folderName}` : ""}
+                          {c.bundleName ? ` → ${c.bundleName}` : ""}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {/* The one thing about this kind that will otherwise be
+                      discovered as a bug. The routine reports what the sync has
+                      already imported, so its own schedule cannot make it see a
+                      change sooner than the connection does — an hourly routine
+                      on a six-hourly connection is an hourly routine that finds
+                      something roughly every six hours. */}
+                  <p className="text-xs text-muted-foreground">
+                    {syncCaveat(
+                      connections.find((c) => c.id === connectionId)?.syncIntervalMinutes,
+                    )}
+                  </p>
                 </div>
               )}
 

--- a/src/components/routines/edit-routine-dialog.test.tsx
+++ b/src/components/routines/edit-routine-dialog.test.tsx
@@ -12,6 +12,7 @@ const routine: Routine = {
   visibility: "private",
   sourceKind: "rss",
   sourceUrl: "https://example.com/feed.xml",
+  connectionId: null,
   instruction: "Summarise anything about pricing.",
   deliveryChannelId: "c1",
   scheduleCron: "0 */6 * * *",

--- a/src/components/routines/edit-routine-dialog.tsx
+++ b/src/components/routines/edit-routine-dialog.tsx
@@ -97,7 +97,11 @@ export function EditRoutineDialog({
             <div className="space-y-2">
               <Label>Source</Label>
               <p className="truncate rounded-md border border-border px-3 py-2 text-sm text-muted-foreground">
-                {routine.sourceKind === "none" ? "Scheduled prompt" : routine.sourceUrl}
+                {routine.sourceKind === "none"
+                  ? "Scheduled prompt"
+                  : routine.sourceKind === "connection"
+                    ? "A connected source"
+                    : routine.sourceUrl}
               </p>
               <p className="text-xs text-muted-foreground">
                 A routine remembers how far it has read this source, so the source itself is fixed.

--- a/src/components/routines/routine-detail.test.tsx
+++ b/src/components/routines/routine-detail.test.tsx
@@ -12,6 +12,7 @@ const routine: Routine = {
   visibility: "private",
   sourceKind: "rss",
   sourceUrl: "https://example.com/feed.xml",
+  connectionId: null,
   instruction: "summarise new posts",
   deliveryChannelId: "c1",
   scheduleCron: "0 * * * *",
@@ -28,6 +29,7 @@ const runs: RoutineRun[] = [
     id: "1",
     status: "ok",
     itemsNew: 3,
+    itemsOverflow: 0,
     durationMs: 1400,
     error: null,
     summary: "Three new posts about pricing.",
@@ -37,6 +39,7 @@ const runs: RoutineRun[] = [
     id: "2",
     status: "skipped",
     itemsNew: 0,
+    itemsOverflow: 0,
     durationMs: 300,
     error: null,
     summary: null,
@@ -46,6 +49,7 @@ const runs: RoutineRun[] = [
     id: "3",
     status: "failed",
     itemsNew: 0,
+    itemsOverflow: 0,
     durationMs: 2100,
     error: "upstream 503",
     summary: null,
@@ -77,6 +81,44 @@ describe("RoutineDetail", () => {
   it("shows a failed run's error", () => {
     render(<RoutineDetail {...props} />);
     expect(screen.getByText("upstream 503")).toBeInTheDocument();
+  });
+
+  // The per-run cap delivers ten and marks everything it saw as seen, so the
+  // rest are not queued for later — they are gone. A row reading "10 new items"
+  // and nothing else says the opposite.
+  it("says how many entries the per-run cap dropped", () => {
+    const capped = [{ ...runs[0], itemsNew: 10, itemsOverflow: 32 }];
+    render(<RoutineDetail {...props} runs={capped} />);
+    expect(screen.getByText("32")).toBeInTheDocument();
+    expect(screen.getByText(/skipped/)).toBeInTheDocument();
+  });
+
+  it("says nothing about drops when there were none", () => {
+    render(<RoutineDetail {...props} />);
+    expect(screen.queryByText(/skipped/)).not.toBeInTheDocument();
+  });
+
+  it("names a connection routine by the account it watches", () => {
+    render(
+      <RoutineDetail
+        {...props}
+        routine={{ ...routine, sourceKind: "connection", sourceUrl: null, connectionId: "cn1" }}
+        connections={[{ id: "cn1", accountLabel: "Covan HQ", folderName: null } as never]}
+      />,
+    );
+    expect(screen.getByText(/Covan HQ/)).toBeInTheDocument();
+  });
+
+  // A uuid in a Source field tells the reader nothing, and the list not having
+  // loaded yet is the ordinary case rather than an error.
+  it("falls back to a readable phrase when the connection is unknown", () => {
+    render(
+      <RoutineDetail
+        {...props}
+        routine={{ ...routine, sourceKind: "connection", sourceUrl: null, connectionId: "gone" }}
+      />,
+    );
+    expect(screen.getByText("A connected source")).toBeInTheDocument();
   });
 
   it("hides owner controls for a teammate's routine", () => {

--- a/src/components/routines/routine-detail.tsx
+++ b/src/components/routines/routine-detail.tsx
@@ -19,6 +19,26 @@ import { RoutineStatus } from "@/components/routines/routine-status";
 import { cronToProse } from "@/lib/cron-to-prose";
 import { formatRelative } from "@/lib/relative-time";
 import type { Routine, RoutineRun } from "@/lib/routines-api";
+import type { Connection } from "@/lib/connections-api";
+
+/**
+ * What this routine watches, in one line.
+ *
+ * A connection is named by its account rather than by its id, and falls back to
+ * the generic phrase rather than to a bare uuid: connections are visible to the
+ * whole workspace, so a miss here means the list has not loaded yet or the
+ * connection has since been deleted, and neither is worth showing a uuid for.
+ */
+function sourceLabel(routine: Routine, connections: Connection[]): string {
+  if (routine.sourceKind === "none") return "Scheduled prompt";
+  if (routine.sourceKind === "connection") {
+    const connection = connections.find((c) => c.id === routine.connectionId);
+    if (!connection) return "A connected source";
+    const scope = connection.folderName ?? connection.bundleName;
+    return `Connected · ${connection.accountLabel}${scope ? ` · ${scope}` : ""}`;
+  }
+  return `${routine.sourceKind.toUpperCase()} · ${routine.sourceUrl ?? ""}`;
+}
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -48,6 +68,16 @@ function RunRow({ run }: { run: RoutineRun }) {
       <span className="text-sm">
         Sent · <span className="tabular-nums">{run.itemsNew}</span> new item
         {run.itemsNew === 1 ? "" : "s"}
+        {/* What the per-run cap declined. These were marked seen, so they are
+            not waiting for the next run — they were never delivered and never
+            will be. A run that shows only "10 new items" reads as complete,
+            which is exactly the impression to avoid on a busy feed. */}
+        {run.itemsOverflow > 0 && (
+          <span className="text-muted-foreground">
+            {" · "}
+            <span className="tabular-nums">{run.itemsOverflow}</span> skipped
+          </span>
+        )}
       </span>
     ) : run.status === "failed" ? (
       <span className="text-sm text-destructive">{run.error ?? "Failed"}</span>
@@ -101,6 +131,7 @@ function RunRow({ run }: { run: RoutineRun }) {
 export function RoutineDetail({
   routine,
   runs,
+  connections = [],
   channelLabel,
   isOwner,
   onTogglePause,
@@ -113,6 +144,12 @@ export function RoutineDetail({
 }: {
   routine: Routine;
   runs: RoutineRun[];
+  /**
+   * The workspace's connections, so a `connection` routine can be named by the
+   * account it watches rather than by a uuid. Empty is fine and is what a
+   * routine of any other kind gets.
+   */
+  connections?: Connection[];
   /** null when the viewer is not the owner — RLS hides other people's channels. */
   channelLabel: string | null;
   isOwner: boolean;
@@ -177,11 +214,7 @@ export function RoutineDetail({
 
       <SectionCard className="mt-8">
         <dl className="divide-y divide-hairline">
-          <Field label="Source">
-            {routine.sourceKind === "none"
-              ? "Scheduled prompt"
-              : `${routine.sourceKind.toUpperCase()} · ${routine.sourceUrl ?? ""}`}
-          </Field>
+          <Field label="Source">{sourceLabel(routine, connections)}</Field>
           <Field label="Schedule">
             <span className="tabular-nums">{cronToProse(routine.scheduleCron)}</span> ·{" "}
             {routine.timezone}

--- a/src/components/routines/routine-status.test.tsx
+++ b/src/components/routines/routine-status.test.tsx
@@ -11,6 +11,7 @@ const base: Routine = {
   visibility: "private",
   sourceKind: "none",
   sourceUrl: null,
+  connectionId: null,
   instruction: "do a thing",
   deliveryChannelId: "c1",
   scheduleCron: "0 * * * *",

--- a/src/components/routines/routines-list.test.tsx
+++ b/src/components/routines/routines-list.test.tsx
@@ -18,6 +18,7 @@ const routine = (over: Partial<Routine>): Routine => ({
   visibility: "private",
   sourceKind: "rss",
   sourceUrl: "https://example.com/feed.xml",
+  connectionId: null,
   instruction: "summarise",
   deliveryChannelId: "c1",
   scheduleCron: "0 * * * *",

--- a/src/lib/routines-api.ts
+++ b/src/lib/routines-api.ts
@@ -2,6 +2,15 @@
 // their own file so api-client.ts stays a transport layer; the request
 // functions themselves live there because `request()` is module-private.
 
+/**
+ * `connection` watches a bundle a Notion or Drive connection already keeps
+ * current, and reports the documents that were added or changed since the last
+ * run. It reads nothing from the provider itself — the sync has already done
+ * that — so what it sees is only ever as fresh as the connection's own
+ * interval.
+ */
+export type RoutineSourceKind = "rss" | "web" | "none" | "connection";
+
 export type Routine = {
   id: string;
   agentId: string;
@@ -9,8 +18,10 @@ export type Routine = {
   userId: string;
   name: string;
   visibility: "private" | "shared";
-  sourceKind: "rss" | "web" | "none";
+  sourceKind: RoutineSourceKind;
   sourceUrl: string | null;
+  /** Set only for `connection`. The connection whose documents it watches. */
+  connectionId: string | null;
   instruction: string;
   deliveryChannelId: string;
   scheduleCron: string;
@@ -28,6 +39,12 @@ export type RoutineRun = {
   /** `skipped` means "looked, nothing new" — it is not a failure. */
   status: "ok" | "skipped" | "failed";
   itemsNew: number;
+  /**
+   * New entries this run saw and did not deliver, dropped by the per-run cap of
+   * ten. They were marked seen, so they are not queued for a later run — they
+   * are gone, which is why the number is shown rather than inferred.
+   */
+  itemsOverflow: number;
   durationMs: number | null;
   error: string | null;
   /** What was delivered. Null for skipped and failed runs, and for runs
@@ -62,8 +79,10 @@ export type RoutineDraft = {
 export type CreateRoutineInput = {
   agentId: string;
   name: string;
-  sourceKind: "rss" | "web" | "none";
+  sourceKind: RoutineSourceKind;
   sourceUrl?: string | null;
+  /** Required when sourceKind is `connection`. */
+  connectionId?: string | null;
   instruction: string;
   deliveryChannelId: string;
   scheduleCron: string;

--- a/src/routes/_authed.agents.$agentId.routines.$routineId.tsx
+++ b/src/routes/_authed.agents.$agentId.routines.$routineId.tsx
@@ -17,6 +17,7 @@ import {
   useRunRoutine,
   useDeliveryChannels,
 } from "@/hooks/use-routines";
+import { useConnections } from "@/hooks/use-connections";
 
 export const Route = createFileRoute("/_authed/agents/$agentId/routines/$routineId")({
   component: RoutineDetailPage,
@@ -28,6 +29,10 @@ function RoutineDetailPage() {
   const { data: routines = [], isLoading } = useRoutines();
   const { data: runs = [] } = useRoutineRuns(routineId);
   const { data: channels = [] } = useDeliveryChannels();
+  // Only so a routine watching one can be named by the account rather than by
+  // its id. Workspace-visible, so this resolves for a teammate reading a shared
+  // routine too — unlike the delivery channel below it.
+  const { data: connectionData } = useConnections();
   const { data: me } = useQuery({ queryKey: ["me"], queryFn: () => api.me() });
   const updateRoutine = useUpdateRoutine();
   const deleteRoutine = useDeleteRoutine();
@@ -126,6 +131,7 @@ function RoutineDetailPage() {
         <RoutineDetail
           routine={routine}
           runs={runs}
+          connections={connectionData?.connections ?? []}
           channelLabel={isOwner ? channelLabel : null}
           isOwner={isOwner}
           onTogglePause={() => void togglePause()}

--- a/supabase/migrations/0047_a_routine_can_watch_what_it_already_syncs.sql
+++ b/supabase/migrations/0047_a_routine_can_watch_what_it_already_syncs.sql
@@ -1,0 +1,192 @@
+-- =========================================================================
+-- A routine can watch what the workspace already syncs
+--
+-- Two changes, both about a routine reporting less than it saw.
+--
+-- The first is a fourth source kind. A routine could watch an RSS feed or a
+-- web page — the open internet — and not the places the team's own work
+-- actually lives, even when a connection (0043) was already re-reading those
+-- places on a schedule and filing the results in a bundle. So "tell me what
+-- changed in the handbook" was not expressible, while "tell me what changed on
+-- a competitor's blog" was.
+--
+-- What this deliberately does NOT do is give the routine engine its own Notion
+-- or Drive client. 0043 says it plainly: nothing here queries a provider at
+-- question time, and there is one substrate rather than a second retrieval
+-- path with its own permissions to get wrong. A `connection` routine reads
+-- `documents` — rows the reconciler has already fetched, versioned, chunked
+-- and (when a document is withdrawn at the source) removed. The routine adds
+-- no provider call, no second token decrypt, and nothing to the sync's
+-- subrequest budget.
+--
+-- The cost of that choice is latency, and it is worth naming: a connection
+-- syncs every `sync_interval_minutes` (six hours by default), so a routine
+-- pointed at one sees a change no sooner than the sync does, whatever its own
+-- cron says. The create dialog says so.
+--
+-- The second change is `items_overflow`. A run delivers at most ten new
+-- entries but marks everything it saw as seen, so a burst of forty reports ten
+-- and silently drops thirty. `diffItems` has always computed that number and
+-- the executor has always thrown it away, which made a documented behaviour
+-- invisible in the one place someone would look for it.
+-- =========================================================================
+
+-- ---- routines.source_kind: 'connection' ----------------------------------
+-- `source_config` carries {"connectionId": "<uuid>"} for this kind, the way it
+-- carries {"url": "..."} for the other two. A column would be tidier and is
+-- deliberately not added: the FK it would want is exactly what the policy
+-- below has to re-check anyway (the system checks FKs with RLS bypassed), so a
+-- column would buy referential integrity and still leave the tenancy guard to
+-- be written by hand.
+-- Found rather than named. 0012 wrote the check inline on the column, so its
+-- name is whatever Postgres generated — `routines_source_kind_check` today, and
+-- something else on any database where the column was ever rebuilt. A
+-- `drop constraint if exists` against a guessed name does not fail loudly if it
+-- guesses wrong: it skips, the new constraint is added alongside the old one,
+-- and every `connection` routine is then refused by a constraint nobody is
+-- looking at. So the old one is looked up by what it constrains.
+do $$
+declare
+  constraint_name text;
+begin
+  for constraint_name in
+    select con.conname
+    from pg_constraint con
+    where con.conrelid = 'public.routines'::regclass
+      and con.contype = 'c'
+      and pg_get_constraintdef(con.oid) like '%source_kind%'
+  loop
+    execute format('alter table public.routines drop constraint %I', constraint_name);
+  end loop;
+end;
+$$;
+
+alter table public.routines
+  add constraint routines_source_kind_check
+  check (source_kind in ('rss', 'web', 'none', 'connection'));
+
+-- A routine of this kind must name a connection, and one that exists in its own
+-- workspace. Without the first half, `source_config->>'connectionId'` is null
+-- and the executor fails every run of a routine that looked fine when it was
+-- saved; without the second, the guard is left entirely to the policies below,
+-- and a check constraint is the cheaper place to catch the shape.
+alter table public.routines
+  drop constraint if exists routines_connection_config_check;
+
+alter table public.routines
+  add constraint routines_connection_config_check
+  check (
+    source_kind <> 'connection'
+    -- `coalesce`, not a bare `->>`. A missing key yields NULL, `NULL ~ ...` is
+    -- NULL, and a CHECK constraint only refuses FALSE — so without this a
+    -- connection routine with no connectionId at all passes the one guard that
+    -- still applies when row level security does not. The policy below catches
+    -- it for an ordinary client; the service role is why that is not enough.
+    or coalesce(source_config ->> 'connectionId', '')
+       ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+  );
+
+-- ---- the tenancy guard ---------------------------------------------------
+-- Same reasoning as the agent and delivery-channel guards these policies
+-- already carry, and the same mechanism: a subquery inside a policy respects
+-- the referenced table's own RLS, so `connections` resolves only to rows the
+-- caller can already see — which for connections means their workspace's
+-- (`connections_select_member`).
+--
+-- Without this, `authenticated` holds a table-level INSERT/UPDATE grant and the
+-- anon key ships in the browser bundle, so a crafted PostgREST write could
+-- point a routine at another workspace's connection. The service-role executor
+-- would then read that connection's documents and mail their titles and
+-- excerpts to a channel in this workspace. The routine never touches the
+-- provider, so nothing else in the stack would have refused it.
+--
+-- Written as a helper because the same expression belongs in both policies, and
+-- two hand-copied subqueries drift.
+create or replace function public.routine_source_is_visible(
+  p_source_kind text,
+  p_source_config jsonb,
+  p_workspace_id uuid
+) returns boolean
+language sql
+stable
+-- Deliberately NOT security definer. This has to run as the caller so the
+-- subquery is filtered by the caller's own RLS; as definer it would see every
+-- connection in the database and answer true for all of them.
+as $$
+  select
+    p_source_kind <> 'connection'
+    or exists (
+      select 1 from public.connections cn
+      -- Cast the row's id to text rather than the input to uuid. A malformed
+      -- string in `source_config` would make `::uuid` raise, and an exception
+      -- from inside a policy reaches the client as a 500 — a crafted write
+      -- would be answered with "server error" instead of "refused". Comparing
+      -- as text cannot raise, so a nonsense id simply matches nothing.
+      where cn.id::text = (p_source_config ->> 'connectionId')
+        and cn.workspace_id = p_workspace_id
+    );
+$$;
+
+comment on function public.routine_source_is_visible(text, jsonb, uuid) is
+  'True unless the routine watches a connection the caller cannot see in that workspace. Runs as the caller so the subquery is RLS-filtered; must not become SECURITY DEFINER.';
+
+drop policy if exists "routines_insert_own" on public.routines;
+create policy "routines_insert_own"
+  on public.routines for insert
+  with check (
+    user_id = auth.uid()
+    and public.is_workspace_member(workspace_id)
+    and exists (
+      select 1 from public.agents a
+      where a.id = routines.agent_id and a.workspace_id = routines.workspace_id
+    )
+    and exists (
+      select 1 from public.delivery_channels dc
+      where dc.id = routines.delivery_channel_id and dc.user_id = auth.uid()
+    )
+    and public.routine_source_is_visible(
+      routines.source_kind, routines.source_config, routines.workspace_id
+    )
+  );
+
+-- The WITH CHECK carries exactly the same guards as the INSERT policy, for the
+-- reason 0012 gives: a weaker one lets an owner repoint their own row at
+-- something the INSERT would have refused.
+--
+-- The connection half of it is, today, unreachable: 0027's trigger raises on
+-- any update that changes `source_kind` or `source_config`, so an existing
+-- routine cannot be repointed at another workspace's connection whatever this
+-- policy says. It is written anyway, for the reason 0043 gives about writing a
+-- policy for a grant nobody holds — a trigger is one `drop trigger` away from
+-- being removed by somebody solving a different problem, and a guard that was
+-- never written is not there to catch that.
+drop policy if exists "routines_update_own" on public.routines;
+create policy "routines_update_own"
+  on public.routines for update
+  using (user_id = auth.uid())
+  with check (
+    user_id = auth.uid()
+    and public.is_workspace_member(workspace_id)
+    and exists (
+      select 1 from public.agents a
+      where a.id = routines.agent_id and a.workspace_id = routines.workspace_id
+    )
+    and exists (
+      select 1 from public.delivery_channels dc
+      where dc.id = routines.delivery_channel_id and dc.user_id = auth.uid()
+    )
+    and public.routine_source_is_visible(
+      routines.source_kind, routines.source_config, routines.workspace_id
+    )
+  );
+
+-- ---- what the cap declined -----------------------------------------------
+-- Counted separately from `items_new` rather than folded into it, because the
+-- two answer different questions: `items_new` is what the summary is about, and
+-- this is what the summary is missing. Nothing recomputes it later — the seen
+-- window has moved on by then — so a run that does not record it has lost it.
+alter table public.routine_runs
+  add column if not exists items_overflow int not null default 0;
+
+comment on column public.routine_runs.items_overflow is
+  'New entries this run saw and did not deliver, dropped by the per-run cap. Marked seen regardless, so they are never delivered later.';

--- a/tests/rls/routines.test.ts
+++ b/tests/rls/routines.test.ts
@@ -22,10 +22,41 @@ import { seedWorkspace, type Seeded } from "./fixtures";
 
 let owner: TestUser;
 let seeded: Seeded;
+let stranger: TestUser;
+let strangerSeeded: Seeded;
+/** A connection in the owner's own workspace, and one in a workspace they are not in. */
+let ownConnectionId: string;
+let foreignConnectionId: string;
+
+/**
+ * `connections` grants `authenticated` no INSERT at all — the worker creates
+ * them with the service role after the OAuth exchange, because the row holds an
+ * encrypted token. So these are seeded the way `delivery_channels` is.
+ */
+async function seedConnection(user: TestUser, bundleId: string): Promise<string> {
+  const { data, error } = await serviceClient()
+    .from("connections")
+    .insert({
+      workspace_id: user.workspaceId,
+      bundle_id: bundleId,
+      user_id: user.id,
+      provider: "notion",
+      account_label: "Seeded Notion",
+      secret_ciphertext: "not-a-real-ciphertext",
+    })
+    .select("id")
+    .single();
+  if (error) throw new Error(`seeding connections failed: ${error.message}`);
+  return data.id as string;
+}
 
 beforeAll(async () => {
   owner = await createTestUser("routines-owner");
   seeded = await seedWorkspace(owner);
+  stranger = await createTestUser("routines-stranger");
+  strangerSeeded = await seedWorkspace(stranger);
+  ownConnectionId = await seedConnection(owner, seeded.bundleId);
+  foreignConnectionId = await seedConnection(stranger, strangerSeeded.bundleId);
 });
 
 afterAll(async () => {
@@ -57,5 +88,75 @@ describe("a routine's source cannot be repointed after creation", () => {
       .eq("id", seeded.routineId);
 
     expect(error).toBeNull();
+  });
+});
+
+/**
+ * 0047's guard, and the reason it needs one.
+ *
+ * A `connection` routine names its source by id in `source_config`, and the
+ * scheduled executor then reads that connection's documents with the
+ * service-role client — row level security is not filtering it. `authenticated`
+ * holds a table-level INSERT on `routines` and the anon key ships in the
+ * browser bundle, so without a policy a crafted PostgREST insert could point a
+ * routine in this workspace at a connection in another one, and the engine
+ * would mail that workspace's document titles and excerpts to a channel here.
+ * Nothing else in the stack would have refused it: the routine never touches
+ * Notion, so no provider token and no OAuth scope is involved.
+ */
+describe("a routine cannot watch another workspace's connection", () => {
+  const routineFor = (user: TestUser, s: Seeded, connectionId: string) => ({
+    workspace_id: user.workspaceId,
+    agent_id: s.agentId,
+    user_id: user.id,
+    name: "Watch the handbook",
+    source_kind: "connection",
+    source_config: { connectionId },
+    instruction: "summarise what changed",
+    delivery_channel_id: s.channelId,
+    schedule_cron: "0 9 * * *",
+  });
+
+  it("refuses a connection in a workspace the caller is not in", async () => {
+    const { error } = await owner.db
+      .from("routines")
+      .insert(routineFor(owner, seeded, foreignConnectionId));
+
+    expect(error).not.toBeNull();
+  });
+
+  it("allows a connection in the caller's own workspace", async () => {
+    const { data, error } = await owner.db
+      .from("routines")
+      .insert(routineFor(owner, seeded, ownConnectionId))
+      .select("id")
+      .single();
+
+    expect(error).toBeNull();
+    expect(data?.id).toBeTruthy();
+  });
+
+  it("refuses a connection routine that names no connection at all", async () => {
+    const { error } = await owner.db.from("routines").insert({
+      ...routineFor(owner, seeded, ownConnectionId),
+      source_config: {},
+    });
+
+    expect(error).not.toBeNull();
+  });
+
+  // A malformed id has to be refused, not raise. `routine_source_is_visible`
+  // compares the connection's id as text rather than casting the input to uuid,
+  // because an exception raised inside a policy reaches the client as a server
+  // error — which would answer a crafted write with "something broke" instead
+  // of "no".
+  it("refuses a malformed connection id without erroring out", async () => {
+    const { error } = await owner.db.from("routines").insert({
+      ...routineFor(owner, seeded, ownConnectionId),
+      source_config: { connectionId: "not-a-uuid" },
+    });
+
+    expect(error).not.toBeNull();
+    expect(error!.message).not.toMatch(/invalid input syntax/i);
   });
 });

--- a/worker/src/lib/dto.ts
+++ b/worker/src/lib/dto.ts
@@ -358,8 +358,10 @@ export type RoutineDTO = {
   userId: string;
   name: string;
   visibility: "private" | "shared";
-  sourceKind: "rss" | "web" | "none";
+  sourceKind: "rss" | "web" | "none" | "connection";
   sourceUrl: string | null;
+  /** Set only for `connection`. The connection whose documents it watches. */
+  connectionId: string | null;
   instruction: string;
   deliveryChannelId: string;
   scheduleCron: string;
@@ -378,7 +380,7 @@ export function mapRoutine(row: {
   name: string;
   visibility: string;
   source_kind: string;
-  source_config: { url?: string } | null;
+  source_config: { url?: string; connectionId?: string } | null;
   instruction: string;
   delivery_channel_id: string;
   schedule_cron: string;
@@ -397,6 +399,7 @@ export function mapRoutine(row: {
     visibility: row.visibility === "shared" ? "shared" : "private",
     sourceKind: row.source_kind as RoutineDTO["sourceKind"],
     sourceUrl: row.source_config?.url ?? null,
+    connectionId: row.source_config?.connectionId ?? null,
     instruction: row.instruction,
     deliveryChannelId: row.delivery_channel_id,
     scheduleCron: row.schedule_cron,
@@ -413,6 +416,12 @@ export type RoutineRunDTO = {
   id: string;
   status: "ok" | "skipped" | "failed";
   itemsNew: number;
+  /**
+   * New entries this run saw and did not deliver, dropped by the per-run cap.
+   * Not deferred — they were marked seen, so they are never delivered later.
+   * Zero for every run recorded before 0047.
+   */
+  itemsOverflow: number;
   durationMs: number | null;
   error: string | null;
   /** What was delivered. Null for skipped and failed runs, and for any run
@@ -425,6 +434,7 @@ export function mapRoutineRun(row: {
   id: string;
   status: string;
   items_new: number | null;
+  items_overflow?: number | null;
   duration_ms: number | null;
   error: string | null;
   summary?: string | null;
@@ -434,6 +444,7 @@ export function mapRoutineRun(row: {
     id: row.id,
     status: row.status === "ok" || row.status === "failed" ? row.status : "skipped",
     itemsNew: row.items_new ?? 0,
+    itemsOverflow: row.items_overflow ?? 0,
     durationMs: row.duration_ms ?? null,
     error: row.error ?? null,
     summary: row.summary ?? null,

--- a/worker/src/lib/routines/connection-source.test.ts
+++ b/worker/src/lib/routines/connection-source.test.ts
@@ -1,0 +1,152 @@
+// worker/src/lib/routines/connection-source.test.ts
+import { describe, it, expect } from "vitest";
+import { fetchConnectionItems } from "./connection-source";
+
+/**
+ * A Supabase-shaped stub for the two reads this module makes: the connection,
+ * scoped by workspace, and that connection's documents.
+ *
+ * `filters` records what each read was scoped by, because the security property
+ * this module has to hold is not "it returned the right rows" — it is "it
+ * refused to look outside the routine's own workspace". A stub that answered
+ * every query with the same rows would pass a test written against the return
+ * value alone.
+ */
+function makeDb(over: { connection?: unknown; documents?: unknown[] } = {}) {
+  const filters: Array<{ table: string; column: string; value: unknown }> = [];
+
+  const db = {
+    from: (table: string) => ({
+      select: () => {
+        const chain: any = {
+          eq: (column: string, value: unknown) => {
+            filters.push({ table, column, value });
+            return chain;
+          },
+          is: (column: string, value: unknown) => {
+            filters.push({ table, column, value });
+            return chain;
+          },
+          order: () => chain,
+          limit: async () => ({ data: over.documents ?? [], error: null }),
+          maybeSingle: async () => ({
+            data: over.connection === undefined ? { id: "cn1" } : over.connection,
+            error: null,
+          }),
+        };
+        return chain;
+      },
+    }),
+  };
+
+  return { db: db as any, filters };
+}
+
+const doc = (over: Record<string, unknown> = {}) => ({
+  id: "d1",
+  name: "Handbook",
+  content: "Holiday policy is twenty-five days.",
+  external_url: "https://notion.so/handbook",
+  external_version: "v1",
+  synced_at: "2026-09-05T10:00:00Z",
+  ...over,
+});
+
+describe("fetchConnectionItems", () => {
+  it("returns each document as a feed item keyed by id and version", async () => {
+    const { db } = makeDb({ documents: [doc()] });
+
+    const items = await fetchConnectionItems(db, { workspaceId: "w1", connectionId: "cn1" });
+
+    expect(items).toEqual([
+      {
+        key: "d1:v1",
+        title: "Handbook",
+        link: "https://notion.so/handbook",
+        publishedAt: "2026-09-05T10:00:00Z",
+        summary: "Holiday policy is twenty-five days.",
+      },
+    ]);
+  });
+
+  // The whole point of putting the version in the key: `diffItems` decides what
+  // is new by identity, so a document whose text was edited at the source has to
+  // arrive under a key the cursor has not seen, or it would sync and never be
+  // reported again.
+  it("gives an edited document a key the cursor has not seen", async () => {
+    const before = await fetchConnectionItems(makeDb({ documents: [doc()] }).db, {
+      workspaceId: "w1",
+      connectionId: "cn1",
+    });
+    const after = await fetchConnectionItems(
+      makeDb({ documents: [doc({ external_version: "v2" })] }).db,
+      { workspaceId: "w1", connectionId: "cn1" },
+    );
+
+    expect(before[0].key).not.toEqual(after[0].key);
+  });
+
+  it("scopes the connection lookup to the routine's own workspace", async () => {
+    const { db, filters } = makeDb({ documents: [] });
+
+    await fetchConnectionItems(db, { workspaceId: "w1", connectionId: "cn1" });
+
+    expect(filters).toContainEqual({ table: "connections", column: "id", value: "cn1" });
+    expect(filters).toContainEqual({
+      table: "connections",
+      column: "workspace_id",
+      value: "w1",
+    });
+  });
+
+  // The executor holds a service-role client, so nothing below it is filtering
+  // by tenancy. 0047's policy stops a routine being *written* with someone
+  // else's connection; this stops a row written before 0047 — or by anything
+  // holding the service role — from being read.
+  it("refuses a connection that is not in the routine's workspace", async () => {
+    const { db } = makeDb({ connection: null });
+
+    await expect(
+      fetchConnectionItems(db, { workspaceId: "w1", connectionId: "cn-elsewhere" }),
+    ).rejects.toThrow(/connection/i);
+  });
+
+  it("refuses a routine whose source_config names no connection", async () => {
+    const { db } = makeDb();
+
+    await expect(
+      fetchConnectionItems(db, { workspaceId: "w1", connectionId: undefined }),
+    ).rejects.toThrow(/connectionId/);
+  });
+
+  // A document the reconciler withdrew has stopped grounding answers; reporting
+  // it as new here would contradict that.
+  it("asks only for documents that are not soft-deleted", async () => {
+    const { db, filters } = makeDb({ documents: [] });
+
+    await fetchConnectionItems(db, { workspaceId: "w1", connectionId: "cn1" });
+
+    expect(filters).toContainEqual({ table: "documents", column: "deleted_at", value: null });
+    expect(filters).toContainEqual({
+      table: "documents",
+      column: "connection_id",
+      value: "cn1",
+    });
+  });
+
+  // A Notion page with no title and no URL still has to produce a usable item
+  // rather than an empty bullet, because the model is given nothing else.
+  it("falls back to a readable title and an empty link", async () => {
+    const { db } = makeDb({
+      documents: [doc({ name: "", external_url: null, external_version: null })],
+    });
+
+    const items = await fetchConnectionItems(db, { workspaceId: "w1", connectionId: "cn1" });
+
+    expect(items[0].title).toBe("Untitled document");
+    expect(items[0].link).toBe("");
+    // No version to key on, so the sync time stands in — an edited document
+    // still arrives under a key the cursor has not seen.
+    expect(items[0].key).toBe("d1:2026-09-05T10:00:00Z");
+  });
+});

--- a/worker/src/lib/routines/connection-source.ts
+++ b/worker/src/lib/routines/connection-source.ts
@@ -1,0 +1,138 @@
+// worker/src/lib/routines/connection-source.ts
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { FeedItem } from "./feed";
+
+/**
+ * What a routine watching a connection reads.
+ *
+ * Deliberately not a provider client. 0043 built connections as a reconciler —
+ * it lists what Notion or Drive holds now, compares versions, imports what
+ * moved and removes what vanished — and the whole argument for that shape was
+ * one substrate: everything downstream of "here is the text" treats a synced
+ * document exactly like an uploaded one. Giving the routine engine its own
+ * Notion client would undo that, and would mean a second place where "has this
+ * changed?" is decided, with its own version comparison to get subtly
+ * differently wrong.
+ *
+ * So this reads `documents`. The reconciler has already done the fetching, the
+ * versioning and the removals; what is left is to say which of those rows the
+ * routine has not reported yet, and that is `diffItems`' job, unchanged. The
+ * items below go through the same diff, the same seen-key window, the same
+ * per-run cap and the same silent first run as an RSS feed's.
+ *
+ * The cost is latency, and it belongs in the create dialog rather than hidden
+ * here: a connection syncs every `sync_interval_minutes` (six hours by
+ * default), so a routine pointed at one cannot see a change sooner than the
+ * sync does, whatever its own cron says.
+ */
+
+/**
+ * How many of a connection's documents one run reads.
+ *
+ * Ordered by `synced_at` descending, which is a real "recently changed"
+ * ordering rather than a proxy: `importOne` writes that column only when a
+ * document is actually added or updated, so a sync that finds nothing new
+ * leaves every row's value alone.
+ *
+ * The bound matters for a large bundle. Everything returned here is marked seen
+ * by `diffItems`, so the window has to be wide enough that a document cannot
+ * fall out of the recent set and then reappear as new — 200 against a per-run
+ * delivery cap of 10 leaves a wide margin. A connection whose sync changes more
+ * than 200 documents between two routine runs would lose the oldest of them,
+ * which is the same trade the feed cap makes and is reported the same way.
+ */
+export const MAX_CONNECTION_DOCUMENTS = 200;
+
+export type ConnectionSourceInput = {
+  /** The routine's own workspace. Never a caller's. */
+  workspaceId: string;
+  /** From `source_config.connectionId`. Absent means a malformed routine row. */
+  connectionId: string | undefined;
+};
+
+export async function fetchConnectionItems(
+  db: SupabaseClient,
+  input: ConnectionSourceInput,
+  limit: number = MAX_CONNECTION_DOCUMENTS,
+): Promise<FeedItem[]> {
+  const { workspaceId, connectionId } = input;
+
+  if (!connectionId) {
+    throw new Error("source_config.connectionId is required for a connection routine");
+  }
+
+  // SCOPING: `db` is the service-role client and row level security is not
+  // filtering this. 0047's policy stops a routine being *written* against
+  // another workspace's connection, and this stops one being *read* — which is
+  // the half that still matters for rows written before 0047, and for anything
+  // else that holds the service role. Matching on id alone would make a
+  // tampered `source_config` a cross-tenant read whose result is then mailed
+  // out of the product.
+  const { data: connection, error: connectionError } = await db
+    .from("connections")
+    .select("id")
+    .eq("id", connectionId)
+    .eq("workspace_id", workspaceId)
+    .maybeSingle();
+
+  if (connectionError) {
+    throw new Error(`connection lookup failed: ${connectionError.message}`);
+  }
+  if (!connection) {
+    throw new Error("the connection this routine watches is not available in this workspace");
+  }
+
+  // Soft-deleted rows are excluded, unlike in the sync itself. A document the
+  // reconciler withdrew has stopped grounding answers everywhere else in the
+  // product, and reporting it here as something new would contradict that.
+  //
+  // The consequence is that a routine reports additions and edits but not
+  // removals. Saying "the pricing sheet was taken down" would be worth having;
+  // it needs the cursor to remember what it saw rather than only what was new,
+  // and that is a wider change than this.
+  const { data, error } = await db
+    .from("documents")
+    .select("id, name, content, external_url, external_version, synced_at")
+    .eq("connection_id", connectionId)
+    .is("deleted_at", null)
+    .order("synced_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`could not read this connection's documents: ${error.message}`);
+  }
+
+  return (data ?? []).map(toItem);
+}
+
+type DocumentRow = {
+  id: string;
+  name: string | null;
+  content: string | null;
+  external_url: string | null;
+  external_version: string | null;
+  synced_at: string | null;
+};
+
+function toItem(row: DocumentRow): FeedItem {
+  // Identity is the document *and its version*, so an edit arrives under a key
+  // the cursor has not seen and is reported again. Keying on the id alone would
+  // mean a document is announced when it first syncs and never again, however
+  // many times somebody rewrites it — which for a watched handbook is the one
+  // event worth watching for.
+  //
+  // `synced_at` stands in when a provider gives no version. It moves on every
+  // real import for the same reason, so the property still holds.
+  const version = row.external_version ?? row.synced_at ?? "";
+
+  return {
+    key: `${row.id}:${version}`,
+    // A Notion page can genuinely have no title. The model is given the title,
+    // the link and the excerpt and nothing else, so an empty string here is an
+    // empty bullet in somebody's Slack.
+    title: row.name?.trim() || "Untitled document",
+    link: row.external_url ?? "",
+    publishedAt: row.synced_at,
+    summary: row.content ?? "",
+  };
+}

--- a/worker/src/lib/routines/dispatcher.ts
+++ b/worker/src/lib/routines/dispatcher.ts
@@ -6,6 +6,7 @@ import { runRoutine as defaultRunRoutine, type ExecutorDeps, type RoutineRow } f
 import { summariseWithModel } from "./summarise";
 import { ownHostsFrom } from "./url-guard";
 import { entitlementsFor } from "../entitlements";
+import { retrieveForAgent } from "../retrieval";
 
 /**
  * How many routines one tick may run, bounded by the Workers **Free** plan's
@@ -55,6 +56,18 @@ function executorDeps(env: RoutineEnv, db: SupabaseClient): ExecutorDeps {
     // resolves that env once (house or workspace) and hands it in here, per
     // call, rather than baking one in at construction the way this used to.
     summarise: (input, runEnv) => summariseWithModel(runEnv)(input),
+    // The same retrieval chat and Slack use, reached through the same module.
+    // `retrieval.ts` exists precisely because a second surface needed to ask an
+    // agent something and two copies would have drifted rather than failed —
+    // this is the third surface, and it passes an empty history because a
+    // routine has no prior turns to carry a subject in.
+    //
+    // `runEnv` for the same reason `summarise` takes it: embedding is a paid
+    // call and goes to whichever key is answering this run.
+    retrieve: async ({ agentId, query }, runEnv) => {
+      const { ragBlock, embeddingTokens } = await retrieveForAgent(db, runEnv, agentId, query, []);
+      return { ragBlock, embeddingTokens };
+    },
     entitlements: entitlementsFor(env),
     fetchDeps: { fetchImpl: boundFetch, ownHosts },
     deliveryDeps: {

--- a/worker/src/lib/routines/executor.test.ts
+++ b/worker/src/lib/routines/executor.test.ts
@@ -79,7 +79,12 @@ const routine = (over: Partial<RoutineRow> = {}): RoutineRow => ({
  * on delivery_channels, both on workspace_members).
  */
 function makeDb(
-  over: { rows?: Record<string, any>; claimWins?: (keys: string[]) => string[] } = {},
+  over: {
+    rows?: Record<string, any>;
+    claimWins?: (keys: string[]) => string[];
+    /** Rows a `connection` routine's document read resolves to. */
+    documents?: any[];
+  } = {},
 ) {
   const updates: Array<{ table: string; values: any }> = [];
   const inserts: Array<{ table: string; values: any }> = [];
@@ -89,6 +94,9 @@ function makeDb(
     if (over.rows && table in over.rows) return over.rows[table];
     if (table === "workspace_members") return { user_id: "u1" };
     if (table === "agents") return { persona: "You are a growth specialist", model: "gpt-4o" };
+    // A `connection` routine looks its connection up scoped to the routine's
+    // own workspace before it reads a single document. See connection-source.ts.
+    if (table === "connections") return { id: "cn1" };
     if (table === "delivery_channels")
       return {
         kind: "slack_webhook",
@@ -110,7 +118,16 @@ function makeDb(
           // agent out of its way.
           is: () => chain,
           order: () => chain,
-          limit: () => chain,
+          // Two callers end a chain with `.limit()` and want different things
+          // from it: `lastRunWasQuotaSkip` follows it with `.maybeSingle()`,
+          // and the document read for a `connection` routine awaits it. A
+          // promise carrying the extra method satisfies both, which is what
+          // postgrest-js's builder does too.
+          limit: () => {
+            const pending: any = Promise.resolve({ data: over.documents ?? [], error: null });
+            pending.maybeSingle = chain.maybeSingle;
+            return pending;
+          },
           maybeSingle: async () => ({ data: await rowFor(table), error: null }),
           single: async () => ({ data: await rowFor(table), error: null }),
         };
@@ -159,6 +176,7 @@ function makeDb(
 
 let fetchImpl: any;
 let summarise: any;
+let retrieve: any;
 let deliverCalls: any[];
 /** Tokens charged through `entitlements.record`, per run. */
 let recorded: Array<{ userId: string; tokens: number }>;
@@ -172,6 +190,7 @@ function makeDeps(db: any) {
     // only has to be a shape `keysForUser` can read without a workspace lookup.
     env: { OPENAI_API_KEY: "sk-test" },
     summarise,
+    retrieve,
     // Unmetered by default, like a self-hosted install. The quota tests
     // override `check` on the returned object.
     entitlements: {
@@ -197,6 +216,10 @@ function makeDeps(db: any) {
 
 beforeEach(() => {
   summarise = vi.fn(async () => ({ text: "summary", tokens: 120 }));
+  // Ungrounded by default, so the assertions below are about what the executor
+  // does with a block rather than about whether one was produced. The tests
+  // that care override this.
+  retrieve = vi.fn(async () => ({ ragBlock: "", embeddingTokens: 0 }));
   // Reset rather than clear: a mockResolvedValue installed by one test would
   // otherwise become the de-facto default for every test after it.
   readWorkspaceKeys.mockReset();
@@ -960,5 +983,210 @@ describe("runRoutine", () => {
       (u) => u.table === "routines" && Object.keys(u.values).length === 1,
     );
     expect(bareReset?.values).toEqual({ claimed_at: null });
+  });
+
+  // ---- what the agent knows ------------------------------------------------
+  //
+  // A routine is meant to be the same colleague as the one in the chat window,
+  // reporting rather than answering. It was not: chat and Slack both retrieve
+  // against the agent's documents and the routine path did not, so the same
+  // agent read the company's own handbook when asked a question and had
+  // forgotten it when it wrote the digest.
+
+  it("grounds the summary in the agent's own documents", async () => {
+    fetchImpl = vi.fn(async () => new Response(ATOM(["a", "b"]), { status: 200 }));
+    retrieve = vi.fn(async () => ({
+      ragBlock: "Excerpt: our own pricing page lists Pro at $29.",
+      embeddingTokens: 0,
+    }));
+    const { db } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    await runRoutine(r, makeDeps(db) as any);
+
+    expect(summarise.mock.calls[0][0].ragBlock).toContain("Pro at $29");
+  });
+
+  it("retrieves against the instruction and what this run actually found", async () => {
+    fetchImpl = vi.fn(async () => new Response(ATOM(["a", "b"]), { status: 200 }));
+    const { db } = makeDb();
+    const r = routine({
+      instruction: "Flag anything about competitor pricing",
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    await runRoutine(r, makeDeps(db) as any);
+
+    const [call] = retrieve.mock.calls;
+    expect(call[0].agentId).toBe("a1");
+    // Both halves: the standing instruction, and the entries this particular
+    // run is about. A query built from the instruction alone returns the same
+    // passages every run, whatever came in.
+    expect(call[0].query).toContain("Flag anything about competitor pricing");
+    expect(call[0].query).toContain("Tb");
+  });
+
+  it("charges the embedding tokens to the owner alongside the completion's", async () => {
+    fetchImpl = vi.fn(async () => new Response(ATOM(["a", "b"]), { status: 200 }));
+    retrieve = vi.fn(async () => ({ ragBlock: "block", embeddingTokens: 900 }));
+    const { db } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    await runRoutine(r, makeDeps(db) as any);
+
+    // 120 from the completion, plus 900 embedding tokens at EMBEDDING_TOKEN_WEIGHT.
+    expect(recorded).toEqual([{ userId: "u1", tokens: 129 }]);
+  });
+
+  it("still delivers, ungrounded, when retrieval throws", async () => {
+    fetchImpl = vi.fn(async () => new Response(ATOM(["a", "b"]), { status: 200 }));
+    retrieve = vi.fn(async () => {
+      throw new Error("embeddings unavailable");
+    });
+    const { db } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    const out = await runRoutine(r, makeDeps(db) as any);
+
+    // An ungrounded digest beats no digest — the same trade retrieval.ts makes
+    // for a chat turn.
+    expect(out.status).toBe("ok");
+    expect(summarise.mock.calls[0][0].ragBlock).toBe("");
+    expect(deliverCalls).toHaveLength(1);
+  });
+
+  it("does not pay to retrieve for a run that has nothing to report", async () => {
+    fetchImpl = vi.fn(async () => res("", { status: 304 }));
+    const { db } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: '"v1"', contentHash: null },
+    });
+
+    await runRoutine(r, makeDeps(db) as any);
+
+    expect(retrieve).not.toHaveBeenCalled();
+  });
+
+  // ---- watching a connection -----------------------------------------------
+
+  it("reads a connection's documents instead of fetching anything", async () => {
+    fetchImpl = vi.fn();
+    const { db } = makeDb({
+      documents: [
+        {
+          id: "d1",
+          name: "Handbook",
+          content: "Holiday policy is twenty-five days.",
+          external_url: "https://notion.so/handbook",
+          external_version: "v2",
+          synced_at: "2026-09-05T10:00:00Z",
+        },
+      ],
+    });
+    const r = routine({
+      source_kind: "connection",
+      source_config: { connectionId: "cn1" },
+      cursor: { seenKeys: ["d1:v1"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    const out = await runRoutine(r, makeDeps(db) as any);
+
+    expect(out).toEqual({ status: "ok", itemsNew: 1 });
+    // The whole design: no provider call, no second token decrypt, nothing
+    // added to the sync's subrequest budget.
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(summarise.mock.calls[0][0].items[0].title).toBe("Handbook");
+  });
+
+  it("says nothing on a connection routine's first run", async () => {
+    fetchImpl = vi.fn();
+    const { db, updates } = makeDb({
+      documents: [{ id: "d1", name: "Handbook", external_version: "v1", synced_at: "2026-09-05" }],
+    });
+    const r = routine({
+      source_kind: "connection",
+      source_config: { connectionId: "cn1" },
+      cursor: null,
+    });
+
+    const out = await runRoutine(r, makeDeps(db) as any);
+
+    // Same rule as a feed: with no cursor there is nothing to compare against,
+    // so the baseline is recorded and the whole bundle is not posted at anyone.
+    expect(out).toEqual({ status: "skipped", itemsNew: 0 });
+    expect(deliverCalls).toHaveLength(0);
+    const saved = updates.find((u) => u.table === "routines")!;
+    expect(saved.values.cursor.seenKeys).toEqual(["d1:v1"]);
+  });
+
+  it("fails a connection routine whose connection is not in its workspace", async () => {
+    fetchImpl = vi.fn();
+    const { db, updates } = makeDb({ rows: { connections: null } });
+    const r = routine({
+      source_kind: "connection",
+      source_config: { connectionId: "cn-elsewhere" },
+      cursor: { seenKeys: [], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    const out = await runRoutine(r, makeDeps(db) as any);
+
+    expect(out.status).toBe("failed");
+    expect(deliverCalls).toHaveLength(0);
+    const saved = updates.find((u) => u.table === "routines")!;
+    expect(saved.values.consecutive_failures).toBe(1);
+  });
+
+  // ---- what the cap declined -----------------------------------------------
+
+  it("records the entries the per-run cap dropped", async () => {
+    // Twelve unseen entries against a cap of ten.
+    const ids = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"];
+    fetchImpl = vi.fn(async () => new Response(ATOM(ids), { status: 200 }));
+    const { db, inserts } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["z"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    const out = await runRoutine(r, makeDeps(db) as any);
+
+    expect(out).toEqual({ status: "ok", itemsNew: 10 });
+    const run = inserts.find((i) => i.table === "routine_runs")!;
+    expect(run.values.items_new).toBe(10);
+    // The two the cap declined are marked seen and never delivered later, so a
+    // run that does not record this number has lost it.
+    expect(run.values.items_overflow).toBe(2);
+  });
+
+  it("tells the reader what was left out of the message", async () => {
+    const ids = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"];
+    fetchImpl = vi.fn(async () => new Response(ATOM(ids), { status: 200 }));
+    const { db } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["z"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    await runRoutine(r, makeDeps(db) as any);
+
+    const sent = JSON.parse(deliverCalls[0].init.body).text;
+    expect(sent).toContain("2 further entries were not included");
+  });
+
+  it("leaves the message alone when nothing was dropped", async () => {
+    fetchImpl = vi.fn(async () => new Response(ATOM(["a", "b"]), { status: 200 }));
+    const { db, inserts } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    await runRoutine(r, makeDeps(db) as any);
+
+    expect(JSON.parse(deliverCalls[0].init.body).text).not.toContain("not included");
+    expect(inserts.find((i) => i.table === "routine_runs")!.values.items_overflow).toBe(0);
   });
 });

--- a/worker/src/lib/routines/executor.ts
+++ b/worker/src/lib/routines/executor.ts
@@ -2,10 +2,11 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { RoutineEnv } from "../../types";
 import { nextRunAt } from "./schedule";
-import { fetchSource, UpstreamError, type FetchDeps } from "./source";
+import { fetchSource, UpstreamError, type FetchDeps, type SourceResult } from "./source";
+import { fetchConnectionItems } from "./connection-source";
 import { diffItems, type Cursor, type FeedItem } from "./feed";
 import { claimItemKeys, deliver, releaseItemKeys, type DeliveryDeps } from "./delivery";
-import type { Entitlements } from "../entitlements";
+import { embeddingCost, type Entitlements } from "../entitlements";
 import {
   billsTheOperator,
   keysForUser,
@@ -41,8 +42,9 @@ export type RoutineRow = {
   user_id: string;
   workspace_id: string;
   name: string;
-  source_kind: "rss" | "web" | "none";
-  source_config: { url?: string };
+  source_kind: "rss" | "web" | "none" | "connection";
+  /** `url` for rss and web, `connectionId` for connection, empty for none. */
+  source_config: { url?: string; connectionId?: string };
   instruction: string;
   delivery_channel_id: string;
   schedule_cron: string;
@@ -59,7 +61,16 @@ export type SummariseInput = {
   instruction: string;
   items: FeedItem[];
   pageText?: string;
+  /**
+   * What the agent already knows, retrieved for this run. Empty when the agent
+   * has no documents, when nothing cleared the similarity floor, or when
+   * retrieval failed — all three mean the same thing to the model, which is
+   * that it answers from its persona alone.
+   */
+  ragBlock: string;
 };
+
+export type RetrievalInput = { agentId: string; query: string };
 
 export type ExecutorDeps = {
   /** Service-role client — bypasses RLS. See the scoping note below. */
@@ -72,12 +83,75 @@ export type ExecutorDeps = {
    */
   env: RoutineEnv;
   summarise: (input: SummariseInput, env: RoutineEnv) => Promise<{ text: string; tokens: number }>;
+  /**
+   * What the agent knows, for one run.
+   *
+   * Injected rather than called directly for the reason `summarise` is: this
+   * module is meant to be drivable without an environment, and `retrieveForAgent`
+   * needs embedding config. The dispatcher supplies the real one.
+   *
+   * Takes the resolved run env for the same reason `summarise` does. Embedding
+   * is a paid call, so it has to go to whichever key is answering this run — an
+   * owner who brought their own is not asking the operator to pay for the
+   * retrieval half of it.
+   */
+  retrieve: (
+    input: RetrievalInput,
+    env: RoutineEnv,
+  ) => Promise<{ ragBlock: string; embeddingTokens: number }>;
   fetchDeps: FetchDeps;
   deliveryDeps: DeliveryDeps;
   /** What the routine's owner may spend. Unmetered on a self-hosted install. */
   entitlements: Entitlements;
   now: () => Date;
 };
+
+/**
+ * How much of a watched page's text goes into the retrieval query.
+ *
+ * The page itself is already in the prompt; this only has to be enough to
+ * describe what the page is about. Embedding twenty thousand characters to
+ * find six passages would cost more than the completion it is grounding.
+ */
+const PAGE_QUERY_CHARS = 500;
+
+/**
+ * What to look up in the agent's documents for this run.
+ *
+ * A routine has no question, which is the thing that makes this different from
+ * a chat turn. It has a standing instruction and whatever arrived this
+ * particular time, and both halves matter: the instruction alone returns the
+ * same passages on every run whatever came in, and the arrivals alone lose the
+ * reason the routine exists.
+ */
+function retrievalQueryFor(instruction: string, items: FeedItem[], pageText?: string): string {
+  if (pageText) return `${instruction}\n${pageText.slice(0, PAGE_QUERY_CHARS)}`;
+  if (items.length === 0) return instruction;
+  return `${instruction}\n${items.map((i) => i.title).join("\n")}`;
+}
+
+/**
+ * Says what the message is missing, in the message.
+ *
+ * A run delivers at most ten new entries and marks everything it saw as seen,
+ * so on a busy feed the reader gets ten of forty and the other thirty are not
+ * late — they are never coming. Somebody reading a digest has no way to know
+ * that, and the shape of the failure is the worst kind: the message looks
+ * complete. The run history carries the same number, but the digest is where
+ * the person is looking.
+ *
+ * Appended after the model's text rather than described to the model, because
+ * this is a fact about the delivery and not something the summary should be
+ * asked to reason about — and a model told "you are missing thirty entries"
+ * tends to hedge the ten it does have.
+ */
+function withOverflowNote(text: string, overflow: number): string {
+  if (overflow <= 0) return text;
+  const entries = overflow === 1 ? "entry" : "entries";
+  // Italic in Slack's mrkdwn and in the Markdown the email path renders, which
+  // are the only two destinations there are.
+  return `${text}\n\n_${overflow} further ${entries} were not included._`;
+}
 
 /**
  * Executes one routine, end to end. Knows nothing about what triggered it —
@@ -152,7 +226,34 @@ export async function runRoutine(
       return { status: "skipped", itemsNew: 0 };
     }
 
-    const result = await fetchSource(routine, routine.cursor, deps.fetchDeps);
+    // A connection routine reads rows the reconciler already imported rather
+    // than fetching anything itself — see `connection-source.ts` for why that
+    // is the design and not a shortcut. Everything downstream is identical to a
+    // feed's: the same diff, the same seen window, the same cap, the same
+    // silent first run.
+    let result: SourceResult;
+    if (routine.source_kind === "connection") {
+      result = {
+        status: "items",
+        items: await fetchConnectionItems(deps.db, {
+          workspaceId: routine.workspace_id,
+          connectionId: routine.source_config.connectionId,
+        }),
+        etag: null,
+      };
+    } else {
+      // Rebuilt rather than passed through, so `SourceInput` keeps its narrower
+      // union and `source.ts` stays what it is: the HTTP path, with the url
+      // guard and the redirect loop that only an outbound fetch needs. A
+      // connection reads the database and has no url to guard, and widening
+      // that type to admit it would put a kind through a module with nothing
+      // to do for it.
+      result = await fetchSource(
+        { source_kind: routine.source_kind, source_config: routine.source_config },
+        routine.cursor,
+        deps.fetchDeps,
+      );
+    }
 
     if (result.status === "unchanged") {
       await finish(routine, deps, startedAt, { status: "skipped", itemsNew: 0, tokens: 0 });
@@ -166,10 +267,24 @@ export async function runRoutine(
     // unique constraint is then the backstop for a run that overruns the
     // stale-claim window or fails between delivering and recording.
     let keysToClaim: string[] = [];
+    /**
+     * New entries this run saw and will not deliver, dropped by the per-run cap.
+     *
+     * Recorded rather than discarded because they are not deferred, they are
+     * gone: `diffItems` marks everything it saw as seen, including these, so a
+     * busy feed's overflow is never delivered on a later run. `diffItems` has
+     * always returned this number and this file used to throw it away, which
+     * made a documented behaviour invisible in the two places somebody would
+     * look for it — the message, and the run history.
+     */
+    let overflow = 0;
 
-    if (result.status === "items" && routine.source_kind === "rss") {
+    const diffed = routine.source_kind === "rss" || routine.source_kind === "connection";
+
+    if (result.status === "items" && diffed) {
       const diff = diffItems(result.items, routine.cursor);
       items = diff.newItems;
+      overflow = diff.overflow;
       nextCursor = { ...diff.nextCursor, etag: result.etag };
       keysToClaim = items.map((i) => i.key);
     } else if (result.status === "content") {
@@ -229,7 +344,7 @@ export async function runRoutine(
 
     // Reserve before sending. A concurrent or retried run gets back fewer keys.
     claimedKeys = await claimItemKeys(deps.db, routine.id, keysToClaim);
-    if (routine.source_kind === "rss") {
+    if (diffed) {
       items = items.filter((i) => claimedKeys.includes(i.key));
     }
     if (claimedKeys.length === 0) {
@@ -274,6 +389,37 @@ export async function runRoutine(
 
     if (agentError) throw new Error(`agent lookup failed: ${agentError.message}`);
 
+    // What the agent already knows, retrieved for this run.
+    //
+    // Placed here deliberately: after the quota check, after the run has
+    // established it has something to report, and after the delivery channel
+    // has been shown to exist — so a tick that will send nothing does not pay
+    // to embed a query, which on a healthy feed is most ticks.
+    //
+    // Through `runEnv`, so an owner who brought their own key pays for the
+    // embedding as well as the completion.
+    //
+    // Best-effort, for the reason `retrieval.ts` gives about a chat turn: an
+    // ungrounded answer beats no answer. That module already falls back to
+    // persona-only on its own failures, so reaching this catch means something
+    // further out broke — and a digest that arrives without the handbook is
+    // still worth more to the reader than a run that failed.
+    let ragBlock = "";
+    let embeddingTokens = 0;
+    try {
+      const retrieved = await deps.retrieve(
+        {
+          agentId: routine.agent_id,
+          query: retrievalQueryFor(routine.instruction, items, pageText),
+        },
+        runEnv,
+      );
+      ragBlock = retrieved.ragBlock;
+      embeddingTokens = retrieved.embeddingTokens;
+    } catch (err) {
+      console.error("routine retrieval failed (continuing persona-only)", err);
+    }
+
     const summary = await deps.summarise(
       {
         persona: agent?.persona ?? null,
@@ -281,11 +427,16 @@ export async function runRoutine(
         instruction: routine.instruction,
         items,
         pageText,
+        ragBlock,
       },
       runEnv,
     );
 
-    await deliver(channel, { subject: routine.name, body: summary.text }, deps.deliveryDeps);
+    await deliver(
+      channel,
+      { subject: routine.name, body: withOverflowNote(summary.text, overflow) },
+      deps.deliveryDeps,
+    );
     // Past this point the message is out. Releasing the claims would let the
     // next tick re-win them and send it again — the duplicate this whole
     // claim-first ordering exists to prevent. Leaving them claimed makes the
@@ -295,7 +446,12 @@ export async function runRoutine(
     await finish(routine, deps, startedAt, {
       status: "ok",
       itemsNew: items.length,
-      tokens: summary.tokens,
+      itemsOverflow: overflow,
+      // One counter write for the run, so the embeddings this run paid for are
+      // charged with the completion rather than in a second place that a later
+      // change could forget — including the decision about whose key paid,
+      // which `finish` makes once from `keys`.
+      tokens: summary.tokens + embeddingCost(embeddingTokens),
       cursor: nextCursor,
       summary: summary.text,
       keys,
@@ -373,6 +529,8 @@ export async function runRoutine(
  */
 type RunOutcome = {
   itemsNew: number;
+  /** New entries the per-run cap declined. Only a run that delivered has any. */
+  itemsOverflow?: number;
   cursor?: Cursor;
   error?: string;
   /** What was delivered. Absent for skipped and failed runs, which sent nothing. */
@@ -410,6 +568,7 @@ async function finish(
     finished_at: finishedAt.toISOString(),
     status: outcome.status,
     items_new: outcome.itemsNew,
+    items_overflow: outcome.itemsOverflow ?? 0,
     tokens: outcome.tokens,
     duration_ms: finishedAt.getTime() - startedAt.getTime(),
     error: outcome.error ?? null,

--- a/worker/src/lib/routines/summarise.test.ts
+++ b/worker/src/lib/routines/summarise.test.ts
@@ -53,6 +53,7 @@ describe("summariseWithModel", () => {
       model: "gpt-4o",
       instruction: "Summarise the latest posts.",
       items: [item(1), item(2)],
+      ragBlock: "",
     });
 
     const call = createMock.mock.calls[0][0];
@@ -65,6 +66,46 @@ describe("summariseWithModel", () => {
     expect(userMessage.content).toContain("Item 2");
   });
 
+  // A routine is meant to be the same colleague as the one in the chat window.
+  // It was not: chat put the agent's retrieved documents in their own system
+  // message and this path had none at all, so the agent that could quote the
+  // handbook when asked had forgotten it by the time it wrote the digest.
+  it("carries what the agent knows in its own system message, as chat does", async () => {
+    const summarise = summariseWithModel(env);
+    await summarise({
+      persona: "You are Ada.",
+      model: "gpt-4o",
+      instruction: "Flag competitor pricing moves.",
+      items: [item(1)],
+      ragBlock: "Excerpt from Pricing.md: our Pro tier is $29.",
+    });
+
+    const messages = createMock.mock.calls[0][0].messages;
+    const systemMessages = messages.filter((m: any) => m.role === "system");
+
+    // Two, not one concatenated block: the persona is the agent's standing
+    // identity and the excerpts are this run's material, and merging them
+    // invites the model to read retrieved text as instructions.
+    expect(systemMessages).toHaveLength(2);
+    expect(systemMessages[1].content).toContain("our Pro tier is $29");
+    // Before the user turn it grounds, same as `routes/chat.ts` assembles it.
+    expect(messages[messages.length - 1].role).toBe("user");
+  });
+
+  it("sends no grounding message when retrieval found nothing", async () => {
+    const summarise = summariseWithModel(env);
+    await summarise({
+      persona: "You are Ada.",
+      model: "gpt-4o",
+      instruction: "Summarise.",
+      items: [item(1)],
+      ragBlock: "",
+    });
+
+    const messages = createMock.mock.calls[0][0].messages;
+    expect(messages.filter((m: any) => m.role === "system")).toHaveLength(1);
+  });
+
   it("makes exactly one completion call for a batch of items, not one per item", async () => {
     const summarise = summariseWithModel(env);
     await summarise({
@@ -72,6 +113,7 @@ describe("summariseWithModel", () => {
       model: "gpt-4o",
       instruction: "Summarise.",
       items: [item(1), item(2), item(3)],
+      ragBlock: "",
     });
 
     expect(createMock).toHaveBeenCalledTimes(1);
@@ -86,6 +128,7 @@ describe("summariseWithModel", () => {
       instruction: "Summarise the page.",
       items: [],
       pageText: bigText,
+      ragBlock: "",
     });
 
     const call = createMock.mock.calls[0][0];
@@ -101,6 +144,7 @@ describe("summariseWithModel", () => {
       model: "not-a-real-model",
       instruction: "Summarise.",
       items: [item(1)],
+      ragBlock: "",
     });
 
     const call = createMock.mock.calls[0][0];
@@ -118,6 +162,7 @@ describe("summariseWithModel", () => {
       model: "gpt-4o",
       instruction: "Summarise.",
       items: [item(1)],
+      ragBlock: "",
     });
 
     expect(createMock.mock.calls[0][0].model).toBe("llama3.3:70b");
@@ -131,6 +176,7 @@ describe("summariseWithModel", () => {
       model: "gpt-4o",
       instruction: "Summarise.",
       items: [item(1)],
+      ragBlock: "",
     });
     expect(withUsage.tokens).toBe(42);
 
@@ -140,6 +186,7 @@ describe("summariseWithModel", () => {
       model: "gpt-4o",
       instruction: "Summarise.",
       items: [item(1)],
+      ragBlock: "",
     });
     expect(withoutUsage.tokens).toBe(0);
   });

--- a/worker/src/lib/routines/summarise.ts
+++ b/worker/src/lib/routines/summarise.ts
@@ -8,6 +8,13 @@ import type { SummariseInput } from "./executor";
  * One LLM call per run, not per item: cheaper, and the user gets one message
  * instead of eight. The agent's persona is applied exactly as it is in chat —
  * a routine is the same colleague, reporting instead of answering.
+ *
+ * "Exactly as in chat" now includes what the agent has read. It did not, and
+ * the gap was invisible because both halves worked: the agent could quote the
+ * handbook when someone asked it a question, and wrote the Monday digest as if
+ * it had never seen one. So a routine watching a competitor's blog could not
+ * say what the news meant for this company, which is the only reason to have
+ * asked an agent rather than forwarded the feed.
  */
 export function summariseWithModel(env: RoutineEnv) {
   return async (input: SummariseInput): Promise<{ text: string; tokens: number }> => {
@@ -26,6 +33,16 @@ export function summariseWithModel(env: RoutineEnv) {
             .filter(Boolean)
             .join("\n\n"),
         },
+        // The grounding block gets its own message rather than being folded
+        // into the persona, which is how `routes/chat.ts` assembles it and for
+        // the same two reasons: the persona is the agent's standing identity
+        // and this is one run's material, and keeping retrieved text in a
+        // separate message is what stops a passage that happens to read like an
+        // instruction from being read as one.
+        //
+        // Nothing is sent when retrieval found nothing, so an agent with no
+        // documents gets exactly the prompt it got before this existed.
+        ...(input.ragBlock ? [{ role: "system" as const, content: input.ragBlock }] : []),
         { role: "user", content: `${input.instruction}\n\n${body}` },
       ],
     });

--- a/worker/src/routes/routines.ts
+++ b/worker/src/routes/routines.ts
@@ -160,8 +160,10 @@ routines.delete("/delivery-channels/:id", async (c) => {
 const createSchema = z.object({
   agentId: z.string().uuid(),
   name: z.string().min(1),
-  sourceKind: z.enum(["rss", "web", "none"]),
+  sourceKind: z.enum(["rss", "web", "none", "connection"]),
   sourceUrl: z.string().nullable().optional(),
+  /** Required for `connection`, ignored otherwise. */
+  connectionId: z.string().uuid().nullable().optional(),
   instruction: z.string().min(1),
   deliveryChannelId: z.string().uuid(),
   scheduleCron: z.string().min(1),
@@ -184,6 +186,19 @@ const updateSchema = z
   })
   .refine((v) => Object.keys(v).length > 0, { message: "no fields to update" });
 
+/**
+ * What the engine reads back off the row.
+ *
+ * One key per kind rather than a bag of everything the request happened to
+ * carry: a `connection` routine that also stored a leftover `url` would look,
+ * to anyone reading the row later, like it might fetch one.
+ */
+function sourceConfigFor(body: z.infer<typeof createSchema>): Record<string, string> {
+  if (body.sourceKind === "connection") return { connectionId: body.connectionId! };
+  if (body.sourceUrl) return { url: body.sourceUrl };
+  return {};
+}
+
 routines.get("/routines", async (c) => {
   const { data, error } = await c
     .get("db")
@@ -203,13 +218,21 @@ routines.post("/routines", async (c) => {
   if (!isValidCron(body.scheduleCron, body.timezone)) {
     return c.json({ error: "unusable schedule" }, 400);
   }
-  if (body.sourceKind !== "none") {
+  if (body.sourceKind === "rss" || body.sourceKind === "web") {
     if (!body.sourceUrl) return c.json({ error: "this source needs a url" }, 400);
     try {
       assertFetchableUrl(body.sourceUrl, ownHostsFrom(c.env));
     } catch (err) {
       return c.json({ error: err instanceof Error ? err.message : "invalid url" }, 400);
     }
+  }
+  // A connection is checked by the database, not here: 0047's policy resolves
+  // the id through the caller's own RLS, so a connection in another workspace
+  // is refused by the same mechanism that refuses another workspace's agent.
+  // This only catches the shape, so the error names the missing field instead
+  // of arriving as the policy's generic refusal below.
+  if (body.sourceKind === "connection" && !body.connectionId) {
+    return c.json({ error: "this source needs a connection" }, 400);
   }
 
   const db = c.get("db");
@@ -228,7 +251,7 @@ routines.post("/routines", async (c) => {
       user_id: c.get("user").id,
       name: body.name,
       source_kind: body.sourceKind,
-      source_config: body.sourceUrl ? { url: body.sourceUrl } : {},
+      source_config: sourceConfigFor(body),
       instruction: body.instruction,
       delivery_channel_id: body.deliveryChannelId,
       schedule_cron: body.scheduleCron,


### PR DESCRIPTION
Three things about routines, all of them cases where the product already half-knew something and did not act on it.

## The agent had forgotten its own documents

Chat retrieves against the agent's bundles, and so does the Slack path, through the same `retrieveForAgent`. The routine path retrieved nothing at all — so the same agent could quote the handbook when somebody asked it a question and wrote the Monday digest as though it had never seen one. A routine watching a competitor could report what happened and never what it meant for this company, which is the only reason to have asked an agent rather than forwarded the feed.

`retrieveForAgent` is now reached from the executor the way `summarise` is, through an injected dep. The block rides in its own system message ahead of the instruction, exactly as `routes/chat.ts` assembles it — separate from the persona, so a retrieved passage that reads like an instruction is not read as one.

A routine has no question, so the query is the standing instruction **plus** what this run found. The instruction alone returns the same passages every run whatever came in; the arrivals alone lose the point of the routine.

- Runs only after the run knows it has something to send, so a tick that will deliver nothing does not pay to embed — on a healthy feed, most ticks.
- Takes the resolved `runEnv`, so an owner who brought their own key pays for the embedding half too.
- `embeddingCost` folds into the one counter write `finish` already makes.
- Best-effort: an agent with no documents, nothing above the similarity floor, and a retrieval that threw all produce the prompt as it was before this existed.

## A routine could watch the open internet, but not the team's own work

A connection (`0043`) has been re-reading Notion and Drive on a schedule and filing the results in a bundle this whole time, and "tell me what changed in the handbook" was still not expressible. `source_kind: 'connection'` closes that.

It deliberately does **not** give the routine engine its own provider client. `0043`'s argument is one substrate — nothing queries a provider at question time, and a synced document is not a second kind of document. A routine that went to Notion itself would be a second place deciding what "changed" means, with its own version comparison to get subtly differently wrong.

So it reads `documents`, keyed by document id *and* `external_version`, and hands the result to the existing `diffItems`: same seen window, same per-run cap, same silent first run, none of it written twice. No provider call, no second token decrypt, nothing added to the tick's subrequest budget.

The cost is latency, and it belongs on screen rather than in a doc — the create dialog states the chosen connection's own interval and that running the routine more often will not beat it.

Known edges, all deliberate: additions and edits are reported, removals are not; a run reads at most 200 documents, newest sync first; the draft parser never proposes this kind, because it would have to name a connection by id.

## The cap dropped entries silently

A run delivers at most ten and marks everything it saw as seen, so on a busy feed thirty are not late — they are never coming. `diffItems` has always returned that number and the executor threw it away.

It now reaches `routine_runs.items_overflow`, a line under the delivered message, and "· 30 skipped" in the run history. A message reporting ten of forty looks exactly like a message reporting all ten there were, which is the failure worth spending a column on.

## Migration 0047

Carries the source kind, the tenancy guard and the column. Two things it had to get right, both found by running it rather than by reading it:

- **A missing `connectionId` yields NULL from `->>`, and a CHECK only refuses FALSE.** Without `coalesce`, the one guard that still applies when RLS does not would have passed a connection routine naming no connection.
- **The old inline check's name is generated, not chosen.** It is looked up by what it constrains instead of guessed: a `drop ... if exists` that guesses wrong does not fail, it leaves both constraints in place and refuses every connection routine from a constraint nobody is reading.

The policy resolves the connection through the caller's own RLS and is not `SECURITY DEFINER` — as definer it would see every connection in the database and answer true for all of them. It compares the row's id as text rather than casting the input to uuid, so a crafted write is answered with "no" rather than a 500.

## Verification

- Worker: 1078 tests, `tsc` clean. Frontend: 544 tests, `tsc` clean. `eslint` clean, `check-rls` passes.
- Four new live-database tests in `tests/rls/routines.test.ts` cover the guard — they need Postgres and run in CI, not locally.
- The migration's constraints and policy function were exercised against a throwaway Postgres 15 cluster, including the drop against `0012`'s real constraint shape.