### PR TITLE
Stop buying the unchanged half of every prompt twice

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,7 +178,7 @@ rather than letting Postgres refuse the insert later. See
    Names alone, on the hot path — the stored full text is only needed by the
    fallback below, so it is loaded lazily there rather than on every turn.
 2. Embed the latest user message and call `match_chunks(p_agent_id,
-   p_query_embedding, p_match_count => 6, p_min_similarity => 0.25)`.
+   p_query_embedding, p_match_count => 10, p_min_similarity => 0.25)`.
 3. `match_chunks` (`0005_message_sources_and_match_threshold.sql`) is
    `SECURITY INVOKER`, so RLS on `document_chunks` and `documents` still applies.
    It computes `1 - (embedding <=> query)` as cosine similarity, keeps only rows
@@ -186,7 +186,7 @@ rather than letting Postgres refuse the insert later. See
    agent, orders by distance and takes the top *n*.
 
    The floor is the interesting part. Without it, an off-topic question still
-   returns the six nearest chunks — nearest is not the same as relevant — and
+   returns the ten nearest chunks — nearest is not the same as relevant — and
    those get injected into the prompt as though they were evidence. The SQL
    default is `0` for backward compatibility; the API passes `0.25`.
 4. Matching chunks are assembled by `buildContextBlock` (`lib/rag.ts`) under a

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -200,13 +200,18 @@ a best-effort attempt on the stored bytes.
 ## What happens when somebody asks a question
 
 Each turn starts by embedding the message that was just sent, with the same model
-the chunks were embedded with, and asking the database for the six nearest chunks
+the chunks were embedded with, and asking the database for the ten nearest chunks
 across the attached bundles whose cosine similarity is at or above 0.25.
+
+Ten are asked for and fewer are sent: a passage already contained in one further
+up the list is dropped rather than repeated — the same document reached through
+two bundles is chunked once per bundle, so the same words can come back twice —
+and the 4000-character budget below decides how many of the rest fit.
 
 The floor is what makes a wrong answer less likely than a coy one. Vector search
 always returns something — ask an agent that only knows the deployment runbook
 about somebody's holiday plans and there is still a nearest chunk. Without a
-floor those six chunks are handed to the model inside a block that says the team
+floor those chunks are handed to the model inside a block that says the team
 has shared this knowledge, which is a claim about relevance that nobody checked.
 The floor drops them instead. `text-embedding-3-small` puts genuinely on-topic
 content well above 0.25 and clearly unrelated content below it, so the effect in
@@ -286,7 +291,7 @@ answer.
 Read them as what was in scope, not as what the model saw, because the two are
 not the same list. The names are collected from every match — and on the fallback
 path from every document that had any text — before the 4000-character budget is
-applied, and the budget is easy to overrun: six chunks of up to 1000 characters
+applied, and the budget is easy to overrun: ten chunks of up to 1000 characters
 each go past it, and on the fallback path a single 8000-character excerpt fills
 it twice over on its own, leaving every document listed after it contributing
 nothing at all. Those documents are still named underneath the answer.

--- a/docs/team.md
+++ b/docs/team.md
@@ -321,8 +321,9 @@ written; it is only whose key is billed. Known, and not yet fixed.
 The figures also now account for prompt caching. Most of what Covan sends the
 model on any given turn is the same bytes as last turn — the persona, the
 document manifest, the conversation so far — so `chat.ts` assembles the prompt
-with that stable part first and the retrieved knowledge after it, and OpenAI
-serves the repeat at a reduced rate. The share that came from the cache is
+with that stable part first and the retrieved knowledge after it, and both
+providers serve the repeat at a reduced rate — OpenAI automatically, Anthropic
+only when the request says so, which it now does. The share that came from the cache is
 recorded per reply and priced accordingly, which makes the estimate lower and
 truer than it was, and makes a change that quietly breaks the arrangement
 visible instead of merely expensive.

--- a/worker/src/lib/completion.test.ts
+++ b/worker/src/lib/completion.test.ts
@@ -118,6 +118,42 @@ describe("toAnthropicMessages", () => {
       complete(env, { model: "claude-haiku-4-5", messages: [{ role: "system", content: "Hi" }] }),
     ).rejects.toThrow(/at least one user message/);
   });
+
+  it("puts the cache breakpoint on the last turn before the retrieved block", () => {
+    // Everything up to and including that turn repeats verbatim next turn. The
+    // block after it does not, which is why it is the boundary.
+    const { cacheIndex } = toAnthropicMessages([
+      { role: "system", content: "You are Ada." },
+      { role: "user", content: "What does the handbook say?" },
+      { role: "assistant", content: "Tuesdays." },
+      { role: "system", content: "KNOWLEDGE: the handbook says Tuesdays." },
+      { role: "user", content: "And Wednesdays?" },
+    ]);
+
+    expect(cacheIndex).toBe(1);
+  });
+
+  it("falls back to the turn before the question when retrieval found nothing", () => {
+    const { cacheIndex } = toAnthropicMessages([
+      { role: "system", content: "You are Ada." },
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi." },
+      { role: "user", content: "How are you?" },
+    ]);
+
+    expect(cacheIndex).toBe(1);
+  });
+
+  it("marks nothing when the only turn is the question itself", () => {
+    // There is no history to cache yet, and marking the question would ask the
+    // provider to cache the one part of the prompt that is different every time.
+    const { cacheIndex } = toAnthropicMessages([
+      { role: "system", content: "You are Ada." },
+      { role: "user", content: "Hello" },
+    ]);
+
+    expect(cacheIndex).toBeNull();
+  });
 });
 
 describe("extractJsonObject", () => {
@@ -259,9 +295,43 @@ describe("complete, on Anthropic", () => {
     expect(text).toBe("an answer");
     const call = anthropicCreate.mock.calls[0][0];
     expect(call.model).toBe("claude-sonnet-4-5");
-    expect(call.system).toBe("You are Ada.");
+    // A block rather than a string, because that is the only shape a cache
+    // breakpoint can ride on — see the cache tests below.
+    expect(call.system).toEqual([
+      { type: "text", text: "You are Ada.", cache_control: { type: "ephemeral" } },
+    ]);
     expect(call.messages).toEqual([{ role: "user", content: "Hello" }]);
     expect(call.max_tokens).toBe(DEFAULT_MAX_TOKENS);
+  });
+
+  it("asks for the repeated half of the prompt to be cached", async () => {
+    // The saving this earns was already priced in lib/pricing.ts and already
+    // read back by anthropicUsage; the number was zero because nothing on the
+    // wire ever asked for it.
+    await complete(env, {
+      model: "claude-sonnet-4-6",
+      messages: [
+        { role: "system", content: "You are Ada." },
+        { role: "user", content: "What does the handbook say?" },
+        { role: "assistant", content: "Tuesdays." },
+        { role: "system", content: "KNOWLEDGE: the handbook says Tuesdays." },
+        { role: "user", content: "And Wednesdays?" },
+      ],
+    });
+
+    const call = anthropicCreate.mock.calls[0][0];
+    expect(call.system[0].cache_control).toEqual({ type: "ephemeral" });
+    // The assistant turn that closes the stable history, not the knowledge
+    // block and not the new question.
+    expect(call.messages[1]).toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "Tuesdays.", cache_control: { type: "ephemeral" } }],
+    });
+    expect(call.messages[2]).toEqual({
+      role: "user",
+      content: "KNOWLEDGE: the handbook says Tuesdays.",
+    });
+    expect(call.messages[3]).toEqual({ role: "user", content: "And Wednesdays?" });
   });
 
   it("honours a ceiling the caller did name", async () => {
@@ -289,8 +359,8 @@ describe("complete, on Anthropic", () => {
     });
 
     const call = anthropicCreate.mock.calls[0][0];
-    expect(call.system).toContain("Draft a persona.");
-    expect(call.system).toContain("single JSON object");
+    expect(call.system[0].text).toContain("Draft a persona.");
+    expect(call.system[0].text).toContain("single JSON object");
     expect(call).not.toHaveProperty("response_format");
     // The fence is stripped here rather than downstream: every caller does a
     // bare JSON.parse and reports a throw to the user as "the model failed".

--- a/worker/src/lib/completion.ts
+++ b/worker/src/lib/completion.ts
@@ -178,20 +178,32 @@ function openaiParams(req: CompletionRequest): OpenAI.Chat.Completions.ChatCompl
  * - **The first turn must be a user turn.** History trimming can leave an
  *   assistant message first; OpenAI accepts that and Anthropic returns a 400.
  *   Leading assistant turns are dropped rather than sent.
+ *
+ * `cacheIndex` is the third return value and the reason this function reports
+ * more than it used to — see `CACHE_CONTROL` below for what it is for.
  */
 export function toAnthropicMessages(messages: CompletionMessage[]): {
   system: string;
   messages: Anthropic.MessageParam[];
+  cacheIndex: number | null;
 } {
   const systemParts: string[] = [];
   const out: Anthropic.MessageParam[] = [];
+  // Where the stable half of the conversation ends: the last turn pushed before
+  // the first mid-conversation system message, which is the volatile retrieved
+  // block. Null until one is seen, and resolved below for the callers that send
+  // no block at all.
+  let stableThrough: number | null = null;
 
   for (const message of messages) {
     const content = message.content?.trim();
     if (!content) continue;
     if (message.role === "system") {
       if (out.length === 0) systemParts.push(content);
-      else out.push({ role: "user", content });
+      else {
+        if (stableThrough === null) stableThrough = out.length - 1;
+        out.push({ role: "user", content });
+      }
       continue;
     }
     // Nothing to answer yet, so an assistant turn here is history that lost its
@@ -200,7 +212,52 @@ export function toAnthropicMessages(messages: CompletionMessage[]): {
     out.push({ role: message.role, content });
   }
 
-  return { system: systemParts.join("\n\n"), messages: out };
+  // No retrieved block on this turn, so the volatile tail is the question alone
+  // and everything before it is the history that repeats.
+  if (stableThrough === null) stableThrough = out.length - 2;
+
+  return {
+    system: systemParts.join("\n\n"),
+    messages: out,
+    cacheIndex: stableThrough >= 0 ? stableThrough : null,
+  };
+}
+
+/**
+ * The marker that makes Anthropic bill a repeated prefix at a tenth of its
+ * price, and the thing this file did not send for as long as Claude has been
+ * offered here.
+ *
+ * Two breakpoints, because the prompt has two stable regions and one volatile
+ * one between them:
+ *
+ * 1. **The system block.** `buildSystemPrefix` exists to be byte-identical turn
+ *    over turn — that is why the retrieved knowledge is a separate message and
+ *    not part of the persona. The whole persona, concision block and document
+ *    manifest therefore repeat exactly, every turn, for the life of a chat.
+ * 2. **The last turn before the retrieved block.** History repeats too: turn
+ *    twelve re-sends the eleven turns before it verbatim. Marking the end of
+ *    that run caches the system block *and* the conversation, leaving only the
+ *    excerpts and the new question to pay full price.
+ *
+ * Both were already true before this marker existed, which is the point:
+ * `lib/pricing.ts` has priced a 10x cache discount since Claude was added,
+ * `anthropicUsage` has read `cache_read_input_tokens` since then too, and the
+ * number it read was always zero. Nothing about the prompt had to change to
+ * earn it — only saying so on the wire.
+ *
+ * A prefix shorter than the model's minimum (1024 tokens, 2048 on Haiku) is not
+ * cached and the request is not refused; a short chat simply pays what it pays
+ * today.
+ */
+const CACHE_CONTROL = { type: "ephemeral" as const };
+
+function withCacheBreakpoint(message: Anthropic.MessageParam): Anthropic.MessageParam {
+  if (typeof message.content !== "string") return message;
+  return {
+    role: message.role,
+    content: [{ type: "text", text: message.content, cache_control: CACHE_CONTROL }],
+  };
 }
 
 // Without `stream`, so the two call sites below can each add their own and get
@@ -208,16 +265,21 @@ export function toAnthropicMessages(messages: CompletionMessage[]): {
 function anthropicParams(
   req: CompletionRequest,
 ): Omit<Anthropic.MessageCreateParamsNonStreaming, "stream"> {
-  const { system, messages } = toAnthropicMessages(req.messages);
+  const { system, messages, cacheIndex } = toAnthropicMessages(req.messages);
   if (messages.length === 0) {
     throw new Error("a completion needs at least one user message");
   }
   const systemText = [system, req.json ? JSON_ONLY_INSTRUCTION : ""].filter(Boolean).join("\n\n");
   return {
     model: req.model,
-    messages,
+    messages:
+      cacheIndex === null
+        ? messages
+        : messages.map((m, i) => (i === cacheIndex ? withCacheBreakpoint(m) : m)),
     max_tokens: req.maxTokens ?? DEFAULT_MAX_TOKENS,
-    ...(systemText ? { system: systemText } : {}),
+    ...(systemText
+      ? { system: [{ type: "text" as const, text: systemText, cache_control: CACHE_CONTROL }] }
+      : {}),
     ...(req.temperature !== undefined && acceptsTemperature(req.model)
       ? { temperature: req.temperature }
       : {}),

--- a/worker/src/lib/models.test.ts
+++ b/worker/src/lib/models.test.ts
@@ -5,6 +5,7 @@ import {
   acceptsTemperature,
   availableModels,
   modelSpec,
+  titleModelFor,
   DEFAULT_MODEL,
   MODEL_IDS,
 } from "./models";
@@ -121,5 +122,33 @@ describe("resolveModel", () => {
       // from ever addressing api.anthropic.com.
       expect(resolveModel("claude-sonnet-4-6", env)).toBe("llama3.3:70b");
     });
+  });
+});
+
+describe("titleModelFor", () => {
+  it("names a conversation on the cheapest model of the same provider", () => {
+    expect(titleModelFor("gpt-4o")).toBe("gpt-4o-mini");
+    expect(titleModelFor("claude-sonnet-4-6")).toBe("claude-haiku-4-5");
+  });
+
+  it("never crosses providers, whichever way round", () => {
+    // A workspace can have one key and not the other. Titling a Claude agent on
+    // an OpenAI id would send that user's first message somewhere their
+    // deployment may have deliberately not enabled — and fail outright where
+    // the key simply is not set.
+    expect(titleModelFor("claude-haiku-4-5")).toBe("claude-haiku-4-5");
+    expect(titleModelFor("gpt-4o-mini")).toBe("gpt-4o-mini");
+    expect(titleModelFor("gpt-5-nano")).toBe("gpt-4o-mini");
+  });
+
+  it("leaves an id this build does not know alone", () => {
+    // Under OPENAI_BASE_URL the catalogue is somebody else's. gpt-4o-mini is a
+    // name that endpoint has probably never heard of, and a 404 would turn a
+    // free convenience into a broken reply.
+    expect(titleModelFor("llama3.3:70b")).toBe("llama3.3:70b");
+  });
+
+  it("defers to OPENAI_MODEL, which is the operator naming their own model", () => {
+    expect(titleModelFor("gpt-4o", { OPENAI_MODEL: "llama3.3:70b" })).toBe("gpt-4o");
   });
 });

--- a/worker/src/lib/models.ts
+++ b/worker/src/lib/models.ts
@@ -172,6 +172,41 @@ export function availableModels(env?: ModelEnv): ModelId[] {
  * to rule 2 — the conversation stays on their endpoint. Setting the key is the
  * act that opts a deployment into sending anything to Anthropic.
  */
+/**
+ * The cheapest model of the same provider, for work that is shaping rather than
+ * thinking.
+ *
+ * Naming a conversation is five words long and reads one message. It was being
+ * asked of whatever the agent runs on, so a `claude-sonnet-4-6` agent paid
+ * flagship input *and* output rates to write "Invoice numbering question", once
+ * per new chat, forever. Nothing about the title got better for it:
+ * `session-title.ts` already caps the reply at 64 tokens, already asks for
+ * minimal effort, and already treats every failure as "keep the name you had".
+ *
+ * The same is true of the other two shaping callers — the persona drafter and
+ * the idea extractor — but those are one-off actions somebody pressed a button
+ * for. Titling is the one that fires on its own, on every new session, on the
+ * hot path of the product's main screen, which is what makes it worth a rule.
+ *
+ * **Same provider, never across.** Swapping a Claude agent onto an OpenAI id
+ * would send that user's first message to a provider their workspace may have
+ * deliberately not enabled, and would fail outright where only one key is set.
+ *
+ * **An id this build does not know keeps its own model**, and so does any
+ * deployment with `OPENAI_MODEL` set. Under `OPENAI_BASE_URL` the catalogue
+ * belongs to somebody else's server: `gpt-4o-mini` is a name it has probably
+ * never heard of, and a 404 would turn a free convenience into a broken one.
+ * Same reasoning as rule 2 of `resolveModel`, and the same direction — when in
+ * doubt, do what the operator configured.
+ */
+export function titleModelFor(model: string, env?: ModelEnv): string {
+  if (env?.OPENAI_MODEL) return model;
+  const spec = modelSpec(model);
+  if (!spec) return model;
+  if (spec.provider === "anthropic") return "claude-haiku-4-5";
+  return "gpt-4o-mini";
+}
+
 export function resolveModel(model: string | null | undefined, env?: ModelEnv): string {
   const spec = modelSpec(model);
   if (spec?.provider === "anthropic" && anthropicEnabled(env)) return model as string;

--- a/worker/src/lib/prompt.ts
+++ b/worker/src/lib/prompt.ts
@@ -62,13 +62,21 @@ export const MANIFEST_NAME_LIMIT = 40;
  * and left the model to fill the gap. Saying that excerpts arrive *when
  * retrieval finds them* is true on both kinds of turn, and gives the model
  * somewhere honest to go when they don't.
+ *
+ * The clause about preferring the excerpt and admitting when it falls short is
+ * here rather than in the excerpt block for the same reason everything else in
+ * this prefix is: the block is rebuilt every turn and never caches, so an
+ * instruction living in it is bought again on every question. This one is
+ * bought once per cache window and applies to every turn of the chat.
  */
 const MANIFEST = (names: string) =>
   `\n\nThe team has shared these documents with you: ${names}. ` +
   `When the user says "the file", "the document", "the video", or asks what was ` +
   `uploaded, they mean one of these — never claim you cannot read files. ` +
   `Relevant excerpts are supplied in a separate system message whenever retrieval ` +
-  `finds them; answer from those. If no excerpt is present, say which of these ` +
+  `finds them; answer from those in preference to what you already believe, and ` +
+  `say plainly when they do not cover what was asked rather than filling the gap. ` +
+  `If no excerpt is present, say which of these ` +
   `documents you would need to look at rather than inventing what it contains.`;
 
 function manifestNames(names: string[]): string {

--- a/worker/src/lib/rag.test.ts
+++ b/worker/src/lib/rag.test.ts
@@ -157,6 +157,67 @@ describe("retrievalQuery", () => {
   });
 });
 
+describe("passages the model has already been given", () => {
+  it("drops a chunk that repeats one already in the block", () => {
+    // The case this exists for: one document attached to an agent through two
+    // bundles is chunked and embedded once per bundle, so match_chunks returns
+    // both copies. Both used to be paid for, and both used to claim a citation.
+    const passage = "Expenses are approved by the team lead, then by finance.";
+    const block = buildContextBlock([
+      { documentId: "d1", documentName: "handbook.md", content: passage },
+      { documentId: "d2", documentName: "handbook (copy).md", content: passage },
+      { documentId: "d3", documentName: "travel.md", content: "Flights book themselves." },
+    ]);
+
+    expect(block.used.map((c) => c.documentName)).toEqual(["handbook.md", "travel.md"]);
+    expect(block.text.match(/Expenses are approved/g)).toHaveLength(1);
+  });
+
+  it("drops a chunk wholly contained in one already admitted", () => {
+    const block = buildContextBlock([
+      { documentName: "a.md", content: "The office is closed on Tuesdays and Thursdays." },
+      { documentName: "b.md", content: "closed on Tuesdays" },
+    ]);
+
+    expect(block.used).toHaveLength(1);
+  });
+
+  it("keeps looking after a duplicate rather than stopping at it", () => {
+    // `continue`, not `break` — the chunks after a repeat are still new, and
+    // stopping would have cost the block its least-relevant-but-real material.
+    const block = buildContextBlock([
+      { documentName: "a.md", content: "Same text." },
+      { documentName: "b.md", content: "Same text." },
+      { documentName: "c.md", content: "Different text." },
+    ]);
+
+    expect(block.used.map((c) => c.documentName)).toEqual(["a.md", "c.md"]);
+  });
+
+  it("still compares on whitespace-insensitive text, and only on that", () => {
+    const block = buildContextBlock([
+      { documentName: "a.md", content: "One   two\nthree" },
+      { documentName: "b.md", content: "one two three" },
+      { documentName: "c.md", content: "one two four" },
+    ]);
+
+    expect(block.used.map((c) => c.documentName)).toEqual(["a.md", "c.md"]);
+  });
+
+  it("respects the budget to the byte with duplicates in the list", () => {
+    const block = buildContextBlock(
+      [
+        { documentName: "a.md", content: "x".repeat(900) },
+        { documentName: "b.md", content: "x".repeat(900) },
+        { documentName: "c.md", content: "y".repeat(900) },
+      ],
+      1000,
+    );
+
+    expect(block.text.length).toBeLessThanOrEqual(1000);
+  });
+});
+
 describe("the similarity floor", () => {
   it("is 0.25 unless the operator says otherwise", () => {
     expect(ragMinSimilarity({})).toBe(DEFAULT_RAG_MIN_SIMILARITY);

--- a/worker/src/lib/rag.ts
+++ b/worker/src/lib/rag.ts
@@ -121,6 +121,23 @@ const TRUNCATION_MARK = "\n…[truncated]";
 const MIN_USEFUL_EXCERPT = 200;
 
 /**
+ * What two passages have to share before the second one is treated as text the
+ * model has already been given.
+ *
+ * Not a similarity measure — a containment check, on purpose. The duplicates
+ * this catches are literal: a document attached to an agent through two bundles
+ * is chunked and embedded once per bundle, so `match_chunks` returns both
+ * copies of the same passage, and both were being paid for and both were
+ * putting the same words in front of the model. Whitespace is normalised
+ * because the two copies can differ in it and mean the same thing; nothing else
+ * is, because "nearly the same passage" is a judgement this should not be
+ * making on its own.
+ */
+function normaliseForComparison(text: string): string {
+  return text.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+/**
  * Assembles retrieved chunks into a system-prompt context block under a total
  * char budget, and reports which of them fitted.
  *
@@ -141,10 +158,18 @@ export function buildContextBlock(chunks: RetrievedChunk[], budget = 4000): Cont
   let remaining = budget - HEADER.length;
   const blocks: string[] = [];
   const used: RetrievedChunk[] = [];
+  const admitted: string[] = [];
 
   for (const ch of chunks) {
     const content = ch.content.trim();
     if (!content || !ch.documentName) continue;
+
+    // A passage already inside one that was admitted adds nothing and costs the
+    // budget twice — and, before it was skipped, could also hang a second
+    // source chip under the answer for a document that had already grounded it.
+    // `continue`, not `break`: the chunks after a duplicate are still new.
+    const normalised = normaliseForComparison(content);
+    if (admitted.some((seen) => seen.includes(normalised))) continue;
 
     const frame =
       `Document: ${ch.documentName}\n`.length + (blocks.length > 0 ? SEPARATOR.length : 0);
@@ -165,6 +190,9 @@ export function buildContextBlock(chunks: RetrievedChunk[], budget = 4000): Cont
     remaining -= frame + body.length;
     blocks.push(`Document: ${ch.documentName}\n${body}`);
     used.push(ch);
+    // The whole passage, not `body`: a later duplicate is a duplicate of what
+    // the chunk said, whether or not the budget let all of it through.
+    admitted.push(normalised);
   }
 
   if (blocks.length === 0) return empty;

--- a/worker/src/lib/retrieval.ts
+++ b/worker/src/lib/retrieval.ts
@@ -23,14 +23,24 @@ import { refersToDocuments, namesDocument } from "./doc-question";
  */
 
 /**
- * How many chunks to retrieve.
+ * How many chunks to *consider*. What reaches the prompt is decided after this,
+ * by `buildContextBlock`'s char budget.
  *
- * The block is re-sent every turn and rides after the cacheable prefix, so it
- * never caches — keeping the count tight cuts recurring input directly. The
- * floor that goes with it is `ragMinSimilarity`, which is configurable because
- * it is a property of the embedding model rather than of this code.
+ * That distinction is why this went from 6 to 10 without costing a token. The
+ * block is re-sent every turn and rides after the cacheable prefix, so it never
+ * caches, and keeping it tight cuts recurring input directly — but the thing
+ * keeping it tight is the 4000-char budget, not this number. Six candidates
+ * frequently could not fill that budget while a seventh, perfectly relevant
+ * passage sat just outside the list; and now that near-duplicates are dropped
+ * rather than admitted (see `buildContextBlock`), a short list could be spent
+ * entirely on two copies of one passage.
+ *
+ * The cost of the four extra candidates is one wider `limit` in a query that
+ * already ran, over an HNSW index. The floor that goes with it is
+ * `ragMinSimilarity`, which is configurable because it is a property of the
+ * embedding model rather than of this code.
  */
-const RAG_MATCH_COUNT = 6;
+const RAG_MATCH_COUNT = 10;
 
 export type RetrievedSource = { id: string | null; name: string };
 

--- a/worker/src/routes/chat.test.ts
+++ b/worker/src/routes/chat.test.ts
@@ -621,6 +621,19 @@ describe("naming the conversation", () => {
     expect(sent).toContain("How many vacation days do I get?");
   });
 
+  it("names it on the cheap model, not on the one answering", async () => {
+    // Five words of title on a flagship model, once per new chat, forever. The
+    // reply keeps the agent's model; only the label moves.
+    const { app } = appWith({ question: "How many vacation days do I get?" });
+
+    await ask(app);
+
+    const titling = completionCreate.mock.calls.find((c) => !c[0].stream);
+    const answering = completionCreate.mock.calls.find((c) => c[0].stream);
+    expect(titling![0].model).toBe("gpt-4o-mini");
+    expect(answering![0].model).toBe("gpt-4o");
+  });
+
   // Renaming on every turn would cost money and move a label out from under
   // somebody reading it.
   it("leaves a session that already has a name alone", async () => {

--- a/worker/src/routes/chat.ts
+++ b/worker/src/routes/chat.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { AppEnv } from "../types";
 import { mapMessage } from "../lib/dto";
 import { serviceClient } from "../lib/supabase";
-import { resolveModel, modelSpec } from "../lib/models";
+import { resolveModel, modelSpec, titleModelFor } from "../lib/models";
 import { streamCompletion, type CompletionMessage } from "../lib/completion";
 import { retrieveForAgent } from "../lib/retrieval";
 import { selectHistory } from "../lib/history";
@@ -184,7 +184,13 @@ chat.post("/chat/stream", async (c) => {
   // Only for a session with no title. A named session is one the user or an
   // earlier turn already settled, and re-titling it every turn would both cost
   // money and move a label out from under someone reading it.
-  const titling = session.title ? null : generateSessionTitle(env, model, lastMessage.content);
+  //
+  // On the cheapest model of the same provider, not on the agent's — see
+  // `titleModelFor`. A title is five words and the agent's model has nothing to
+  // add to them.
+  const titling = session.title
+    ? null
+    : generateSessionTitle(env, titleModelFor(model, env), lastMessage.content);
 
   const stream = new ReadableStream({
     async start(controller) {


### PR DESCRIPTION
## What problem does this solve?

A chat turn pays for the same tokens more than once, in four separate places. None of this asks the model for less — it stops buying things twice.

**Claude prompt caching was never asked for.** `lib/pricing.ts` has priced a 10× cache discount for every Claude model since they were offered, and `anthropicUsage` has read `cache_read_input_tokens` back for just as long. The number was always zero. The prompt was already built for caching — `buildSystemPrefix` is byte-identical turn over turn, which is the whole reason the retrieved knowledge is a separate message and not part of the persona — so this is two `cache_control` markers on a request whose shape did not otherwise change: one on the system block, one on the last turn before the retrieved block, so the conversation caches along with the persona.

**A session title was asked of the agent's own model.** Naming a conversation is five words that read one message; a `claude-sonnet-4-6` agent paid flagship input and output rates for them, once per new chat, forever. `titleModelFor` moves it to the cheapest model of the *same* provider — never across providers (a workspace can hold one key and not the other), and not at all for an id this build does not know or a deployment with `OPENAI_MODEL` set, because under `OPENAI_BASE_URL` `gpt-4o-mini` is a name that endpoint has probably never heard of.

**Retrieval could send the same passage twice.** A document attached to an agent through two bundles is chunked and embedded once per bundle, so `match_chunks` returns both copies — both were paid for, and both hung a source chip under the answer. `buildContextBlock` now skips a passage already contained in one it admitted. With duplicates gone, the candidate count goes 6 → 10, which costs no tokens: the 4000-character budget decides what is actually sent, not the number of candidates.

**One line of grounding discipline** — prefer the excerpt to what you already believe, and say plainly when it does not cover the question — added to the cacheable prefix rather than to the excerpt block, so it is bought once per cache window instead of once per turn.

No schema change, no API change, no UI change.

## Checks

- [x] The commands above pass

## If you touched the database

Not touched.

## If you touched `serviceClient()` or the service-role key

Not touched.

## If you touched UI

Not touched.

---

By opening this pull request you agree to the contributor license agreement in
[`CONTRIBUTING.md`](../CONTRIBUTING.md#contributor-license-agreement).