### PR TITLE
Give Rolldown's runtime a chunk that cannot import anything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,54 @@ jobs:
         run: bun run test
         working-directory: worker
 
+  self-host:
+    name: The self-host build boots
+    runs-on: ubuntu-latest
+    # The job that would have caught #101 on the day it landed instead of nine
+    # days and 229 commits later.
+    #
+    # Everything else here reads source. This builds the artifact a self-hoster
+    # runs and asks it for four pages, because the bug was in neither the source
+    # nor the tests — it was in how the bundler chunked a graph that every other
+    # check was perfectly happy with. Lint, types, 1,647 unit tests and the RLS
+    # suite were all green the entire time the product answered 500 on every
+    # route it had.
+    #
+    # `node-server` is the preset `Dockerfile.web` sets. The hosted site builds
+    # `cloudflare-module` and was unaffected throughout, which is most of how
+    # this went unnoticed: the deployment anybody was watching was fine.
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Restore the package cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock', 'worker/bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - run: bun install --frozen-lockfile
+
+      - name: Build it the way Dockerfile.web does
+        # Sentinels, for the same reason Dockerfile.web uses them: Vite inlines
+        # VITE_* as literal strings at build time, and nothing here should carry
+        # a real project's values. `.invalid` is reserved by RFC 2606 and can
+        # never resolve, so a page that somehow tried to reach one fails at once
+        # rather than reaching somebody else's server.
+        run: bun run build
+        env:
+          NITRO_PRESET: node-server
+          VITE_SUPABASE_URL: https://covan-ci-supabase-url.invalid
+          VITE_SUPABASE_ANON_KEY: covan-ci-anon-key
+          VITE_API_URL: https://covan-ci-api-url.invalid
+
+      - name: Serve four pages from it
+        run: node scripts/check-self-host.mjs
+
   rls:
     name: Row level security
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "check:rls": "node scripts/check-rls.mjs",
+    "//check:self-host": "Boots the built self-host server and asks it for four pages. Needs a build first: `NITRO_PRESET=node-server bun run build`. Kept separate from `build` so a build failure reads as a build failure. This is the only check that runs the artifact rather than reading the source, which is why it is the only one that could have caught #101.",
+    "check:self-host": "node scripts/check-self-host.mjs",
     "//fonts": "Re-downloads DM Sans and Geist into public/fonts and rewrites src/fonts.css. Not in build or CI on purpose: a build that fetches binaries from a third party is a build that fails when that third party does, and these files change roughly never. Run it on a laptop only when a family or a weight actually does, and commit what it writes.",
     "fonts": "node scripts/fetch-fonts.mjs",
     "format": "prettier --write .",

