### PR TITLE
Let a tick that cannot sync claim nothing, instead of pausing everyone

### DIFF
--- a/worker/src/lib/background.test.ts
+++ b/worker/src/lib/background.test.ts
@@ -19,7 +19,15 @@ const base = {
   ALLOWED_ORIGIN: "https://app.example.com",
 };
 
-const withStore = { ...base, DOCS_DIR: "/tmp/docs" };
+/** A document store but no OAuth credentials: can write, cannot authenticate. */
+const storeOnly = { ...base, DOCS_DIR: "/tmp/docs" };
+
+/** Everything a sync needs. Both halves, which is the point. */
+const withStore = {
+  ...storeOnly,
+  NOTION_CLIENT_ID: "notion-client",
+  NOTION_CLIENT_SECRET: "notion-secret",
+};
 
 describe("runScheduledWork", () => {
   beforeEach(() => {
@@ -60,6 +68,44 @@ describe("runScheduledWork", () => {
     expect(runDueConnections).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("DOCS or DOCS_DIR"));
     warn.mockRestore();
+  });
+
+  // The hazard this guards, stated as the thing that must not happen: claiming.
+  //
+  // A Worker with somewhere to write but no way to authenticate reaches
+  // `sync.ts`, fails `isConfigured` there, and that path does not skip — it
+  // PAUSES the connection and tells the person an operator has to set the
+  // client credentials. So one deploy of the engine with the storage binding
+  // and without the secrets would pause every connection in every workspace.
+  //
+  // Nothing downstream can tell that apart from a deployment that genuinely
+  // dropped the provider, which is precisely why the decision has to be made
+  // here, where "this Worker" and "this deployment" are still distinguishable.
+  it("claims nothing when no source has its client credentials on this Worker", async () => {
+    runDueRoutines.mockResolvedValue({ claimed: 0, ok: 0, failed: 0 });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await runScheduledWork(storeOnly);
+
+    expect(runDueConnections).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("NOTION_CLIENT_ID"));
+    warn.mockRestore();
+  });
+
+  // One is enough to be worth a tick. The provider that is not configured is
+  // handled per connection downstream; what must not happen is the whole tick
+  // standing down because the *other* source is missing.
+  it("syncs when one source is configured and the other is not", async () => {
+    runDueRoutines.mockResolvedValue({ claimed: 0, ok: 0, failed: 0 });
+    const onlyGoogle = {
+      ...storeOnly,
+      GOOGLE_CLIENT_ID: "google-client",
+      GOOGLE_CLIENT_SECRET: "google-secret",
+    };
+
+    await runScheduledWork(onlyGoogle);
+
+    expect(runDueConnections).toHaveBeenCalledWith(onlyGoogle);
   });
 
   it("propagates a routine failure rather than carrying on to the connections", async () => {

--- a/worker/src/lib/background.ts
+++ b/worker/src/lib/background.ts
@@ -2,6 +2,7 @@ import type { RoutineEnv } from "./../types";
 import { canSyncConnections } from "./../types";
 import { runDueRoutines } from "./routines/dispatcher";
 import { runDueConnections } from "./connections/dispatcher";
+import { PROVIDERS } from "./connections/registry";
 
 /**
  * One scheduled tick, for both Workers that have one.
@@ -40,6 +41,34 @@ export async function runScheduledWork(env: RoutineEnv): Promise<void> {
     // finds the answer in `wrangler tail` rather than in the database.
     console.warn(
       "connections not synced: this Worker has no document storage bound (DOCS or DOCS_DIR)",
+    );
+    return;
+  }
+
+  // The same question again, about the other half of what a sync needs — and it
+  // has to be asked *here*, before anything is claimed, because of what happens
+  // downstream if it is not.
+  //
+  // `sync.ts` also checks `isConfigured`, and when it fails there the
+  // connection is **paused**, with a message telling the person an operator has
+  // to set the client credentials. That is the right answer to the question it
+  // thinks it is answering — "this deployment stopped offering Notion" — and
+  // the wrong answer to the one that actually arises here: "this *Worker* was
+  // deployed without credentials the deployment does have". The two are
+  // indistinguishable from inside a single env, and they are not equally
+  // costly. Guessing "removed" when the truth is "not on this Worker" pauses
+  // every connection in every workspace and blames the operator for it;
+  // guessing the other way leaves a source a little stale.
+  //
+  // So a Worker that cannot configure any provider claims nothing at all, and
+  // says why, exactly as it does for the document store above. A deployment
+  // that really has removed a provider still tells people so, in the place that
+  // is designed to say it — the Integrations page lists an unconfigured source
+  // with the variables that would turn it on, rather than hiding it.
+  if (!PROVIDERS.some((provider) => provider.isConfigured(env))) {
+    console.warn(
+      "connections not synced: no source has its OAuth client credentials on this Worker " +
+        "(NOTION_CLIENT_ID/NOTION_CLIENT_SECRET, GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET)",
     );
     return;
   }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -100,10 +100,16 @@ export type RoutineEnv = {
  * A sync writes documents: it embeds text and puts bytes in the document store,
  * so it needs the embedding configuration and one of the two storage bindings —
  * neither of which the routine engine has ever touched. Naming that as its own
- * type is what lets `cron.ts` stay honest. That Worker is deployed to a second
- * Cloudflare account with `RoutineEnv` and nothing else; it can now be given
- * these bindings as well, and `canSyncConnections` below is how it asks whether
- * it was, rather than claiming them in a type and finding out in production.
+ * type is what lets `cron.ts` stay honest: it is deployed with `RoutineEnv` and
+ * may or may not have been given the rest, so it asks rather than claiming them
+ * in a type and finding out in production.
+ *
+ * The storage binding is what `canSyncConnections` tests, but it is not the
+ * whole of what a sync needs — the OAuth client credentials below are the other
+ * half, and a Worker holding one without the other is the dangerous
+ * combination rather than the harmless one. `lib/background` checks for both
+ * before a tick claims anything, and the comment there says what goes wrong if
+ * it does not.
  */
 export type SyncEnv = RoutineEnv & {
   /**

--- a/worker/wrangler.cron.toml.example
+++ b/worker/wrangler.cron.toml.example
@@ -23,16 +23,38 @@
 #   RESEND_API_KEY
 #   RESEND_FROM
 #
-# Not set here, deliberately: SUPABASE_ANON_KEY (no user-scoped access — this
-# Worker only ever uses the service role) and the DOCS R2 binding.
+# Not set here, deliberately: SUPABASE_ANON_KEY. This Worker only ever uses the
+# service role, so a user-scoped key would be a credential with no caller.
 #
-# That bucket is the reason connected sources do NOT sync from this Worker. A
-# sync writes documents, and the bucket belongs to the API Worker's account —
-# which is the account this file exists to escape. `lib/background` checks for a
-# document store before it tries, so a tick here delivers routines and logs one
-# line saying connections were skipped, instead of failing them all. To sync
-# Notion and Drive on Cloudflare, put a cron trigger on the API Worker itself;
-# wrangler.toml.example says so where the trigger would go.
+# ---- Syncing connected sources from this Worker ----------------------------
+#
+# Off by default, and turning it on is two things that must happen in this
+# order. Doing the second without the first is worse than leaving it off.
+#
+# 1. The four OAuth client secrets, the same way as the ones above:
+#      NOTION_CLIENT_ID / NOTION_CLIENT_SECRET
+#      GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET
+#    Only the pairs you actually offer. A sync re-reads the source with the
+#    person's stored token, and Google's access tokens last an hour — refreshing
+#    one needs the client secret, so a Worker without it cannot sync Drive even
+#    though the connection is perfectly good.
+#
+# 2. The DOCS binding below, uncommented. A sync writes documents, and this is
+#    where they go. It only works if this Worker is on the same account as the
+#    bucket — an R2 binding cannot cross accounts — so an engine you moved to a
+#    second account to escape the five-cron cap cannot have it at all. In that
+#    case leave both off and put the cron trigger on the API Worker instead;
+#    wrangler.toml.example says so where the trigger would go.
+#
+# The order matters because of what the two halves do when they are missing.
+# `lib/background` checks for both before it claims anything, and skips with one
+# log line if either is absent — so all-off and half-off are both safe. What it
+# is protecting against is further down: `lib/connections/sync` treats a
+# provider without credentials as a provider the deployment has *removed*, and
+# pauses the connection with a message telling the person to go and ask an
+# operator. A Worker given storage but not secrets would reach that path for
+# every connection in every workspace. The guard means it no longer can, and
+# the ordering above means you never find out whether the guard works.
 
 name = "covan-routines"
 main = "src/cron.ts"
@@ -63,9 +85,22 @@ ALLOWED_ORIGIN = "https://your-app.example.com"
 # OPENAI_BASE_URL = "https://openrouter.ai/api/v1"
 # OPENAI_MODEL = "meta-llama/llama-3.3-70b-instruct"
 
+# Where a sync puts the documents it reads. Step 2 of the header's two, and the
+# one to uncomment second — the same bucket name as wrangler.toml, since both
+# Workers must read and write the same documents. Leave commented to keep this
+# Worker on routines only.
+# [[r2_buckets]]
+# binding = "DOCS"
+# bucket_name = "covan-docs"
+
 # The engine's heartbeat. It only asks "is anything due?" — each routine's own
 # frequency lives in routines.next_run_at, so "every 15 minutes" and "Mondays at
 # 09:00" both run off this one trigger.
+#
+# It is also what makes syncing from here worth setting up. A connection claimed
+# on this trigger is re-read within minutes; the alternative in the header — a
+# cron on the API Worker — shares that Worker's schedule, which exists for the
+# nightly purge and so refreshes a source about once a day.
 [triggers]
 crons = ["*/5 * * * *"]
 


### PR DESCRIPTION
A Worker with somewhere to write and no way to authenticate was the one combination that did damage. Found while measuring covan-cloud#160, where the obvious fix — bind the document store to the five-minute engine — turns out to be the trigger.

## What goes wrong

`lib/background` checked for the document store before claiming, and skipped politely without it. It did not check the other half.

A sync also needs the OAuth client credentials. Google's access tokens last an hour, and refreshing one needs `GOOGLE_CLIENT_SECRET` — so a Worker without it cannot sync Drive even though the connection is perfectly good. Such a Worker sails past this file, claims a connection, and reaches `isConfigured` in `lib/connections/sync`:

```js
if (!provider.isConfigured(deps.env)) {
  return finish(connection, deps, startedAt, {
    status: "failed",
    pause: `${provider.label} is not configured on this Covan any more. An operator has to set its client credentials before this connection can resume.`,
  });
}
```

That path does not skip. It **pauses** the connection and blames the operator, in front of the person who connected it.

## Why the fix is here and not there

`sync.ts` is answering *"this deployment stopped offering Notion"*, and for that question pausing is right. The question that actually arises is *"this **Worker** was deployed without credentials the deployment does have"*.

From inside a single `env` those are indistinguishable — and nowhere near equally expensive:

| guess | when it is wrong | cost |
| --- | --- | --- |
| "removed" | credentials are on the API Worker | every connection in every workspace paused |
| "not here" | operator really did drop the provider | a source goes stale |

So the decision moves up to the one place where "this Worker" and "this deployment" are still different things. A tick that cannot configure any provider claims nothing and says why — exactly as it already did for storage.

Nothing is lost for the genuine case: a deployment that really has dropped a provider still says so where it is designed to, on the Integrations page, which lists an unconfigured source with the variables that would turn it on rather than hiding it.

## Tests

The new test uses the **identical env** the old `withStore` did — document store, no credentials — and asserts the opposite outcome, so it fails by construction without this change. Plus one that a tick still runs when only one of the two sources is configured, because standing the whole tick down for the *other* provider would be the opposite mistake.

`worker`: 89 files, **1,093 passed** (was 1,091). `eslint` 0 errors, both `tsc --noEmit` clean.

## Template

`wrangler.cron.toml.example` gains the `DOCS` binding, commented out, plus the ordering that matters: **secrets first, storage second.** Half-configured is safe now — that is what this commit buys — and the documented order means nobody has to find out whether the guard works. It also notes the constraint the old comment was really about: an R2 binding cannot cross accounts, so an engine moved to a second account to escape the five-cron cap cannot have one at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)