### PR TITLE
Ask the row for the count, not the screen

### DIFF
--- a/src/components/routines/routine-detail.test.tsx
+++ b/src/components/routines/routine-detail.test.tsx
@@ -103,8 +103,13 @@ describe("RoutineDetail", () => {
   it("distinguishes a filtered run from an empty one, with what it read", () => {
     const filtered = [{ ...runs[1], nothingRelevant: true, itemsNew: 6 }];
     render(<RoutineDetail {...props} runs={filtered} />);
-    expect(screen.getByText(/Nothing relevant/)).toBeInTheDocument();
-    expect(screen.getByText(/6/)).toBeInTheDocument();
+    // Read off the row itself, not off the screen. `getByText(/6/)` asked
+    // whether a 6 was rendered anywhere, which the timestamp beside this row
+    // also answers — so it threw on "found multiple elements" rather than
+    // failing on anything about the count. Asserting the row's whole sentence
+    // is both unambiguous and closer to what the row has to say: the number is
+    // only useful attached to what it counts.
+    expect(screen.getByText(/Nothing relevant/)).toHaveTextContent("Nothing relevant · 6 reviewed");
     expect(screen.queryByText("Nothing new")).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
`main` has been red in both trees on this one test, and not on anything about the count.

```
TestingLibraryElementError: Found multiple elements with the text: /6/
```

`getByText(/6/)` asks whether a 6 was rendered anywhere on the screen. The timestamp beside this row is also a 6, so testing-library throws on the ambiguity rather than reporting a mismatch — the assertion never got as far as checking the count.

Loosening or anchoring the regex would hide it again the next time a number moved. Instead the assertion now reads the row's whole sentence:

```js
expect(screen.getByText(/Nothing relevant/)).toHaveTextContent("Nothing relevant · 6 reviewed");
```

That is unambiguous, and it says more than the original did: the number is only useful attached to what it counts, so checking it lands *in that row* is the thing worth checking.

Proved it still fails on a wrong count before keeping it — swapped the expected 6 for a 7, watched it go red, swapped it back.

**Verification**: 75 files / 546 tests pass, typecheck clean, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)