--- a/scripts/check-self-host.mjs
+++ b/scripts/check-self-host.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Boots the built self-host server and asks it for a few pages.
+ *
+ * This exists because #101 was invisible to everything else we run. Lint,
+ * typecheck, 1,647 unit tests and the RLS suite were all green for nine days
+ * while `.output/server/index.mjs` answered 500 on every route it had. Nothing
+ * was wrong with any source file — the bug lived in how the bundler chunked
+ * them, so the only test that could ever have caught it is one that runs the
+ * artifact. There was no such test. There is now.
+ *
+ * What it does NOT do is build. CI builds in its own step so that a build
+ * failure reads as a build failure, and so this script stays runnable against
+ * an `.output/` you already have:
+ *
+ *   NITRO_PRESET=node-server bun run build
+ *   node scripts/check-self-host.mjs
+ *
+ * `node-server` is the preset `Dockerfile.web` sets, which makes it the one
+ * self-hosters actually run. The hosted site is built with
+ * `cloudflare-module` and was unaffected throughout — checking the wrong one of
+ * those two is most of how this survived as long as it did.
+ *
+ * Dependency-free, like the other scripts here.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const ENTRY = join(root, ".output/server/index.mjs");
+const SSR_DIR = join(root, ".output/server/_ssr");
+
+const PORT = Number(process.env.PORT ?? 3199);
+
+/*
+ * Four pages that render without a database.
+ *
+ * Deliberately not just `/`. The failure this guards against is a module-scope
+ * throw during SSR, which takes down every route at once — but a future one
+ * might not, and a single-route check would then report health it had not
+ * measured. The two legal pages are static, and `/sign-in` is the first page a
+ * new self-hoster sees, so between them they cover the paths somebody hits
+ * before they have any data at all.
+ */
+const ROUTES = ["/", "/privacy", "/terms", "/sign-in"];
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Reports import cycles between the emitted SSR chunks.
+ *
+ * Only ever called when something has already failed, and only to explain it.
+ * It is not an assertion: plenty of module cycles are harmless, and ESM is
+ * specified to handle them. The one in #101 was fatal for a narrower reason —
+ * the value crossing the back-edge was a `var` read during module evaluation,
+ * so whichever side ran second saw it hoisted and still `undefined`.
+ *
+ * Printing the cycle turns "TypeError: __exportAll is not a function" from a
+ * mystery into a diagnosis, which is the difference between an afternoon and
+ * ten minutes for whoever meets this next.
+ */
+function cyclesBetweenChunks() {
+  if (!existsSync(SSR_DIR)) return [];
+
+  const imports = new Map();
+  for (const file of readdirSync(SSR_DIR).filter((f) => f.endsWith(".mjs"))) {
+    const source = readFileSync(join(SSR_DIR, file), "utf8");
+    const targets = [...source.matchAll(/from\s*"\.\/([^"]+\.mjs)"/g)].map((m) => m[1]);
+    imports.set(file, new Set(targets));
+  }
+
+  const found = [];
+  for (const [file, targets] of imports) {
+    for (const target of targets) {
+      // Report each pair once: a↔b and b↔a are the same cycle.
+      if (file < target && imports.get(target)?.has(file)) found.push(`${file} ↔ ${target}`);
+    }
+  }
+  return found;
+}
+
+async function probe(path) {
+  const response = await fetch(`http://127.0.0.1:${PORT}${path}`, { redirect: "manual" });
+  return response.status;
+}
+
+/** Resolves once the server answers at all, whatever it answers. */
+async function waitForListening() {
+  for (let waited = 0; waited < 30_000; waited += 250) {
+    await wait(250);
+    try {
+      await probe("/");
+      return true;
+    } catch {
+      // Connection refused: still starting.
+    }
+  }
+  return false;
+}
+
+if (!existsSync(ENTRY)) {
+  console.error(
+    `✗ ${ENTRY} does not exist.\n` + `  Build first:  NITRO_PRESET=node-server bun run build`,
+  );
+  process.exit(1);
+}
+
+const server = spawn(process.execPath, [ENTRY], {
+  cwd: root,
+  env: { ...process.env, PORT: String(PORT) },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+/*
+ * Kept rather than streamed. A module-scope throw is printed by the server the
+ * first time a request reaches it, and that text is the single most useful
+ * thing to show when this fails — but printing it during a passing run would
+ * bury the result in noise.
+ */
+let serverOutput = "";
+server.stdout.on("data", (chunk) => (serverOutput += chunk));
+server.stderr.on("data", (chunk) => (serverOutput += chunk));
+
+let failed = false;
+try {
+  if (!(await waitForListening())) {
+    console.error(`✗ the server never listened on ${PORT} within 30s`);
+    failed = true;
+  } else {
+    for (const route of ROUTES) {
+      const status = await probe(route);
+      const ok = status >= 200 && status < 400;
+      console.log(`${ok ? "✓" : "✗"} ${String(status)}  ${route}`);
+      if (!ok) failed = true;
+    }
+  }
+} finally {
+  server.kill("SIGKILL");
+}
+
+if (failed) {
+  console.error("\n--- what the server said ---");
+  console.error(serverOutput.trim() || "(nothing)");
+
+  const cycles = cyclesBetweenChunks();
+  if (cycles.length > 0) {
+    console.error(
+      "\n--- circular imports between SSR chunks ---\n" +
+        cycles.map((c) => `  ${c}`).join("\n") +
+        "\n\n" +
+        "  A cycle is not automatically a bug, but it is how #101 failed: a\n" +
+        "  helper crossing the back-edge was read during module evaluation,\n" +
+        "  while it was hoisted and still undefined. If the error above is\n" +
+        '  "X is not a function" and X is defined in one of the files named\n' +
+        "  here, that is the same shape. See the rolldownConfig comment in\n" +
+        "  vite.config.ts.",
+    );
+  }
+  process.exit(1);
+}
+
+console.log(`\n✓ the self-host build serves ${ROUTES.length} routes`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,50 @@ export default defineConfig(({ command }) => ({
     }),
     // Nitro turns the SSR build into a deployable server. It is build-only:
     // in dev, Vite serves SSR itself and adding nitro here would fight it.
-    ...(command === "build" ? [nitro({ defaultPreset: "node-server" })] : []),
+    ...(command === "build"
+      ? [
+          nitro({
+            defaultPreset: "node-server",
+            // Pins Rolldown's own runtime helpers to a chunk of their own.
+            //
+            // This is not a size or caching tweak. Without it the build emits
+            // a server that throws `__exportAll is not a function` on every
+            // request — see #101, which is what nine days of a dead self-host
+            // build cost before anyone traced it.
+            //
+            // There are two Rolldown passes here, and only the second one is
+            // wrong. Vite's SSR build already gets this right: it emits
+            // `rolldown-runtime-*.js` as its own 360-byte chunk with no
+            // imports at all. Nitro then re-chunks that output into
+            // `.output/server/_ssr/`, and it is that pass which merged the
+            // runtime helper into a chunk that also re-exported the server
+            // entry's namespace. That chunk therefore imported the big server
+            // chunk, while the big server chunk imported `__exportAll` back
+            // out of it — a cycle. `__exportAll` is a `var`, so whichever side
+            // Node evaluates second finds it hoisted and still `undefined`.
+            // Hence a TypeError rather than a resolution failure, which is why
+            // grepping for a missing file turns up nothing.
+            //
+            // A group with nothing else in it cannot import anything, so the
+            // back-edge has nowhere to attach and the cycle cannot form.
+            //
+            // Nothing in our source is at fault, and that is the point worth
+            // keeping: #101 bisected to `0f8c46e`, a commit about telling a
+            // dead session apart from an unreachable one, which touches no
+            // build configuration whatsoever. It merely moved the module graph
+            // enough to tip the chunker over. Any commit could do that again,
+            // in either direction, which is why the fix belongs here and not in
+            // whatever module happens to be holding the graph today.
+            rolldownConfig: {
+              output: {
+                codeSplitting: {
+                  groups: [{ name: "rolldown-runtime", test: /rolldown-runtime/ }],
+                },
+              },
+            },
+          }),
+        ]
+      : []),
     viteReact(),
   ],
   resolve: {


### PR DESCRIPTION
Closes #101.

Every route of the self-host build has answered 500 for nine days with `TypeError: __exportAll is not a function`.

## Root cause

There are **two** Rolldown passes here, and only the second is wrong.

Vite's SSR build already gets it right — it emits `rolldown-runtime-*.js` as its own 360-byte chunk with no imports at all:

```js
var __exportAll = (all, no_symbols) => { /* … */ };
export { __exportAll as t };
```

Nitro then re-chunks that output into `.output/server/_ssr/`, and **that** pass merged the runtime helper into a chunk which also re-exported the server entry's namespace:

| file | size | contents |
| --- | --- | --- |
| `_ssr/server-X.mjs` | 495 B | the runtime helper **and** `export { server_exports }` — so it imports the big chunk |
| `_ssr/server-X2.mjs` | 61 KB | `import { n as __exportAll } from "./server-X.mjs"` |

Each imports the other. `__exportAll` is a `var`, initialised during module evaluation, so whichever side Node evaluates second reaches it while it is hoisted and still `undefined`. That is why the failure is a `TypeError` and not a resolution error — and why grepping for a missing file turns up nothing.

A group with nothing else in it has nothing to import, so the back-edge has nowhere to attach. After the fix the helper lands in `_runtime2.mjs`: **zero imports, a true leaf.**

## Nothing in this repository was at fault

Bisected across all 229 commits since `v0.1.0` to **`0f8c46e`** — *"Tell 'nobody is signed in' apart from 'could not tell'"*. It touches ten source files and **no build configuration whatsoever**. It simply moved the module graph enough to tip the chunker over.

Any commit could do that again, in either direction. That is the argument for fixing it at the chunking layer rather than in whichever module happens to be holding the graph today.

Upstream may also have moved — we are on rolldown 1.1.0 and 1.2.8 exists — but vite 8.3.0 is blocked by this repo's own 24-hour `minimum-release-age` guard, correctly. This fix does not depend on that landing.

## The other half: why nothing caught it

**CI never built the frontend at all.** Lint, types, 1,647 unit tests and the RLS suite were green the entire nine days. The bug was in neither the source nor the tests, so no amount of either would have found it.

`scripts/check-self-host.mjs` boots the built artifact and asks it for four pages, wired up as a new `The self-host build boots` job. On failure it prints what the server said *and* any import cycles between the emitted chunks, so the next person gets a diagnosis instead of a mystery.

Verified the way a regression test has to be:

- **without** the fix → fails, naming `server-X.mjs ↔ server-X2.mjs`
- **with** the fix → `✓ 200` on `/`, `/privacy`, `/terms`, `/sign-in`

One benign cycle (`router ↔ router2`) survives and the build serves fine, which is exactly why the script *reports* cycles rather than asserting there are none.

## Blast radius

The hosted site was never affected — it builds `cloudflare-module`, a different artifact. That is most of how this lasted as long as it did: the deployment anybody was watching was fine. Rebuilt with that preset to confirm this change is safe there too.

`eslint` 0 errors · `tsc --noEmit` clean · 556 frontend + 1,091 worker tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)