### PR TITLE
Let a door recognise somebody who is already inside

### DIFF
--- a/src/routes/sign-in.test.tsx
+++ b/src/routes/sign-in.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type React from "react";
+import type { SessionAnswer } from "@/lib/supabase/session";
 
 const navigate = vi.fn();
 
@@ -17,6 +18,9 @@ vi.mock("@/lib/supabase/client", () => ({ supabase: { auth: { signInWithPassword
 const setRemember = vi.fn();
 vi.mock("@/lib/supabase/auth-storage", () => ({ setRemember }));
 
+const readSession = vi.fn<() => Promise<SessionAnswer>>(async () => ({ kind: "none" }));
+vi.mock("@/lib/supabase/session", () => ({ readSession }));
+
 async function renderSignIn() {
   const { Route } = await import("./sign-in");
   const Component = (Route as unknown as { component: () => React.ReactElement }).component;
@@ -29,9 +33,55 @@ async function fillAndSubmit(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("button", { name: /sign in/i }));
 }
 
+describe("the sign-in page when somebody is already signed in", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readSession.mockResolvedValue({ kind: "none" });
+  });
+
+  // The whole of the "it signs me out when I go to the home page" report. The
+  // session was never lost: `/` is a landing page that does not look for one,
+  // so its only button sends a signed-in person here — and this page used to
+  // answer a password prompt, which is indistinguishable from having been
+  // signed out. Nothing was wrong with the session; both doors were just blind.
+  it("lets a held session straight through to the app", async () => {
+    readSession.mockResolvedValue({
+      kind: "session",
+      session: { access_token: "t" } as never,
+    });
+
+    await renderSignIn();
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/app", replace: true }));
+    expect(signInWithPassword).not.toHaveBeenCalled();
+  });
+
+  it("asks for a password when nobody is signed in", async () => {
+    await renderSignIn();
+
+    await waitFor(() => expect(readSession).toHaveBeenCalled());
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+  });
+
+  // The third answer means the lookup could not complete, not that the session
+  // is gone. Forwarding on it would strand somebody on a Loading… screen behind
+  // a network they cannot reach; the form is the useful thing to show instead.
+  it("still offers the form when the lookup could not complete", async () => {
+    readSession.mockResolvedValue({ kind: "unknown" });
+
+    await renderSignIn();
+
+    await waitFor(() => expect(readSession).toHaveBeenCalled());
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+  });
+});
+
 describe("the sign-in page's Remember me box", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    readSession.mockResolvedValue({ kind: "none" });
   });
 
   it("starts checked", async () => {

--- a/src/routes/sign-in.tsx
+++ b/src/routes/sign-in.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { Eye, EyeOff, Lock, Mail } from "lucide-react";
 import { AuthLayout } from "@/components/auth-layout";
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { supabase } from "@/lib/supabase/client";
 import { setRemember } from "@/lib/supabase/auth-storage";
+import { readSession } from "@/lib/supabase/session";
 
 export const Route = createFileRoute("/sign-in")({
   component: SignIn,
@@ -19,6 +20,36 @@ function SignIn() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [remember, setRememberChecked] = useState(true);
+
+  /*
+   * A password prompt is the wrong answer to somebody who is already signed in.
+   *
+   * This page is where every other surface sends people — the landing page's
+   * only button, a bookmark, the link in an invitation — and it used to ask for
+   * a password regardless. That is the whole of the "it signs me out when I go
+   * back to the home page" report: nothing had signed anybody out, the stored
+   * session was sitting untouched in localStorage the entire time, and this
+   * page simply never looked. Being asked to type your password again is
+   * indistinguishable from having been signed out, so it was reported as one.
+   *
+   * Only a definite session forwards. `none` is the normal case and `unknown`
+   * means the lookup could not complete — neither may replace the form, because
+   * a lookup that cannot finish is exactly when somebody needs a way in.
+   */
+  useEffect(() => {
+    let active = true;
+
+    void readSession().then((answer) => {
+      if (!active || answer.kind !== "session") return;
+      // `replace`, so the back button goes wherever they came from rather than
+      // to a sign-in page that will only bounce them here again.
+      navigate({ to: "/app", replace: true });
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [navigate]);
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();

--- a/src/routes/sign-up.test.tsx
+++ b/src/routes/sign-up.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type React from "react";
+import type { SessionAnswer } from "@/lib/supabase/session";
 
 const navigate = vi.fn();
 
@@ -20,6 +21,9 @@ vi.mock("@/lib/legal", () => ({
   privacyLink: () => ({ href: "/privacy", external: false }),
 }));
 
+const readSession = vi.fn<() => Promise<SessionAnswer>>(async () => ({ kind: "none" }));
+vi.mock("@/lib/supabase/session", () => ({ readSession }));
+
 async function renderSignUp() {
   const { Route } = await import("./sign-up");
   const Component = (Route as unknown as { component: () => React.ReactElement }).component;
@@ -35,9 +39,50 @@ async function fillAndSubmit(user: ReturnType<typeof userEvent.setup>, email = "
   await user.click(screen.getByRole("button", { name: /create account/i }));
 }
 
+// The landing page's only button points here, so this is where a signed-in
+// person who typed the bare domain actually ends up. Offering them a form to
+// make a second account is the same bug as the sign-in page's, one door over.
+describe("the sign-up page when somebody is already signed in", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readSession.mockResolvedValue({ kind: "none" });
+  });
+
+  it("lets a held session straight through to the app", async () => {
+    readSession.mockResolvedValue({
+      kind: "session",
+      session: { access_token: "t" } as never,
+    });
+
+    await renderSignUp();
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/app", replace: true }));
+    expect(signUp).not.toHaveBeenCalled();
+  });
+
+  it("offers the form when nobody is signed in", async () => {
+    await renderSignUp();
+
+    await waitFor(() => expect(readSession).toHaveBeenCalled());
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.getByLabelText(/full name/i)).toBeInTheDocument();
+  });
+
+  it("still offers the form when the lookup could not complete", async () => {
+    readSession.mockResolvedValue({ kind: "unknown" });
+
+    await renderSignUp();
+
+    await waitFor(() => expect(readSession).toHaveBeenCalled());
+    expect(navigate).not.toHaveBeenCalled();
+    expect(screen.getByLabelText(/full name/i)).toBeInTheDocument();
+  });
+});
+
 describe("signing up", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    readSession.mockResolvedValue({ kind: "none" });
     signUp.mockResolvedValue({ data: { session: null }, error: null });
   });
 

--- a/src/routes/sign-up.tsx
+++ b/src/routes/sign-up.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useState, type FormEvent, type ReactNode } from "react";
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
 import { Eye, EyeOff, Lock, Mail, User } from "lucide-react";
 import { AuthLayout } from "@/components/auth-layout";
 import { Button } from "@/components/ui/button";
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { supabase } from "@/lib/supabase/client";
+import { readSession } from "@/lib/supabase/session";
 import { privacyLink, termsLink } from "@/lib/legal";
 import { LegalAnchor } from "@/components/legal-anchor";
 
@@ -22,6 +23,29 @@ function SignUp() {
   // The address, not a boolean: "check your email" is advice, and which inbox to
   // check is the part of it that is actually information.
   const [sentTo, setSentTo] = useState<string | null>(null);
+
+  /*
+   * The same door as the sign-in page's, and it needs the same answer.
+   *
+   * "Get started" is the landing page's only call to action, so this is where a
+   * signed-in person who typed the bare domain lands. A blank sign-up form is
+   * the loudest possible way to tell somebody they have been signed out, and
+   * they have not been — see the note on the sign-in page for the report this
+   * closes. Only a definite session forwards; see there for why the other two
+   * answers leave the form alone.
+   */
+  useEffect(() => {
+    let active = true;
+
+    void readSession().then((answer) => {
+      if (!active || answer.kind !== "session") return;
+      navigate({ to: "/app", replace: true });
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [navigate]);
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();


### PR DESCRIPTION
Reported as *"it signs me out when I go back to the home page, and asks me to log in again."*

**Nothing signed anybody out.** Driven in a real browser against the deployed build, the session key was in `localStorage` at every step of the report:

```
1. sign in → /app         session keys on disk: ['sb-…-auth-token']
2. typed the bare domain → /   session keys on disk: ['sb-…-auth-token']
3. → /sign-in             session keys on disk: ['sb-…-auth-token']
```

`/sign-in` and `/sign-up` rendered their forms unconditionally — they never looked for a session. Being asked to type your password again is indistinguishable, from the outside, from having been signed out, so that is how it was reported.

Both now forward a held session to `/app`.

### Only a definite session forwards

`readSession()`'s third answer means the lookup could not complete, and a lookup that cannot finish is exactly when somebody needs a way in. So `unknown` leaves the form alone rather than replacing it with a redirect nobody can complete. `none` is the normal case and is untouched.

### The other half

On the hosted build `/` is the landing page, which had no idea a session existed either — its only call to action said "Get started" and pointed at `/sign-up`. That lives in covan-cloud and ships alongside this.

### Verification

Six new tests, red before the change and green after. End-to-end in a real browser against a mock GoTrue:

| | before | after |
|---|---|---|
| `/` | 8× "Get started", 0 ways in | 8× "Open app" → `/app` |
| `/sign-in` | password form | forwards to `/app` |

Signed-out path re-walked and unchanged: `/` still sells, both forms still open, signing in still works.

Full suite / typecheck / lint clean.

> **Note**: CI on this branch is red until #123 lands — `main` carries an unrelated broken test. Rebase after that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)