### PR TITLE
A routine that can decide there is nothing worth sending

### DIFF
--- a/docs/routines.md
+++ b/docs/routines.md
@@ -148,6 +148,9 @@ routine for the team — a routine is the same colleague, reporting rather than
 answering. Your instruction is the user message, with the new entries or the
 watched page's text beneath it.
 
+That call also decides whether to send at all — see
+[Nothing relevant](#nothing-relevant).
+
 The agent also gets what it knows. Before the call, the run retrieves against
 the agent's documents exactly as a chat turn does, and the excerpts ride in
 their own system message ahead of your instruction. Without that the claim above
@@ -353,6 +356,47 @@ routine the engine paused recovers with one click once the cause is fixed.
 answer to "why didn't it send me anything?". A run is skipped when the source
 answered `304` or hashed to the same page as last time, when a feed had no new
 entries, and on the first run of a feed or page watcher.
+
+### Nothing relevant
+
+There is a second answer to that question, and it is the one you will see most
+on a broad source: the run had real new entries, and the agent decided none of
+them were what your instruction asked for.
+
+Before this existed, every run with new entries delivered. Point a routine at a
+general news feed and ask for competitor news, and most runs are six unrelated
+posts plus a paragraph explaining that none of them are about competitors —
+hourly, in a channel people read, until they stop reading it. The routine goes
+on working and stops being useful, and nothing anywhere records that.
+
+So the model is asked two things rather than one: whether the material contains
+anything the instruction asked for, and the report. When the answer to the first
+is no, nothing is delivered and the run is recorded as
+`Nothing relevant · 6 reviewed`. **The count is the point.** A routine that
+filters and a routine that is broken both look like silence from outside, and
+that row is where you can see it is still reading.
+
+Three things follow.
+
+**It costs what it costs.** The model call that produced the judgement is the
+call you pay for, so a filtered run is billed like any other. What it saves is
+attention, not tokens.
+
+**A rejected entry is not offered again.** The cursor advances and the delivery
+claims stay, so an entry that has been judged is done with — otherwise a busy
+feed would spend a model call per run re-reaching the same answer.
+
+**A scheduled prompt is never asked.** With no source, there is nothing for its
+output to be irrelevant *to*: the instruction is the whole job. Asking anyway
+would let one `false` silence "remind the team to post standup" permanently.
+
+The decision comes back as a field of its own rather than as something to read
+out of the summary text, and **every way of failing to read it delivers**:
+unreadable JSON, a missing decision, or a decision that is not a plain `false`
+all send the message. That asymmetry is deliberate. A routine that sends
+something it should have withheld is the noise there was before, noticed at
+once; a routine that goes quiet because of a bug is indistinguishable from a
+quiet week, for as long as it takes somebody to get suspicious.
 
 Two more are worth naming. If the owner is no longer a member of the workspace,
 the run stops before anything else happens and the routine pauses, and unlike a

--- a/src/components/routines/routine-detail.test.tsx
+++ b/src/components/routines/routine-detail.test.tsx
@@ -30,6 +30,7 @@ const runs: RoutineRun[] = [
     status: "ok",
     itemsNew: 3,
     itemsOverflow: 0,
+    nothingRelevant: false,
     durationMs: 1400,
     error: null,
     summary: "Three new posts about pricing.",
@@ -40,6 +41,7 @@ const runs: RoutineRun[] = [
     status: "skipped",
     itemsNew: 0,
     itemsOverflow: 0,
+    nothingRelevant: false,
     durationMs: 300,
     error: null,
     summary: null,
@@ -50,6 +52,7 @@ const runs: RoutineRun[] = [
     status: "failed",
     itemsNew: 0,
     itemsOverflow: 0,
+    nothingRelevant: false,
     durationMs: 2100,
     error: "upstream 503",
     summary: null,
@@ -91,6 +94,26 @@ describe("RoutineDetail", () => {
     render(<RoutineDetail {...props} runs={capped} />);
     expect(screen.getByText("32")).toBeInTheDocument();
     expect(screen.getByText(/skipped/)).toBeInTheDocument();
+  });
+
+  // "Nothing new" and "nothing here was relevant" are different answers to
+  // "why didn't it send me anything?", and only one of them means the model
+  // made a judgement somebody might disagree with. Silence is what a broken
+  // routine looks like too, so the count is what gives anyone a way to check.
+  it("distinguishes a filtered run from an empty one, with what it read", () => {
+    const filtered = [{ ...runs[1], nothingRelevant: true, itemsNew: 6 }];
+    render(<RoutineDetail {...props} runs={filtered} />);
+    expect(screen.getByText(/Nothing relevant/)).toBeInTheDocument();
+    expect(screen.getByText(/6/)).toBeInTheDocument();
+    expect(screen.queryByText("Nothing new")).not.toBeInTheDocument();
+  });
+
+  it("still reads as neutral, not as a failure", () => {
+    const filtered = [{ ...runs[1], nothingRelevant: true, itemsNew: 6 }];
+    render(<RoutineDetail {...props} runs={filtered} />);
+    const row = screen.getByText(/Nothing relevant/);
+    expect(row.className).toContain("text-muted-foreground");
+    expect(row.className).not.toContain("destructive");
   });
 
   it("says nothing about drops when there were none", () => {

--- a/src/components/routines/routine-detail.tsx
+++ b/src/components/routines/routine-detail.tsx
@@ -81,6 +81,15 @@ function RunRow({ run }: { run: RoutineRun }) {
       </span>
     ) : run.status === "failed" ? (
       <span className="text-sm text-destructive">{run.error ?? "Failed"}</span>
+    ) : run.nothingRelevant ? (
+      // A different answer to "why didn't it send me anything?" than the one
+      // below: this run had entries and the agent decided none of them were
+      // what you asked for. The count is not decoration — a filtered routine
+      // and a broken one both look like silence from the outside, and this is
+      // the only place to see that it is still reading.
+      <span className="text-sm text-muted-foreground">
+        Nothing relevant · <span className="tabular-nums">{run.itemsNew}</span> reviewed
+      </span>
     ) : (
       <span className="text-sm text-muted-foreground">Nothing new</span>
     );

--- a/src/lib/routines-api.ts
+++ b/src/lib/routines-api.ts
@@ -45,6 +45,12 @@ export type RoutineRun = {
    * are gone, which is why the number is shown rather than inferred.
    */
   itemsOverflow: number;
+  /**
+   * The run read real entries and the agent judged none of them to be what the
+   * instruction asked for — as opposed to a run that found nothing new at all.
+   * `itemsNew` is how many it read before deciding.
+   */
+  nothingRelevant: boolean;
   durationMs: number | null;
   error: string | null;
   /** What was delivered. Null for skipped and failed runs, and for runs

--- a/worker/src/lib/dto.ts
+++ b/worker/src/lib/dto.ts
@@ -2,6 +2,7 @@
  * Row → frontend DTO mappers.
  * Frontend TS types are fixed: camelCase fields, timestamps as epoch-ms.
  */
+import { NOTHING_RELEVANT_REASON } from "./routines/executor";
 
 export type DocumentDTO = {
   id: string;
@@ -422,6 +423,16 @@ export type RoutineRunDTO = {
    * Zero for every run recorded before 0047.
    */
   itemsOverflow: number;
+  /**
+   * A skipped run that looked at real entries and judged none of them to be
+   * what the instruction asked for — as opposed to one that found nothing new.
+   * `itemsNew` says how many it read before deciding.
+   *
+   * Computed here rather than left to the client to match `error` against a
+   * string: the constant lives in the executor, and a copy of it in the
+   * frontend would be a magic string in a second package, free to drift.
+   */
+  nothingRelevant: boolean;
   durationMs: number | null;
   error: string | null;
   /** What was delivered. Null for skipped and failed runs, and for any run
@@ -445,6 +456,7 @@ export function mapRoutineRun(row: {
     status: row.status === "ok" || row.status === "failed" ? row.status : "skipped",
     itemsNew: row.items_new ?? 0,
     itemsOverflow: row.items_overflow ?? 0,
+    nothingRelevant: row.status === "skipped" && row.error === NOTHING_RELEVANT_REASON,
     durationMs: row.duration_ms ?? null,
     error: row.error ?? null,
     summary: row.summary ?? null,

--- a/worker/src/lib/routines/executor.test.ts
+++ b/worker/src/lib/routines/executor.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_FAILURES,
   MAX_TRANSIENT_FAILURES,
   QUOTA_SKIP_REASON,
+  NOTHING_RELEVANT_REASON,
   type RoutineRow,
 } from "./executor";
 import { encryptSecret } from "../secret-box";
@@ -215,7 +216,7 @@ function makeDeps(db: any) {
 }
 
 beforeEach(() => {
-  summarise = vi.fn(async () => ({ text: "summary", tokens: 120 }));
+  summarise = vi.fn(async () => ({ text: "summary", tokens: 120, declined: false }));
   // Ungrounded by default, so the assertions below are about what the executor
   // does with a block rather than about whether one was produced. The tests
   // that care override this.
@@ -1188,5 +1189,119 @@ describe("runRoutine", () => {
 
     expect(JSON.parse(deliverCalls[0].init.body).text).not.toContain("not included");
     expect(inserts.find((i) => i.table === "routine_runs")!.values.items_overflow).toBe(0);
+  });
+
+  // ---- deciding not to send ------------------------------------------------
+  //
+  // Every run with new entries used to deliver. Point a routine at a general
+  // news feed and ask for competitor news, and most runs are six unrelated
+  // posts plus a paragraph saying none of them are about competitors — hourly,
+  // in a channel, until it is muted. The routine keeps working and stops being
+  // read, which is the failure that does not show up anywhere.
+
+  const declines = () => {
+    summarise = vi.fn(async () => ({ text: "", tokens: 120, declined: true }));
+  };
+
+  it("sends nothing when the model found nothing worth sending", async () => {
+    fetchImpl = vi.fn(async () => new Response(ATOM(["a", "b", "c"]), { status: 200 }));
+    declines();
+    const { db } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    const out = await runRoutine(r, makeDeps(db) as any);
+
+    expect(out).toEqual({ status: "skipped", itemsNew: 0 });
+    expect(deliverCalls).toHaveLength(0);
+  });
+
+  it("records how many entries it reviewed before deciding", async () => {
+    fetchImpl = vi.fn(async () => new Response(ATOM(["a", "b", "c"]), { status: 200 }));
+    declines();
+    const { db, inserts } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    await runRoutine(r, makeDeps(db) as any);
+
+    const run = inserts.find((i) => i.table === "routine_runs")!;
+    expect(run.values.status).toBe("skipped");
+    // Two new entries were read and judged. A row reading 0 would be
+    // indistinguishable from a feed that had not moved, which is the question
+    // this number exists to answer.
+    expect(run.values.items_new).toBe(2);
+    expect(run.values.error).toBe(NOTHING_RELEVANT_REASON);
+    // Nothing was delivered, so there is nothing to show under the row.
+    expect(run.values.summary).toBeNull();
+  });
+
+  it("advances the cursor, so a rejected entry is not judged again", async () => {
+    fetchImpl = vi.fn(async () => new Response(ATOM(["a", "b", "c"]), { status: 200 }));
+    declines();
+    const { db, updates } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    await runRoutine(r, makeDeps(db) as any);
+
+    const saved = updates.find((u) => u.table === "routines")!;
+    expect(saved.values.cursor.seenKeys).toEqual(expect.arrayContaining(["b", "c"]));
+  });
+
+  it("still charges the call that produced the decision", async () => {
+    fetchImpl = vi.fn(async () => new Response(ATOM(["a", "b"]), { status: 200 }));
+    declines();
+    const { db } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    await runRoutine(r, makeDeps(db) as any);
+
+    // Silence is cheaper in noise, not in tokens: the model call that decided
+    // this is the model call that cost money.
+    expect(recorded).toEqual([{ userId: "u1", tokens: 120 }]);
+  });
+
+  it("does not count as a failure", async () => {
+    fetchImpl = vi.fn(async () => new Response(ATOM(["a", "b"]), { status: 200 }));
+    declines();
+    const { db, updates } = makeDb();
+    const r = routine({
+      consecutive_failures: 3,
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    await runRoutine(r, makeDeps(db) as any);
+
+    // A run that looked and decided is a working run. Counting it would pause a
+    // healthy routine after five quiet ones.
+    expect(updates.find((u) => u.table === "routines")!.values.consecutive_failures).toBe(0);
+  });
+
+  it("never lets a scheduled prompt decline", async () => {
+    fetchImpl = vi.fn();
+    const { db } = makeDb();
+
+    await runRoutine(routine({ source_kind: "none", source_config: {} }), makeDeps(db) as any);
+
+    // Nothing to be irrelevant to, and one `false` would silence it forever.
+    expect(summarise.mock.calls[0][0].mayDecline).toBe(false);
+  });
+
+  it("lets a routine that watches something decline", async () => {
+    fetchImpl = vi.fn(async () => new Response(ATOM(["a", "b"]), { status: 200 }));
+    const { db } = makeDb();
+    const r = routine({
+      cursor: { seenKeys: ["a"], lastPublishedAt: null, etag: null, contentHash: null },
+    });
+
+    await runRoutine(r, makeDeps(db) as any);
+
+    expect(summarise.mock.calls[0][0].mayDecline).toBe(true);
   });
 });

--- a/worker/src/lib/routines/executor.ts
+++ b/worker/src/lib/routines/executor.ts
@@ -25,6 +25,19 @@ export const MAX_FAILURES = 5;
 export const QUOTA_SKIP_REASON = "skipped: the owner's monthly token quota is used up";
 
 /**
+ * Written to `routine_runs.error` when the model read what arrived and judged
+ * none of it to be what the instruction asked for.
+ *
+ * Invariable, like `QUOTA_SKIP_REASON` and for a related reason: the interface
+ * matches it exactly to decide whether a skipped row reads "Nothing new" or
+ * "Nothing relevant", and the count of what was reviewed lives in
+ * `items_new` rather than in this string. It must also never equal
+ * `QUOTA_SKIP_REASON`, which `lastRunWasQuotaSkip` compares against — a
+ * collision there would suppress the quota notice.
+ */
+export const NOTHING_RELEVANT_REASON = "skipped: nothing in this run matched the instruction";
+
+/**
  * The same limit for failures that are the remote's fault rather than the
  * routine's — a 429 or a 5xx. Set far higher because backoff is capped at six
  * hours past the natural next run, so reaching this many consecutive transient
@@ -68,6 +81,15 @@ export type SummariseInput = {
    * that it answers from its persona alone.
    */
   ragBlock: string;
+  /**
+   * Whether this run is allowed to decide there is nothing worth sending.
+   *
+   * False for a scheduled prompt, which has no source for its output to be
+   * irrelevant *to* — the instruction is the whole job, and one `false` would
+   * silence "remind the team to post standup" permanently. True for everything
+   * that watches something.
+   */
+  mayDecline: boolean;
 };
 
 export type RetrievalInput = { agentId: string; query: string };
@@ -82,7 +104,19 @@ export type ExecutorDeps = {
    * a scheduled run has no request to guard.
    */
   env: RoutineEnv;
-  summarise: (input: SummariseInput, env: RoutineEnv) => Promise<{ text: string; tokens: number }>;
+  summarise: (
+    input: SummariseInput,
+    env: RoutineEnv,
+  ) => Promise<{
+    text: string;
+    tokens: number;
+    /**
+     * The model read the material and judged none of it to be what the
+     * instruction asked for, so this run delivers nothing. Only ever true when
+     * the input allowed it — see `SummariseInput.mayDecline`.
+     */
+    declined: boolean;
+  }>;
   /**
    * What the agent knows, for one run.
    *
@@ -428,9 +462,37 @@ export async function runRoutine(
         items,
         pageText,
         ragBlock,
+        // A scheduled prompt has no source, so there is nothing for its output
+        // to be irrelevant to — and one `false` would silence it permanently.
+        // Everything that watches something may decline.
+        mayDecline: routine.source_kind !== "none",
       },
       runEnv,
     );
+
+    // The model read what arrived and judged none of it to be what was asked
+    // for. This is a working run, not a failure and not an empty source: the
+    // entries were real, they were read, and the answer was no.
+    //
+    // The cursor advances and the delivery claims stay, both deliberately. A
+    // rejected entry has been judged; offering it again next run would spend
+    // another model call to reach the same answer, and on a busy feed that is
+    // most of the bill.
+    if (summary.declined) {
+      await finish(routine, deps, startedAt, {
+        status: "skipped",
+        // What it read before deciding. Zero here would be indistinguishable
+        // from a feed that had not moved, which is the question this number is
+        // on the row to answer.
+        itemsNew: items.length,
+        itemsOverflow: overflow,
+        tokens: summary.tokens + embeddingCost(embeddingTokens),
+        cursor: nextCursor,
+        error: NOTHING_RELEVANT_REASON,
+        keys,
+      });
+      return { status: "skipped", itemsNew: 0 };
+    }
 
     await deliver(
       channel,
@@ -546,6 +608,20 @@ type RunOutcome = {
       /** Whose key paid for `tokens`. Required, and that is the point. */
       keys: ProviderKeys;
     }
+  | {
+      /**
+       * A run that paid for a model call and then decided not to send.
+       *
+       * It is not an `"ok"` run — nothing was delivered — and it is not free
+       * either, so it carries the same answer about who paid. This branch
+       * exists so that widening "skipped" to admit a spend could not be done
+       * without also answering that question: `keys` is required here for the
+       * same reason it is required above.
+       */
+      status: "skipped";
+      tokens: number;
+      keys: ProviderKeys;
+    }
   | { status: "skipped" | "failed"; tokens: 0; keys?: undefined }
 );
 
@@ -582,10 +658,15 @@ async function finish(
   // counter that cannot be written must not turn a successful run into a failed
   // one that retries and pays twice.
   // Only what the operator is billed for — same rule as `recordQuota` on a
-  // request, asked through the same predicate. The `status === "ok"` term is
-  // not a second guard so much as what makes the type narrow: it is the only
-  // outcome that can have spent anything, and the only one carrying the answer.
-  if (outcome.status === "ok" && outcome.tokens > 0 && billsTheOperator(outcome.keys)) {
+  // request, asked through the same predicate. `outcome.keys` is what makes the
+  // type narrow rather than a second guard: the branches that can have spent
+  // anything are exactly the branches carrying the answer to who paid, so a
+  // spend the union let through without one would not compile.
+  //
+  // Not keyed on `status === "ok"` any more. A run that paid for a model call
+  // and then declined to send is a skipped run that spent real money, and
+  // billing it as if it were free would make a filtered routine free to run.
+  if (outcome.tokens > 0 && outcome.keys && billsTheOperator(outcome.keys)) {
     try {
       await deps.entitlements.record(routine.user_id, outcome.tokens);
     } catch (err) {

--- a/worker/src/lib/routines/summarise.test.ts
+++ b/worker/src/lib/routines/summarise.test.ts
@@ -54,6 +54,7 @@ describe("summariseWithModel", () => {
       instruction: "Summarise the latest posts.",
       items: [item(1), item(2)],
       ragBlock: "",
+      mayDecline: false,
     });
 
     const call = createMock.mock.calls[0][0];
@@ -78,6 +79,7 @@ describe("summariseWithModel", () => {
       instruction: "Flag competitor pricing moves.",
       items: [item(1)],
       ragBlock: "Excerpt from Pricing.md: our Pro tier is $29.",
+      mayDecline: false,
     });
 
     const messages = createMock.mock.calls[0][0].messages;
@@ -100,6 +102,7 @@ describe("summariseWithModel", () => {
       instruction: "Summarise.",
       items: [item(1)],
       ragBlock: "",
+      mayDecline: false,
     });
 
     const messages = createMock.mock.calls[0][0].messages;
@@ -114,6 +117,7 @@ describe("summariseWithModel", () => {
       instruction: "Summarise.",
       items: [item(1), item(2), item(3)],
       ragBlock: "",
+      mayDecline: false,
     });
 
     expect(createMock).toHaveBeenCalledTimes(1);
@@ -129,6 +133,7 @@ describe("summariseWithModel", () => {
       items: [],
       pageText: bigText,
       ragBlock: "",
+      mayDecline: false,
     });
 
     const call = createMock.mock.calls[0][0];
@@ -145,6 +150,7 @@ describe("summariseWithModel", () => {
       instruction: "Summarise.",
       items: [item(1)],
       ragBlock: "",
+      mayDecline: false,
     });
 
     const call = createMock.mock.calls[0][0];
@@ -163,6 +169,7 @@ describe("summariseWithModel", () => {
       instruction: "Summarise.",
       items: [item(1)],
       ragBlock: "",
+      mayDecline: false,
     });
 
     expect(createMock.mock.calls[0][0].model).toBe("llama3.3:70b");
@@ -177,6 +184,7 @@ describe("summariseWithModel", () => {
       instruction: "Summarise.",
       items: [item(1)],
       ragBlock: "",
+      mayDecline: false,
     });
     expect(withUsage.tokens).toBe(42);
 
@@ -187,7 +195,102 @@ describe("summariseWithModel", () => {
       instruction: "Summarise.",
       items: [item(1)],
       ragBlock: "",
+      mayDecline: false,
     });
     expect(withoutUsage.tokens).toBe(0);
+  });
+
+  // ---- deciding not to send ------------------------------------------------
+  //
+  // A routine used to send whatever the model wrote, every time it had new
+  // entries. Ask for "anything about our competitors" against a general news
+  // feed and most runs are six unrelated posts and a paragraph explaining that
+  // none of them are about competitors — which arrives hourly, in a Slack
+  // channel, until somebody mutes it. The routine is then technically working
+  // and practically dead.
+
+  const declining = (over: Record<string, unknown> = {}) => ({
+    persona: "You are Ada.",
+    model: "gpt-4o",
+    instruction: "Flag anything about our competitors.",
+    items: [item(1), item(2)],
+    ragBlock: "",
+    mayDecline: true,
+    ...over,
+  });
+
+  it("reports a declined run when the model says nothing matched", async () => {
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: '{"relevant": false, "summary": ""}' } }],
+      usage: { prompt_tokens: 30, completion_tokens: 12 },
+    });
+
+    const result = await summariseWithModel(env)(declining());
+
+    expect(result.declined).toBe(true);
+    // Still billed. The call that produced the judgement is the call that costs
+    // money — silence is cheaper in noise, not in tokens.
+    expect(result.tokens).toBe(42);
+  });
+
+  it("returns the summary, not the envelope, when something did match", async () => {
+    createMock.mockResolvedValue({
+      choices: [
+        { message: { content: '{"relevant": true, "summary": "Acme launched a Pro tier."}' } },
+      ],
+      usage: { prompt_tokens: 30, completion_tokens: 12 },
+    });
+
+    const result = await summariseWithModel(env)(declining());
+
+    expect(result.declined).toBe(false);
+    expect(result.text).toBe("Acme launched a Pro tier.");
+  });
+
+  // The whole safety of this feature. A routine that goes quiet looks exactly
+  // like a routine with nothing to report, so a parse bug would be invisible
+  // for weeks. Failing open means the worst case is the noise we had before.
+  it("sends the raw text rather than going silent when the JSON is unreadable", async () => {
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: "I could not follow the format. Acme launched a tier." } }],
+      usage: { prompt_tokens: 30, completion_tokens: 12 },
+    });
+
+    const result = await summariseWithModel(env)(declining());
+
+    expect(result.declined).toBe(false);
+    expect(result.text).toBe("I could not follow the format. Acme launched a tier.");
+  });
+
+  it("sends rather than going silent when the object omits the decision", async () => {
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: '{"summary": "Acme launched a Pro tier."}' } }],
+      usage: { prompt_tokens: 30, completion_tokens: 12 },
+    });
+
+    const result = await summariseWithModel(env)(declining());
+
+    expect(result.declined).toBe(false);
+  });
+
+  // A scheduled prompt has no source, so there is nothing for its output to be
+  // irrelevant *to* — the instruction is the whole job. Asking anyway would let
+  // one `false` silence "remind the team to post standup" forever.
+  it("does not ask for a decision at all when the routine may not decline", async () => {
+    await summariseWithModel(env)(declining({ mayDecline: false }));
+
+    const call = createMock.mock.calls[0][0];
+    expect(call.response_format).toBeUndefined();
+  });
+
+  it("asks for a decision when the routine may decline", async () => {
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: '{"relevant": true, "summary": "x"}' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
+
+    await summariseWithModel(env)(declining());
+
+    expect(createMock.mock.calls[0][0].response_format).toEqual({ type: "json_object" });
   });
 });

--- a/worker/src/lib/routines/summarise.ts
+++ b/worker/src/lib/routines/summarise.ts
@@ -5,6 +5,26 @@ import { complete, totalTokens } from "../completion";
 import type { SummariseInput } from "./executor";
 
 /**
+ * What the model is told when it is allowed to send nothing.
+ *
+ * Phrased as a judgement about the *material*, not about the writing: "is there
+ * anything here the instruction asked for" rather than "would this be a good
+ * message". The second framing makes a model hedge — it can always find a way
+ * to be useful — and hedging is exactly the paragraph this exists to stop.
+ */
+const DECISION_INSTRUCTION =
+  "Return a JSON object with two fields. `relevant` is true only if the material below " +
+  "contains something the instruction actually asked for, and false when it does not. " +
+  "`summary` is your report, written as you normally would, and must be empty when " +
+  "`relevant` is false.\n\n" +
+  "Say false rather than writing a message explaining that nothing matched. A message " +
+  "that says nothing happened is the thing this field exists to avoid: it is delivered " +
+  "to a channel people read, and enough of them make them stop reading it.";
+
+/** The decision, as the model returns it. Neither field is trusted to be there. */
+type Decision = { relevant?: unknown; summary?: unknown };
+
+/**
  * One LLM call per run, not per item: cheaper, and the user gets one message
  * instead of eight. The agent's persona is applied exactly as it is in chat —
  * a routine is the same colleague, reporting instead of answering.
@@ -15,9 +35,16 @@ import type { SummariseInput } from "./executor";
  * it had never seen one. So a routine watching a competitor's blog could not
  * say what the news meant for this company, which is the only reason to have
  * asked an agent rather than forwarded the feed.
+ *
+ * That one call now also decides whether to send at all, when the caller allows
+ * it. Two questions and one call rather than two calls: a separate relevance
+ * pass would double the bill on every run to answer something the model has
+ * already had to work out in order to write the summary.
  */
 export function summariseWithModel(env: RoutineEnv) {
-  return async (input: SummariseInput): Promise<{ text: string; tokens: number }> => {
+  return async (
+    input: SummariseInput,
+  ): Promise<{ text: string; tokens: number; declined: boolean }> => {
     const body = input.pageText
       ? `Watched page content:\n\n${input.pageText.slice(0, 20_000)}`
       : input.items
@@ -26,6 +53,7 @@ export function summariseWithModel(env: RoutineEnv) {
 
     const { text, usage } = await complete(env, {
       model: resolveModel(input.model, env),
+      json: input.mayDecline,
       messages: [
         {
           role: "system",
@@ -43,10 +71,55 @@ export function summariseWithModel(env: RoutineEnv) {
         // Nothing is sent when retrieval found nothing, so an agent with no
         // documents gets exactly the prompt it got before this existed.
         ...(input.ragBlock ? [{ role: "system" as const, content: input.ragBlock }] : []),
+        ...(input.mayDecline ? [{ role: "system" as const, content: DECISION_INSTRUCTION }] : []),
         { role: "user", content: `${input.instruction}\n\n${body}` },
       ],
     });
 
-    return { text, tokens: totalTokens(usage) };
+    const tokens = totalTokens(usage);
+    if (!input.mayDecline) return { text, tokens, declined: false };
+
+    return { ...readDecision(text), tokens };
   };
+}
+
+/**
+ * The model's answer, read so that every failure means "send it".
+ *
+ * This is the whole safety of the feature and it only points one way. A routine
+ * that goes quiet is indistinguishable, from outside, from a routine with
+ * nothing to report — so a parse bug here would not look like a bug, it would
+ * look like a quiet week, for as long as it took somebody to get suspicious. A
+ * routine that sends something it should have withheld is the noise we had
+ * before, noticed immediately, and fixed by the next run.
+ *
+ * So: unreadable JSON, a missing `relevant`, a non-boolean `relevant`, or
+ * `relevant: false` with a summary written anyway — all of them deliver.
+ * `declined` is true only when the model said so plainly.
+ */
+function readDecision(text: string): { text: string; declined: boolean } {
+  let decision: Decision;
+  try {
+    decision = JSON.parse(text) as Decision;
+  } catch {
+    // `completion.ts` already digs an object out of a fenced or prose-wrapped
+    // reply, so reaching here means there was no object to find. The raw text
+    // is the best summary available, and sending it beats silence.
+    return { text, declined: false };
+  }
+
+  if (decision === null || typeof decision !== "object") return { text, declined: false };
+
+  const summary = typeof decision.summary === "string" ? decision.summary : "";
+
+  // Only an explicit `false` declines. `undefined`, a string "false", and
+  // anything else a model might improvise all send.
+  if (decision.relevant !== false) {
+    // A well-formed object whose summary came back empty would deliver a blank
+    // message, which is worse than either outcome this feature offers. Fall
+    // back to the whole reply, which at least contains what the model wrote.
+    return { text: summary || text, declined: false };
+  }
+
+  return { text: summary, declined: true };
 }


### PR DESCRIPTION
Every run with new entries delivered. Point a routine at a general news feed and ask for competitor news, and most runs are six unrelated posts plus a paragraph explaining that none of them are about competitors — hourly, in a channel people read, until they stop reading it.

The routine goes on working and stops being useful, and nothing anywhere records that. It is the failure mode this feature has, and the one nothing in the product could see.

## The change

The model is asked two things instead of one, **in the same call**: `{"relevant": bool, "summary": "..."}`. A separate relevance pass would double the bill on every run to answer something the model already has to work out in order to write the summary.

When the answer is no, nothing is delivered and the run is recorded as `Nothing relevant · 6 reviewed`.

## Every way of failing to read the decision delivers

Unreadable JSON, a missing `relevant`, anything that is not a plain `false` — all of them send the message.

The asymmetry is the whole safety of it. A routine that sends something it should have withheld is the noise there was before: noticed at once, fixed by the next run. A routine that goes quiet because of a bug is indistinguishable from a quiet week, for as long as it takes somebody to get suspicious. A self-hosted install whose small model cannot hold the format falls back to the behaviour it had rather than going dark.

## A scheduled prompt is never asked

With no source there is nothing for its output to be irrelevant *to* — the instruction is the whole job. Asking anyway would let one `false` silence "remind the team to post standup" permanently.

## The count is not decoration

A routine that filters and a routine that is broken both look like silence from outside. That number is the only place anyone can see it is still reading.

It comes from `items_new`, which has always meant "new entries this run had" and was only ever 0 on a skipped row because there genuinely were none. The two skip reasons are told apart by an invariable string in `error` — the shape `QUOTA_SKIP_REASON` already uses — mapped to a DTO boolean so the constant is not copied into the frontend. **No migration.**

## One type had to give

`RunOutcome` forbade a skipped run from reporting a spend: *"a skipped or failed run that wanted to report a spend would have to become an `ok` one first, and would then have to say who paid."*

A declined run breaks that — it paid for a model call and delivered nothing. The union gains a third branch where `keys` is still **required**, so "skipped but billed" cannot be written without answering who paid. The billing guard now turns on `keys` rather than on `status === "ok"`; left as it was, a filtered routine would have run for free on the operator, and a BYOK workspace's filtered runs would have been billed to the wrong party.

Two more things follow from the decision being real work:

- **Tokens are still charged.** The call that produced the judgement is the call that costs money. What is saved is attention, not spend.
- **The cursor advances and the delivery claims stay**, so a rejected entry is not judged again. On a busy feed that would be a model call per run to re-reach the same answer.

## Behaviour change

**Existing routines are filtered from the first run after deploy.** There is no per-routine switch, deliberately: the behaviour it replaces is not one anybody would choose on purpose, and an opt-in would leave it off for exactly the people who never open the settings page and are being buried.

## Verification

Worker 1091 tests, frontend 546 tests, both `tsc` clean, `eslint` clean.

New tests cover the parts that would fail silently: a parse failure delivers, a missing decision field delivers, a scheduled prompt is never asked, the cursor advances, the tokens are still recorded, and consecutive quiet runs do not increment `consecutive_failures` — without that last one a healthy filtered routine would pause itself after five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)