### PR TITLE
Give an agent a temperature and a reasoning setting of its own

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -135,7 +135,7 @@ client for all of it.
 | ---------------------------------------------- | -------------------------------- |
 | `GET /agents`                                  | Every agent in the workspace     |
 | `POST /agents`                                 | Create one                       |
-| `PATCH /agents/:id`                            | Rename, re-persona, change model |
+| `PATCH /agents/:id`                            | Rename, re-persona, change model, tune |
 | `DELETE /agents/:id`                           | Delete                           |
 | `POST /agents/:id/bundles/:bundleId`           | Attach a knowledge bundle        |
 | `DELETE /agents/:id/bundles/:bundleId`         | Detach it                        |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -93,6 +93,20 @@ a change to either list. The mode is
 `normal` or `brainstorm`, and brainstorm layers a facilitation instruction block
 on top of the persona rather than replacing it.
 
+Two settings tune how that model answers, and both are on Auto until somebody
+says otherwise. **Temperature** is 0 to 2 and decides how much the wording
+varies between two answers to the same question; Auto leaves it to the mode,
+which asks for 0.9 in brainstorm and sends nothing at all in normal chat. The
+GPT-5 family decides this for itself and rejects any other value, so the control
+is inert there and says so. **Reasoning** is `minimal`, `low`, `medium` or
+`high` and decides how long a reasoning model deliberates before it starts
+writing — more thinking, more tokens, and on a long analysis a better answer.
+Auto sends no setting at all, which is not the same as `medium`, and the models
+that answer without a separate thinking step ignore it entirely.
+
+Both apply wherever the agent answers: the chat screen, a Slack thread, and a
+routine's scheduled report.
+
 ## Persona
 
 The persona is the system prompt every conversation with an agent starts from. It

--- a/src/lib/agent-meta.test.ts
+++ b/src/lib/agent-meta.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { EMOJIS, MODELS, PERSONA_TEMPLATES, modelsFor } from "./agent-meta";
+import { EMOJIS, MODELS, PERSONA_TEMPLATES, modelsFor, specFor } from "./agent-meta";
 
 /**
  * Two invariants that nothing else would catch, because both fail silently.
@@ -69,5 +69,30 @@ describe("modelsFor", () => {
 
   it("ignores a null current pick, which is how 'no preference' arrives", () => {
     expect(modelsFor(["gpt-4o"], null)).toEqual(["gpt-4o"]);
+  });
+});
+
+describe("specFor", () => {
+  const specs = {
+    "gpt-4o": { temperature: true, reasoning: false },
+    "gpt-5-mini": { temperature: false, reasoning: true },
+  };
+
+  it("answers from what the server said", () => {
+    expect(specFor(specs, "gpt-5-mini")).toEqual({ temperature: false, reasoning: true });
+  });
+
+  it("assumes a model it was told nothing about takes a temperature and does not reason", () => {
+    // The server's own answer for an unknown id, and the situation is normal
+    // rather than exceptional: under a custom endpoint every id is unknown, and
+    // an agent can sit on a Claude model after the key was rotated out.
+    // Optimistic about the control that is harmless to offer, conservative
+    // about the one that is not.
+    expect(specFor(specs, "llama3.3:70b")).toEqual({ temperature: true, reasoning: false });
+  });
+
+  it("answers the same way before /me has said anything at all", () => {
+    expect(specFor(undefined, "gpt-5-mini")).toEqual({ temperature: true, reasoning: false });
+    expect(specFor(specs, null)).toEqual({ temperature: true, reasoning: false });
   });
 });

--- a/src/lib/agent-meta.ts
+++ b/src/lib/agent-meta.ts
@@ -59,6 +59,44 @@ export function modelsFor(available: string[] | undefined, current?: string | nu
  */
 const DEFAULT_PICKER_MODELS = MODELS.filter((m) => !m.startsWith("claude-"));
 
+/**
+ * How hard a reasoning model is asked to think, cheapest first. Mirrors
+ * `REASONING_EFFORTS` in `worker/src/lib/models.ts`, which is what the API
+ * validates against and what migration 0048 constrains the column to.
+ */
+export const REASONING_EFFORTS = ["minimal", "low", "medium", "high"] as const;
+
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
+
+/** What each effort buys, for the one line of help under the picker. */
+export const REASONING_EFFORT_HINTS: Record<ReasoningEffort, string> = {
+  minimal: "Answers immediately. Cheapest, and best for lookups and rewrites.",
+  low: "A moment's thought before answering.",
+  medium: "The model's usual amount of deliberation.",
+  high: "Thinks at length first. Best for analysis, and the most expensive.",
+};
+
+export type ModelSpec = { temperature: boolean; reasoning: boolean };
+
+/**
+ * What a model will accept, as the server described it.
+ *
+ * The fallback matters more than the lookup. `modelSpecs` arrives with /me and
+ * covers the ids this deployment serves; an agent can be sitting on one it does
+ * not — a Claude pick after the key was rotated out, or anything at all under a
+ * custom endpoint, where every id is unknown by design. The answer for those is
+ * the server's own answer for an unknown id (`lib/models.ts`): a temperature is
+ * accepted, and the model does not reason. Optimistic about the control that is
+ * harmless to offer and conservative about the one that is not.
+ */
+export function specFor(
+  specs: Record<string, ModelSpec> | undefined,
+  model: string | null | undefined,
+): ModelSpec {
+  const known = model ? specs?.[model] : undefined;
+  return known ?? { temperature: true, reasoning: false };
+}
+
 // A per-model colour used to live here — emerald for GPT, violet for Llama and
 // so on. The design system allows exactly one saturated colour, so a palette
 // keyed on model name is off-system by construction: models are now

--- a/src/lib/agents-store.tsx
+++ b/src/lib/agents-store.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, type Bundle } from "./api-client";
 import { canWriteAsRole } from "./roles";
+import type { ReasoningEffort } from "./agent-meta";
 import { chatBundleMarker, chatBundleName, findChatBundle } from "./chat-uploads";
 import { useHasSession } from "./session-presence";
 
@@ -13,6 +14,17 @@ export type Agent = {
   model: string;
   persona: string;
   mode: "normal" | "brainstorm";
+  /**
+   * How much the model may vary its wording, 0 to 2, or null for Auto.
+   *
+   * Null is a setting and not a missing value: it means the mode decides, which
+   * is 0.9 for a brainstorm agent and nothing at all for a normal one. Every
+   * agent is on it until somebody moves the dial, so `0` and `null` are
+   * different answers and the form has to keep them apart.
+   */
+  temperature: number | null;
+  /** How long the agent thinks first, or null for whatever the model does. */
+  reasoningEffort: ReasoningEffort | null;
   documents: {
     id: string;
     name: string;
@@ -94,7 +106,18 @@ type Store = {
    * or not the button was there; this is so the button is not there.
    */
   canWrite: boolean;
-  createAgent: (a: Omit<Agent, "id" | "createdAt" | "documents" | "bundleIds">) => Promise<Agent>;
+  /**
+   * The tuning settings are optional here and required nowhere else: a new
+   * agent is created on Auto, and both surfaces that create one say so by not
+   * mentioning them. Settings is where they are chosen, once there is an agent
+   * to choose them for.
+   */
+  createAgent: (
+    a: Omit<
+      Agent,
+      "id" | "createdAt" | "documents" | "bundleIds" | "temperature" | "reasoningEffort"
+    >,
+  ) => Promise<Agent>;
   updateAgent: (id: string, patch: Partial<Agent>) => void;
   removeDocument: (agentId: string, docId: string) => Promise<void>;
   reindexDocument: (docId: string) => Promise<Agent["documents"][number]>;

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -49,6 +49,13 @@ export type Me = {
    * list. `modelsFor` in `lib/agent-meta` handles the absence.
    */
   models?: string[];
+  /**
+   * What each of those ids accepts — whether a temperature may be sent, and
+   * whether the model thinks before it answers. Optional for the same reason
+   * `models` is: a frontend deployed ahead of its API gets nothing here, and
+   * `specFor` in `lib/agent-meta` answers for an id it was told nothing about.
+   */
+  modelSpecs?: Record<string, { temperature: boolean; reasoning: boolean }>;
   onboarding: { completed: boolean; answers: OnboardingAnswers };
 };
 
@@ -252,7 +259,12 @@ export const api = {
     }): Promise<Agent> => request("POST", "/agents", input),
     update: (
       id: string,
-      patch: Partial<Pick<Agent, "name" | "emoji" | "model" | "persona" | "mode">>,
+      patch: Partial<
+        Pick<
+          Agent,
+          "name" | "emoji" | "model" | "persona" | "mode" | "temperature" | "reasoningEffort"
+        >
+      >,
     ): Promise<Agent> => request("PATCH", `/agents/${id}`, patch),
     remove: (id: string): Promise<void> => request("DELETE", `/agents/${id}`),
     toggleFavorite: (id: string): Promise<{ favorited: boolean }> =>

--- a/src/routes/_authed.agents.$agentId.settings.test.tsx
+++ b/src/routes/_authed.agents.$agentId.settings.test.tsx
@@ -1,0 +1,147 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type React from "react";
+
+/**
+ * The two tuning controls, which are the part of this screen where a null and a
+ * number mean different things.
+ *
+ * Auto is not a value on the slider — it means the mode decides, which is 0.9
+ * in brainstorm and nothing at all in normal chat. Every agent is on it, so a
+ * form that quietly resolved it to a number would change every reply in the
+ * product the first time anybody opened Settings and pressed Save.
+ */
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (options: { component: () => React.ReactElement }) => ({
+    ...options,
+    useParams: () => ({ agentId: "agent-1" }),
+  }),
+  useNavigate: () => vi.fn(),
+}));
+
+const me = {
+  models: ["gpt-4o", "gpt-5-mini"],
+  modelSpecs: {
+    "gpt-4o": { temperature: true, reasoning: false },
+    "gpt-5-mini": { temperature: false, reasoning: true },
+  },
+};
+
+vi.mock("@/lib/api-client", () => ({ api: { me: () => Promise.resolve(me) } }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/components/generate-persona-button", () => ({
+  GeneratePersonaButton: () => null,
+}));
+
+const updateAgent = vi.fn();
+const agent = {
+  id: "agent-1",
+  name: "GTM Agent",
+  emoji: "📈",
+  model: "gpt-4o",
+  persona: "You are our PM.",
+  mode: "normal" as const,
+  temperature: null as number | null,
+  reasoningEffort: null as string | null,
+  documents: [],
+  bundleIds: [],
+  createdAt: Date.parse("2026-09-01T10:00:00Z"),
+};
+const store = { agents: [agent], updateAgent, deleteAgent: vi.fn(), canWrite: true };
+
+vi.mock("@/lib/agents-store", () => ({ useAgentsStore: () => store }));
+
+const { Route } = await import("./_authed.agents.$agentId.settings");
+
+function renderSettings() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Component = (Route as unknown as { component: () => React.ReactElement }).component;
+  return render(
+    <QueryClientProvider client={client}>
+      <Component />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  updateAgent.mockClear();
+  agent.model = "gpt-4o";
+  agent.temperature = null;
+  agent.reasoningEffort = null;
+});
+
+describe("the tuning controls", () => {
+  it("starts on Auto, with no number on screen to argue with", async () => {
+    renderSettings();
+
+    expect(await screen.findByLabelText("Auto")).toBeChecked();
+    expect(screen.queryByLabelText("Temperature")).not.toBeInTheDocument();
+  });
+
+  it("saves null for a setting nobody touched", async () => {
+    // The important one. Opening Settings and pressing Save must not move an
+    // agent off the behaviour it has had since it was created.
+    renderSettings();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+
+    expect(updateAgent).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({ temperature: null, reasoningEffort: null }),
+    );
+  });
+
+  it("offers a number to adjust once Auto is turned off", async () => {
+    renderSettings();
+
+    await userEvent.click(await screen.findByLabelText("Auto"));
+
+    // 0.7 rather than 0: a slider that opens at one end reads as "off", and the
+    // extreme it landed on is never the value somebody meant.
+    expect(screen.getByLabelText("Temperature")).toHaveValue("0.7");
+    expect(screen.getByText("0.7")).toBeInTheDocument();
+  });
+
+  it("saves the number the slider is on", async () => {
+    renderSettings();
+
+    await userEvent.click(await screen.findByLabelText("Auto"));
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    expect(updateAgent).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({ temperature: 0.7 }),
+    );
+  });
+
+  it("keeps a temperature the agent already had", async () => {
+    agent.temperature = 0.2;
+    renderSettings();
+
+    expect(await screen.findByLabelText("Temperature")).toHaveValue("0.2");
+    expect(screen.getByLabelText("Auto")).not.toBeChecked();
+  });
+
+  it("says why the control is dead on a model that decides for itself", async () => {
+    // gpt-5-mini rejects any temperature but its own with a 400. A disabled
+    // control that explains itself beats one that vanishes when the model picker
+    // above it changes.
+    agent.model = "gpt-5-mini";
+    renderSettings();
+
+    // Waited for by the explanation rather than by the control: the form
+    // renders before /me answers, and until it does every model looks like it
+    // takes a temperature.
+    expect(await screen.findByText(/rejects any other value/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Auto")).toBeDisabled();
+  });
+
+  it("says why reasoning is dead on a model that does not reason", async () => {
+    renderSettings();
+
+    expect(await screen.findByText(/answers without a separate thinking step/)).toBeInTheDocument();
+  });
+});

--- a/src/routes/_authed.agents.$agentId.settings.tsx
+++ b/src/routes/_authed.agents.$agentId.settings.tsx
@@ -33,7 +33,15 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { toast } from "sonner";
-import { EMOJIS, modelsFor } from "@/lib/agent-meta";
+import {
+  EMOJIS,
+  modelsFor,
+  specFor,
+  REASONING_EFFORTS,
+  REASONING_EFFORT_HINTS,
+  type ReasoningEffort,
+} from "@/lib/agent-meta";
+import { Checkbox } from "@/components/ui/checkbox";
 import { AgentAvatar } from "@/components/avatars";
 import { GeneratePersonaButton } from "@/components/generate-persona-button";
 
@@ -83,9 +91,28 @@ function AgentSettingsForm({ agent }: { agent: Agent }) {
   const { data: me } = useQuery({ queryKey: ["me"], queryFn: () => api.me() });
   const models = modelsFor(me?.models, model);
   const [mode, setMode] = useState(agent.mode);
+  // Null is Auto, and Auto is what every agent starts on: the mode decides.
+  // `?? null` rather than a default, because an API older than this screen
+  // sends neither field and "the server did not say" is the same answer.
+  const [temperature, setTemperature] = useState<number | null>(agent.temperature ?? null);
+  const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort | null>(
+    agent.reasoningEffort ?? null,
+  );
+  // What the *currently picked* model accepts, not what the saved one did — so
+  // switching to gpt-5 in this form greys the temperature out before you save,
+  // rather than after the reply comes back wrong.
+  const spec = specFor(me?.modelSpecs, model);
 
   const save = () => {
-    updateAgent(agent.id, { name: name.trim() || agent.name, emoji, model, persona, mode });
+    updateAgent(agent.id, {
+      name: name.trim() || agent.name,
+      emoji,
+      model,
+      persona,
+      mode,
+      temperature,
+      reasoningEffort,
+    });
     toast.success("Changes saved");
   };
 
@@ -155,6 +182,18 @@ function AgentSettingsForm({ agent }: { agent: Agent }) {
                 answering directly — good for finding new directions.
               </p>
             </div>
+            <TemperatureField
+              value={temperature}
+              onChange={setTemperature}
+              accepted={spec.temperature}
+              model={model}
+            />
+            <ReasoningField
+              value={reasoningEffort}
+              onChange={setReasoningEffort}
+              accepted={spec.reasoning}
+              model={model}
+            />
             <div className="space-y-2">
               <div className="flex items-center justify-between gap-2">
                 <Label className="text-xs" htmlFor="a-persona">
@@ -266,6 +305,155 @@ function AgentSettingsForm({ agent }: { agent: Agent }) {
     </PageContainer>
   );
 }
+
+/**
+ * How much the model may vary its wording.
+ *
+ * Two controls for one setting, because the setting has a state that is not a
+ * number. Auto is not 0.7 or any other value — it means the mode decides, which
+ * is 0.9 in brainstorm and *nothing sent at all* in normal chat, and no point
+ * on a 0-to-2 slider can say that. So the checkbox chooses between "the mode
+ * decides" and "I decide", and the slider only exists in the second case.
+ *
+ * A native range input rather than a slider component: there is no slider in
+ * `components/ui`, and one control does not justify a Radix dependency and a
+ * lockfile change. The thumb is squared off and amber because DESIGN.md says
+ * selection markers are squares and the accent is the pointer.
+ */
+function TemperatureField({
+  value,
+  onChange,
+  accepted,
+  model,
+}: {
+  value: number | null;
+  onChange: (next: number | null) => void;
+  accepted: boolean;
+  model: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <Label className="text-xs" htmlFor="a-temperature">
+          Temperature
+        </Label>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="a-temperature-auto"
+            checked={value === null}
+            disabled={!accepted}
+            // 0.7 on first touch rather than 0: a slider that starts at one end
+            // reads as "off", and the number somebody wants is almost never the
+            // extreme they landed on.
+            onCheckedChange={(checked) => onChange(checked === true ? null : 0.7)}
+          />
+          <Label className="text-xs font-normal text-muted-foreground" htmlFor="a-temperature-auto">
+            Auto
+          </Label>
+        </div>
+      </div>
+      {value !== null && (
+        <div className="flex items-center gap-3">
+          <input
+            id="a-temperature"
+            type="range"
+            min={0}
+            max={2}
+            step={0.1}
+            value={value}
+            disabled={!accepted}
+            onChange={(e) => onChange(Number(e.target.value))}
+            className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-surface-muted accent-primary outline-none disabled:cursor-not-allowed disabled:opacity-50 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-[4px] [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[#f48d16] [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-[4px] [&::-webkit-slider-thumb]:bg-[#f48d16]"
+          />
+          <span className="w-8 shrink-0 text-right font-mono text-xs tabular-nums">
+            {value.toFixed(1)}
+          </span>
+        </div>
+      )}
+      <p className="text-xs text-muted-foreground">
+        {!accepted ? (
+          <>
+            <span className="font-mono">{model}</span> decides this for itself and rejects any other
+            value, so the agent runs on its own setting.
+          </>
+        ) : value === null ? (
+          "Left to the mode: steady in Normal, wide-ranging in Brainstorm."
+        ) : value <= 0.3 ? (
+          "Close to the same answer every time. Good for support and policy questions."
+        ) : value <= 1 ? (
+          "Some variation in wording, the same substance."
+        ) : (
+          "Freely inventive, and less predictable. Worth checking what it says."
+        )}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * How long the agent thinks before it starts writing.
+ *
+ * Auto is a real option and the one every agent is on — it sends no effort at
+ * all and lets the model do what it does. "Medium" is a different request, so
+ * the two cannot be collapsed into one item however similar they look.
+ *
+ * Shown rather than hidden on a model that does not reason. The picker above it
+ * is the thing that decides whether this control does anything, and a setting
+ * that vanishes when you change a neighbouring field reads as a bug; a disabled
+ * one that says why reads as an explanation.
+ */
+function ReasoningField({
+  value,
+  onChange,
+  accepted,
+  model,
+}: {
+  value: ReasoningEffort | null;
+  onChange: (next: ReasoningEffort | null) => void;
+  accepted: boolean;
+  model: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label className="text-xs">Reasoning</Label>
+      <Select
+        value={value ?? AUTO}
+        disabled={!accepted}
+        onValueChange={(v) => onChange(v === AUTO ? null : (v as ReasoningEffort))}
+      >
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={AUTO}>Auto</SelectItem>
+          {REASONING_EFFORTS.map((effort) => (
+            <SelectItem key={effort} value={effort}>
+              {effort[0].toUpperCase() + effort.slice(1)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-xs text-muted-foreground">
+        {!accepted ? (
+          <>
+            <span className="font-mono">{model}</span> answers without a separate thinking step, so
+            this has no effect on it.
+          </>
+        ) : value === null ? (
+          "Whatever the model does by default."
+        ) : (
+          REASONING_EFFORT_HINTS[value]
+        )}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The picker's stand-in for null. A `Select` item cannot carry an empty value —
+ * Radix reserves it for "nothing is selected", which is not what Auto means.
+ */
+const AUTO = "auto";
 
 function PersonaPreview({
   emoji,

--- a/supabase/migrations/0048_a_dial_the_agent_owns.sql
+++ b/supabase/migrations/0048_a_dial_the_agent_owns.sql
@@ -1,0 +1,60 @@
+-- =========================================================================
+-- A dial the agent owns
+--
+-- Two settings that existed in the code and nowhere else: how much the model
+-- varies its wording, and how long it thinks before it starts writing.
+--
+-- Both were decided by `mode`. `lib/prompt.ts` returned 0.9 for a brainstorm
+-- agent and nothing at all for a normal one, and `reasoning_effort` was sent
+-- only by the three callers whose task is shaping rather than thinking, always
+-- as `minimal`. So a team that wanted its support agent to answer the same way
+-- twice, or its analyst to think harder before answering, had one control
+-- between them — the mode picker — and it moved four behaviours at once.
+--
+-- Both columns are nullable, and null is the default for every agent that
+-- exists. It does not mean "no temperature" or "no thinking": it means the mode
+-- decides, which is exactly what happens today. This migration therefore
+-- changes no reply. The dial appears; nobody is moved to a new setting by it.
+--
+-- `temperature` is `real` rather than `numeric` because it is a model
+-- parameter, not money, and 0.7 has never needed to be exactly 0.7.
+--
+-- The range check is on the column rather than only in the API, unlike
+-- `workspaces.default_model` (0014), and for the opposite reason: the set of
+-- model *names* changes faster than the schema should, but the meaning of a
+-- temperature does not. 0 to 2 is what both providers accept, and a row outside
+-- it is a 400 from the provider on every turn until somebody edits it back.
+--
+-- `reasoning_effort` is checked against a fixed list for the same reason — the
+-- four names are the API's vocabulary, not ours. A model that does not reason
+-- ignores the column, which `lib/models.ts` decides per id and is why this is
+-- not a `not null default 'medium'`: "the model's own default" and "medium"
+-- are different requests, and only one of them is what an untouched agent has
+-- been getting.
+--
+-- No policy change. `agents_update_workspace_member` (0021) is a row policy and
+-- already governs who may write these columns; a viewer cannot, a member can.
+-- =========================================================================
+
+alter table public.agents
+  add column if not exists temperature real;
+
+alter table public.agents
+  add column if not exists reasoning_effort text;
+
+alter table public.agents
+  drop constraint if exists agents_temperature_range;
+
+alter table public.agents
+  add constraint agents_temperature_range
+  check (temperature is null or (temperature >= 0 and temperature <= 2));
+
+alter table public.agents
+  drop constraint if exists agents_reasoning_effort_known;
+
+alter table public.agents
+  add constraint agents_reasoning_effort_known
+  check (
+    reasoning_effort is null
+    or reasoning_effort in ('minimal', 'low', 'medium', 'high')
+  );

--- a/worker/src/lib/completion.test.ts
+++ b/worker/src/lib/completion.test.ts
@@ -7,6 +7,7 @@ import {
   totalTokens,
   DEFAULT_MAX_TOKENS,
   REASONING_HEADROOM,
+  reasoningHeadroom,
   type CompletionEnv,
   type CompletionEvent,
 } from "./completion";
@@ -269,6 +270,40 @@ describe("complete, on OpenAI", () => {
     it("leaves an uncapped request uncapped rather than inventing a ceiling", async () => {
       await complete(openaiOnly, { model: "gpt-5", messages: [{ role: "user", content: "Hi" }] });
       expect(openaiCreate.mock.calls[0][0]).not.toHaveProperty("max_completion_tokens");
+    });
+
+    it("forwards an agent's own effort, which used to be minimal or nothing", async () => {
+      await complete(openaiOnly, {
+        model: "gpt-5",
+        messages: [{ role: "user", content: "Hi" }],
+        maxTokens: 1536,
+        reasoningEffort: "high",
+      });
+      expect(openaiCreate.mock.calls[0][0].reasoning_effort).toBe("high");
+    });
+
+    it.each([
+      ["minimal", 0],
+      ["low", 2048],
+      ["medium", REASONING_HEADROOM],
+      ["high", 8192],
+    ] as const)("gives %s effort room to think in", async (effort, headroom) => {
+      // A ceiling a "high" turn exhausts before it writes a word is not a
+      // shorter answer, it is an empty one with finish_reason "length".
+      await complete(openaiOnly, {
+        model: "gpt-5",
+        messages: [{ role: "user", content: "Hi" }],
+        maxTokens: 1536,
+        reasoningEffort: effort,
+      });
+      expect(openaiCreate.mock.calls[0][0].max_completion_tokens).toBe(1536 + headroom);
+    });
+
+    it("keeps the unset case on exactly the number it has always used", async () => {
+      // `reasoningHeadroom` replaced a constant. The measured value is the one
+      // every request in the product runs on today, so it must not have moved.
+      expect(reasoningHeadroom(undefined)).toBe(REASONING_HEADROOM);
+      expect(REASONING_HEADROOM).toBe(4096);
     });
   });
 

--- a/worker/src/lib/completion.ts
+++ b/worker/src/lib/completion.ts
@@ -2,7 +2,12 @@ import type OpenAI from "openai";
 import type Anthropic from "@anthropic-ai/sdk";
 import { createOpenAI } from "./openai";
 import { createAnthropic } from "./anthropic";
-import { providerFor, acceptsTemperature, reasonsBeforeAnswering } from "./models";
+import {
+  providerFor,
+  acceptsTemperature,
+  reasonsBeforeAnswering,
+  type ReasoningEffort,
+} from "./models";
 
 /**
  * The one seam every completion goes through, whichever provider answers it.
@@ -58,17 +63,26 @@ export type CompletionRequest = {
   /** Ask for a single JSON object back. */
   json?: boolean;
   /**
-   * Set by a caller whose task is shaping, not thinking.
+   * How long the model may deliberate before it starts writing.
    *
-   * Drafting a persona from a title or pulling ideas out of a transcript are
-   * writing tasks with a known shape; a reasoning model deliberating over them
-   * buys nothing and costs a multiple. Measured on the persona drafter: default
-   * effort spends 512-1408 tokens thinking before writing ~120 tokens of
-   * answer, and `"minimal"` spends none and writes the same answer.
+   * Two kinds of caller set this, and they arrive from opposite directions.
+   *
+   * The first is a caller whose task is shaping, not thinking, and it says
+   * `"minimal"`. Drafting a persona from a title or pulling ideas out of a
+   * transcript are writing tasks with a known shape; a reasoning model
+   * deliberating over them buys nothing and costs a multiple. Measured on the
+   * persona drafter: default effort spends 512-1408 tokens thinking before
+   * writing ~120 tokens of answer, and `"minimal"` spends none and writes the
+   * same answer.
+   *
+   * The second is a chat turn carrying an agent's own setting (0048), which can
+   * be any of the four and is usually none of them — an agent that names no
+   * effort is left on the model's default, which is what every agent had before
+   * the setting existed. `"medium"` is a request, not a synonym for silence.
    *
    * Nothing on a non-reasoning model, which has no such setting.
    */
-  reasoningEffort?: "minimal";
+  reasoningEffort?: ReasoningEffort;
 };
 
 /**
@@ -99,6 +113,33 @@ export const DEFAULT_MAX_TOKENS = 4096;
  * then nothing to make room for.
  */
 export const REASONING_HEADROOM = 4096;
+
+/**
+ * The same headroom, sized to how much thinking was actually asked for.
+ *
+ * `REASONING_HEADROOM` was one number because there was one behaviour: either a
+ * caller wanted no deliberation (`"minimal"`) or it took whatever the model
+ * chose. Now that an agent can ask for `"high"`, one number is the wrong shape
+ * in both directions — 4096 is more than a `"low"` turn will ever use, and a
+ * ceiling a `"high"` turn can exhaust before it writes a word, which is not a
+ * shorter answer but an empty one with `finish_reason: "length"`.
+ *
+ * Anchored on the measured value rather than invented around it: the unset case
+ * keeps 4096 exactly, so nothing that runs today changes. The others scale from
+ * it in the direction their name promises.
+ */
+export function reasoningHeadroom(effort: ReasoningEffort | undefined): number {
+  switch (effort) {
+    case "minimal":
+      return 0;
+    case "low":
+      return 2048;
+    case "high":
+      return 8192;
+    default:
+      return REASONING_HEADROOM;
+  }
+}
 
 const JSON_ONLY_INSTRUCTION =
   "Respond with a single JSON object and nothing else: no prose before or after it, " +
@@ -141,17 +182,17 @@ function openaiParams(req: CompletionRequest): OpenAI.Chat.Completions.ChatCompl
   const reasons = reasonsBeforeAnswering(req.model);
   // Two ways to keep thinking from eating the answer, and which one applies is
   // the caller's call, not the model's: minimal effort when the task does not
-  // want deliberation, headroom when it does. See REASONING_HEADROOM.
-  const minimal = reasons && req.reasoningEffort === "minimal";
-  const cap =
-    req.maxTokens !== undefined && reasons && !minimal
-      ? req.maxTokens + REASONING_HEADROOM
-      : req.maxTokens;
+  // want deliberation, headroom when it does — sized to how much was asked for.
+  // See `reasoningHeadroom`.
+  const headroom = reasons ? reasoningHeadroom(req.reasoningEffort) : 0;
+  const cap = req.maxTokens !== undefined ? req.maxTokens + headroom : req.maxTokens;
   return {
     model: req.model,
     messages: req.messages as OpenAI.Chat.Completions.ChatCompletionMessageParam[],
     ...(cap !== undefined ? { max_completion_tokens: cap } : {}),
-    ...(minimal ? { reasoning_effort: "minimal" as const } : {}),
+    // Only where it means something. A model that answers without a separate
+    // thinking step has no such parameter, and sending one is a 400.
+    ...(reasons && req.reasoningEffort ? { reasoning_effort: req.reasoningEffort } : {}),
     ...(req.temperature !== undefined && acceptsTemperature(req.model)
       ? { temperature: req.temperature }
       : {}),

--- a/worker/src/lib/dto.ts
+++ b/worker/src/lib/dto.ts
@@ -32,6 +32,13 @@ export type AgentDTO = {
   model: string | null;
   persona: string | null;
   mode: "normal" | "brainstorm";
+  /**
+   * The two tuning settings (0048). Null is not a missing value — it is the
+   * setting, and it means the mode decides, which is what every agent has until
+   * somebody moves the dial.
+   */
+  temperature: number | null;
+  reasoningEffort: string | null;
   documents: DocumentDTO[];
   bundleIds: string[];
   createdAt: number;
@@ -137,6 +144,19 @@ export type MeDTO = {
    */
   models: string[];
   /**
+   * What each of those ids will accept, keyed by id.
+   *
+   * The same reasoning as `models`, one level down. Whether a temperature can
+   * be sent and whether the model thinks before it answers are facts about the
+   * model, decided in `lib/models.ts`, and the agent settings screen needs them
+   * to know which of its two tuning controls mean anything: the GPT-5 family
+   * rejects any temperature but its own with a 400, and nothing but that family
+   * has a reasoning effort at all. A frontend holding its own copy of that
+   * table would be a second source of truth for something the server already
+   * decides — and would be wrong for exactly the ids it had not heard of.
+   */
+  modelSpecs: Record<string, { temperature: boolean; reasoning: boolean }>;
+  /**
    * Where this account stands with its first run. The `_authed` layout gates on
    * `completed`, which is why this rides along with /me rather than having an
    * endpoint of its own — every page load needs the answer, and this response
@@ -187,6 +207,8 @@ export function mapAgent(row: {
   model: string | null;
   persona: string | null;
   mode?: string | null;
+  temperature?: number | null;
+  reasoning_effort?: string | null;
   created_at: string;
   agent_bundles?: Array<{
     bundle_id: string;
@@ -209,6 +231,8 @@ export function mapAgent(row: {
     model: row.model,
     persona: row.persona,
     mode: row.mode === "brainstorm" ? "brainstorm" : "normal",
+    temperature: row.temperature ?? null,
+    reasoningEffort: row.reasoning_effort ?? null,
     documents: agentBundles.flatMap((ab) => ab.knowledge_bundles?.documents ?? []).map(mapDocument),
     bundleIds: agentBundles.map((ab) => ab.bundle_id),
     createdAt: toEpochMs(row.created_at),

--- a/worker/src/lib/models.test.ts
+++ b/worker/src/lib/models.test.ts
@@ -6,6 +6,7 @@ import {
   availableModels,
   modelSpec,
   titleModelFor,
+  modelSpecsFor,
   DEFAULT_MODEL,
   MODEL_IDS,
 } from "./models";
@@ -150,5 +151,24 @@ describe("titleModelFor", () => {
 
   it("defers to OPENAI_MODEL, which is the operator naming their own model", () => {
     expect(titleModelFor("gpt-4o", { OPENAI_MODEL: "llama3.3:70b" })).toBe("gpt-4o");
+  });
+});
+
+describe("modelSpecsFor", () => {
+  it("describes each id the picker was given", () => {
+    expect(modelSpecsFor(["gpt-4o", "gpt-5-mini"])).toEqual({
+      "gpt-4o": { temperature: true, reasoning: false },
+      "gpt-5-mini": { temperature: false, reasoning: true },
+    });
+  });
+
+  it("says nothing about an id this build does not know", () => {
+    // Silence, not a guess. The frontend has its own answer for an id it was
+    // told nothing about, and inventing one here would make it look authoritative.
+    expect(modelSpecsFor(["llama3.3:70b"])).toEqual({});
+  });
+
+  it("carries no provider, which is a routing decision and nobody else's business", () => {
+    expect(modelSpecsFor(["gpt-4o"])["gpt-4o"]).not.toHaveProperty("provider");
   });
 });

--- a/worker/src/lib/models.ts
+++ b/worker/src/lib/models.ts
@@ -36,6 +36,23 @@ export const MODEL_IDS = [
 
 export type ModelId = (typeof MODEL_IDS)[number];
 
+/**
+ * How hard a reasoning model is asked to think before it writes, in the API's
+ * own vocabulary, cheapest first.
+ *
+ * A tuple for the same reason `MODEL_IDS` is one: `routes/agents.ts` builds a
+ * `z.enum()` out of it, and migration 0048 checks the same four strings in the
+ * database. Three lists that have to agree, so this is the one they are all
+ * spelled from.
+ *
+ * Absent is not a fifth value: an agent that names no effort gets whatever the
+ * model does by default, which is what every agent got before this was
+ * settable. Saying `"medium"` is a different request from saying nothing.
+ */
+export const REASONING_EFFORTS = ["minimal", "low", "medium", "high"] as const;
+
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
+
 export type ModelSpec = {
   provider: ModelProvider;
   /**
@@ -172,6 +189,24 @@ export function availableModels(env?: ModelEnv): ModelId[] {
  * to rule 2 — the conversation stays on their endpoint. Setting the key is the
  * act that opts a deployment into sending anything to Anthropic.
  */
+/**
+ * What each of `ids` accepts, for the agent settings screen to render against.
+ *
+ * `SPECS` stays private — `provider` is a routing decision and nothing outside
+ * this file has any business reading it — so this projects the two fields a
+ * picker needs and no more.
+ */
+export function modelSpecsFor(
+  ids: readonly string[],
+): Record<string, { temperature: boolean; reasoning: boolean }> {
+  const out: Record<string, { temperature: boolean; reasoning: boolean }> = {};
+  for (const id of ids) {
+    const spec = modelSpec(id);
+    if (spec) out[id] = { temperature: spec.temperature, reasoning: spec.reasoning };
+  }
+  return out;
+}
+
 /**
  * The cheapest model of the same provider, for work that is shaping rather than
  * thinking.

--- a/worker/src/lib/prompt.test.ts
+++ b/worker/src/lib/prompt.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildSystemPrefix,
   temperatureFor,
+  reasoningEffortFor,
   maxTokensFor,
   BRAINSTORM_INSTRUCTIONS,
   CONCISION_INSTRUCTIONS,
@@ -101,6 +102,50 @@ describe("temperatureFor", () => {
   it("returns 0.9 for brainstorm and undefined for normal", () => {
     expect(temperatureFor("brainstorm")).toBe(0.9);
     expect(temperatureFor("normal")).toBeUndefined();
+  });
+
+  it("leaves the mode in charge when the agent named no temperature", () => {
+    // Null is what every agent has until somebody moves the dial, and it has to
+    // mean exactly what the two lines above mean — otherwise 0048 changes every
+    // reply in the product on the day it is applied.
+    expect(temperatureFor("brainstorm", null)).toBe(0.9);
+    expect(temperatureFor("normal", null)).toBeUndefined();
+    expect(temperatureFor("normal", undefined)).toBeUndefined();
+  });
+
+  it("lets the agent's own setting win in either mode", () => {
+    expect(temperatureFor("normal", 0.2)).toBe(0.2);
+    expect(temperatureFor("brainstorm", 0.2)).toBe(0.2);
+  });
+
+  it("takes 0, which is a setting and not an absence", () => {
+    // The bug this pins: `override || mode default` would read 0 as "unset" and
+    // quietly hand a support agent asked for determinism the mode's own value.
+    expect(temperatureFor("normal", 0)).toBe(0);
+    expect(temperatureFor("brainstorm", 0)).toBe(0);
+  });
+});
+
+describe("reasoningEffortFor", () => {
+  it("sends nothing when the agent named nothing", () => {
+    // Not "medium". A request that carries no effort gets the model's own
+    // default, which is what every reply in this product has been getting.
+    expect(reasoningEffortFor(null)).toBeUndefined();
+    expect(reasoningEffortFor(undefined)).toBeUndefined();
+    expect(reasoningEffortFor("")).toBeUndefined();
+  });
+
+  it("passes the four the API knows", () => {
+    for (const effort of ["minimal", "low", "medium", "high"]) {
+      expect(reasoningEffortFor(effort)).toBe(effort);
+    }
+  });
+
+  it("drops a value neither the database nor the API would have allowed", () => {
+    // Reachable only by a row written around both. Forwarding it would be a 400
+    // on every turn of that agent's conversations; dropping it is one reply
+    // without a setting nobody asked for.
+    expect(reasoningEffortFor("maximum")).toBeUndefined();
   });
 });
 

--- a/worker/src/lib/prompt.ts
+++ b/worker/src/lib/prompt.ts
@@ -1,3 +1,5 @@
+import { REASONING_EFFORTS, type ReasoningEffort } from "./models";
+
 export const DEFAULT_PERSONA = "You are a helpful AI assistant for a team workspace.";
 
 // Layered on top of the persona when an agent is in brainstorm mode. Sequences
@@ -107,8 +109,46 @@ export function buildSystemPrefix(input: {
   return prefix;
 }
 
-export function temperatureFor(mode: "normal" | "brainstorm"): number | undefined {
+/**
+ * How much the model may vary its wording, and who decides.
+ *
+ * The agent's own setting wins when it has one (0048). Null — which is every
+ * agent until somebody moves the dial — leaves the decision where it has always
+ * been: brainstorm wants range and asks for 0.9, and normal chat sends nothing
+ * at all, which is not the same as sending the provider's default value and is
+ * the reason this returns `undefined` rather than a number.
+ *
+ * `0` is a legitimate setting and means "as close to the same answer every time
+ * as this model gets", so the check is against null and not against falsiness.
+ */
+export function temperatureFor(
+  mode: "normal" | "brainstorm",
+  override?: number | null,
+): number | undefined {
+  if (override !== null && override !== undefined) return override;
   return mode === "brainstorm" ? 0.9 : undefined;
+}
+
+/**
+ * How long the agent may think before it answers.
+ *
+ * There is no mode default here and deliberately no default of any kind:
+ * `undefined` means the request carries no `reasoning_effort` and the model
+ * does whatever it does, which is what every reply in this product has been
+ * getting. See `REASONING_EFFORTS` in `lib/models.ts` for why "medium" is not
+ * that.
+ *
+ * Unknown strings are dropped rather than forwarded. The database constrains
+ * this column (0048) and the API validates it, so a value that is neither null
+ * nor one of the four can only be a row written before those existed or by
+ * something that bypassed both — and forwarding it would turn that into a 400
+ * on every turn of a conversation.
+ */
+export function reasoningEffortFor(override?: string | null): ReasoningEffort | undefined {
+  if (!override) return undefined;
+  return (REASONING_EFFORTS as readonly string[]).includes(override)
+    ? (override as ReasoningEffort)
+    : undefined;
 }
 
 // Upper bound on generated tokens. Output tokens are the most expensive

--- a/worker/src/lib/routines/executor.ts
+++ b/worker/src/lib/routines/executor.ts
@@ -71,6 +71,18 @@ export type RoutineRow = {
 export type SummariseInput = {
   persona: string | null;
   model: string | null;
+  /**
+   * The agent's own tuning (0048), carried so a routine writes the way the
+   * agent answers. A routine is the same colleague reporting instead of
+   * replying, and an agent told to stay close to its material should not
+   * improvise on a schedule because the report took a different code path.
+   *
+   * Null — or absent, which is the same thing here — means what it means
+   * everywhere else: the model's own defaults, which is what every routine ran
+   * on before the settings existed.
+   */
+  temperature?: number | null;
+  reasoningEffort?: string | null;
   instruction: string;
   items: FeedItem[];
   pageText?: string;
@@ -410,7 +422,7 @@ export async function runRoutine(
 
     const { data: agent, error: agentError } = await deps.db
       .from("agents")
-      .select("persona, model")
+      .select("persona, model, temperature, reasoning_effort")
       .eq("id", routine.agent_id)
       .eq("workspace_id", routine.workspace_id)
       // Service-role client, so RLS is not filtering this. `claim_due_routines`
@@ -458,6 +470,8 @@ export async function runRoutine(
       {
         persona: agent?.persona ?? null,
         model: agent?.model ?? null,
+        temperature: agent?.temperature ?? null,
+        reasoningEffort: agent?.reasoning_effort ?? null,
         instruction: routine.instruction,
         items,
         pageText,

--- a/worker/src/lib/routines/summarise.ts
+++ b/worker/src/lib/routines/summarise.ts
@@ -2,6 +2,7 @@
 import type { RoutineEnv } from "../../types";
 import { resolveModel } from "../models";
 import { complete, totalTokens } from "../completion";
+import { temperatureFor, reasoningEffortFor } from "../prompt";
 import type { SummariseInput } from "./executor";
 
 /**
@@ -54,6 +55,13 @@ export function summariseWithModel(env: RoutineEnv) {
     const { text, usage } = await complete(env, {
       model: resolveModel(input.model, env),
       json: input.mayDecline,
+      // The agent's own settings, so a routine reports the way the agent
+      // answers. There is no mode here — a routine is neither normal chat nor
+      // brainstorm — so `temperatureFor` is given the one it would fall back to
+      // and the agent's value overrides it or nothing is sent, which is exactly
+      // what this call did before the settings existed.
+      temperature: temperatureFor("normal", input.temperature),
+      reasoningEffort: reasoningEffortFor(input.reasoningEffort),
       messages: [
         {
           role: "system",

--- a/worker/src/lib/slack/handle.ts
+++ b/worker/src/lib/slack/handle.ts
@@ -1,13 +1,12 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type OpenAI from "openai";
 import type { Bindings } from "../../types";
 import type { Entitlements } from "../entitlements";
 import { embeddingCost } from "../entitlements";
 import { retrieveForAgent } from "../retrieval";
 import { selectHistory } from "../history";
-import { buildSystemPrefix, maxTokensFor, temperatureFor } from "../prompt";
+import { buildSystemPrefix, maxTokensFor, temperatureFor, reasoningEffortFor } from "../prompt";
 import { resolveModel } from "../models";
-import { createOpenAI } from "../openai";
+import { complete, type CompletionMessage } from "../completion";
 import { decryptSecret } from "../secret-box";
 import { billsTheOperator, keysForUser, withProviderKeys } from "../keys/resolve";
 import { lookupEmail, postMessage } from "./api";
@@ -148,7 +147,7 @@ export async function handleSlackEvent(
 
   const { data: agent, error: agentError } = await deps.db
     .from("agents")
-    .select("id,name,persona,model,mode,workspace_id")
+    .select("id,name,persona,model,mode,temperature,reasoning_effort,workspace_id")
     .eq("id", installation.agent_id)
     .eq("workspace_id", installation.workspace_id)
     .maybeSingle();
@@ -218,7 +217,7 @@ export async function handleSlackEvent(
   // retrieved block riding immediately before the latest question.
   const priorTurns = history.slice(0, -1);
   const latestTurn = history[history.length - 1];
-  const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
+  const messages: CompletionMessage[] = [
     { role: "system", content: systemPrefix },
     ...priorTurns,
     ...(retrieval.ragBlock ? [{ role: "system" as const, content: retrieval.ragBlock }] : []),
@@ -227,11 +226,25 @@ export async function handleSlackEvent(
 
   let completion;
   try {
-    completion = await createOpenAI(runEnv).chat.completions.create({
+    // Through the completion seam, not `createOpenAI` directly.
+    //
+    // This call used to build its own request, and building it here meant
+    // getting it wrong here: `max_tokens` is the parameter the GPT-5 family
+    // does not take, a temperature is what that family rejects outright, and a
+    // Claude id was being handed to the OpenAI client which has never been able
+    // to serve one. All three were 400s on a mention, for agents that answer
+    // perfectly well in the chat screen — and all three are decisions
+    // `lib/completion.ts` already makes for every other caller.
+    //
+    // Which is also what makes the two settings below mean the same thing in
+    // both places. An agent asked to answer twice the same way should not do it
+    // in one surface and improvise in the other.
+    completion = await complete(runEnv, {
       model: resolveModel(agent.model, runEnv),
       messages,
-      temperature: temperatureFor(mode),
-      max_tokens: maxTokensFor(mode),
+      temperature: temperatureFor(mode, agent.temperature),
+      reasoningEffort: reasoningEffortFor(agent.reasoning_effort),
+      maxTokens: maxTokensFor(mode),
     });
   } catch (err) {
     console.error("slack completion failed", err);
@@ -246,13 +259,13 @@ export async function handleSlackEvent(
     return;
   }
 
-  const answer = completion.choices[0]?.message?.content?.trim() ?? "";
-  const promptTokens = completion.usage?.prompt_tokens ?? 0;
-  const completionTokens = completion.usage?.completion_tokens ?? 0;
-  // How much of `promptTokens` OpenAI served from its own cache — a subset of
-  // that count, not an addition. It is the only evidence that the cacheable
-  // prefix assembled above is actually working.
-  const cachedTokens = completion.usage?.prompt_tokens_details?.cached_tokens ?? 0;
+  const answer = completion.text.trim();
+  const promptTokens = completion.usage.promptTokens ?? 0;
+  const completionTokens = completion.usage.completionTokens ?? 0;
+  // How much of `promptTokens` the provider served from its own cache — a
+  // subset of that count, not an addition. It is the only evidence that the
+  // cacheable prefix assembled above is actually working.
+  const cachedTokens = completion.usage.cachedTokens ?? 0;
 
   // One counter write per turn, whichever way the rest of this goes — but only
   // where the operator is the one being billed. Somebody else's key spent

--- a/worker/src/routes/agents.test.ts
+++ b/worker/src/routes/agents.test.ts
@@ -1,0 +1,191 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import type { AppEnv } from "../types";
+import { agents } from "./agents";
+
+/**
+ * The agents route, tested where it stopped being a pass-through.
+ *
+ * It had no test file for as long as every field it accepted was spelled the
+ * same in the API and in the database, because there was nothing between the
+ * two to get wrong: the handler validated a body and handed it to `.update()`.
+ * `reasoningEffort` is the first field where those two spellings differ, and the
+ * failure that would cause is not a type error — it is PostgREST refusing a
+ * column named `reasoningEffort` at runtime, on the save the user cares about.
+ */
+
+const USER_ID = "user-1";
+const WORKSPACE_ID = "workspace-1";
+
+const AGENT_ROW = {
+  id: "agent-1",
+  name: "GTM",
+  emoji: "📈",
+  model: "gpt-4o",
+  persona: "You are our PM.",
+  mode: "normal",
+  temperature: null as number | null,
+  reasoning_effort: null as string | null,
+  created_at: "2026-09-01T10:00:00Z",
+  agent_bundles: [],
+};
+
+/**
+ * Enough of the request-scoped client for this route, recording what it was
+ * asked to write. `getActiveWorkspaceId` reads `profiles`; everything else is
+ * the agents table.
+ */
+function fakeDb() {
+  const writes: Record<string, unknown>[] = [];
+  const db = {
+    from(table: string) {
+      if (table === "profiles") {
+        const chain = {
+          select: () => chain,
+          eq: () => chain,
+          maybeSingle: async () => ({ data: { active_workspace_id: WORKSPACE_ID }, error: null }),
+          single: async () => ({ data: { active_workspace_id: WORKSPACE_ID }, error: null }),
+        };
+        return chain;
+      }
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        order: () => chain,
+        maybeSingle: async () => ({ data: AGENT_ROW, error: null }),
+        single: async () => ({ data: AGENT_ROW, error: null }),
+        update(patch: Record<string, unknown>) {
+          writes.push(patch);
+          return chain;
+        },
+        insert(row: Record<string, unknown>) {
+          writes.push(row);
+          return chain;
+        },
+      };
+      return chain;
+    },
+  };
+  return { db, writes };
+}
+
+function appWith(db: unknown) {
+  const app = new Hono<AppEnv>();
+  app.use("/*", async (c, next) => {
+    c.set("user", { id: USER_ID, email: "a@example.com" } as never);
+    c.set("db", db as never);
+    await next();
+  });
+  app.route("/", agents);
+  return app;
+}
+
+const patch = (app: Hono<AppEnv>, body: unknown) =>
+  app.request("/agents/agent-1", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+describe("PATCH /agents/:id", () => {
+  it("writes the reasoning effort to the column that exists", async () => {
+    const { db, writes } = fakeDb();
+
+    const res = await patch(appWith(db), { reasoningEffort: "high" });
+
+    expect(res.status).toBe(200);
+    expect(writes[0]).toEqual({ reasoning_effort: "high" });
+    expect(writes[0]).not.toHaveProperty("reasoningEffort");
+  });
+
+  it("writes only the fields that were sent", async () => {
+    // A PATCH of one field has to stay a PATCH of one field: filling the others
+    // in from defaults would let the settings page overwrite a persona somebody
+    // else had just changed in another tab.
+    const { db, writes } = fakeDb();
+
+    await patch(appWith(db), { name: "Growth" });
+
+    expect(writes[0]).toEqual({ name: "Growth" });
+  });
+
+  it("takes null, which is how a setting is put back on Auto", async () => {
+    // The difference this pins: absent means "leave it alone" and null means
+    // "clear it". Without the second, a temperature could be set and never unset.
+    const { db, writes } = fakeDb();
+
+    await patch(appWith(db), { temperature: null, reasoningEffort: null });
+
+    expect(writes[0]).toEqual({ temperature: null, reasoning_effort: null });
+  });
+
+  it("takes 0, which is a temperature and not an empty field", async () => {
+    const { db, writes } = fakeDb();
+
+    await patch(appWith(db), { temperature: 0 });
+
+    expect(writes[0]).toEqual({ temperature: 0 });
+  });
+
+  it("refuses a temperature outside what the providers accept", async () => {
+    // The database says the same thing (0048). This is what turns it into a 400
+    // naming the field rather than a 500 naming a constraint.
+    const { db, writes } = fakeDb();
+
+    const res = await patch(appWith(db), { temperature: 3 });
+
+    expect(res.status).toBe(400);
+    expect(writes).toHaveLength(0);
+  });
+
+  it("refuses an effort the API has no name for", async () => {
+    const { db, writes } = fakeDb();
+
+    const res = await patch(appWith(db), { reasoningEffort: "maximum" });
+
+    expect(res.status).toBe(400);
+    expect(writes).toHaveLength(0);
+  });
+
+  it("still refuses an empty body", async () => {
+    const { db } = fakeDb();
+
+    expect((await patch(appWith(db), {})).status).toBe(400);
+  });
+
+  it("returns the agent with both settings on it", async () => {
+    const { db } = fakeDb();
+
+    const res = await patch(appWith(db), { name: "Growth" });
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body).toMatchObject({ temperature: null, reasoningEffort: null });
+  });
+});
+
+describe("POST /agents", () => {
+  it("creates an agent on Auto when nothing was asked for", async () => {
+    const { db, writes } = fakeDb();
+
+    const res = await appWith(db).request("/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "GTM" }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(writes[0]).toMatchObject({ temperature: null, reasoning_effort: null });
+  });
+
+  it("takes both settings when the caller does name them", async () => {
+    const { db, writes } = fakeDb();
+
+    await appWith(db).request("/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "GTM", temperature: 0.2, reasoningEffort: "low" }),
+    });
+
+    expect(writes[0]).toMatchObject({ temperature: 0.2, reasoning_effort: "low" });
+  });
+});

--- a/worker/src/routes/agents.ts
+++ b/worker/src/routes/agents.ts
@@ -4,11 +4,29 @@ import type { AppEnv } from "../types";
 import { mapAgent } from "../lib/dto";
 import { getActiveWorkspaceId } from "../lib/workspace";
 import { callDeletionFn } from "../lib/deletion";
+import { REASONING_EFFORTS } from "../lib/models";
 
 const agents = new Hono<AppEnv>();
 
 const AGENT_SELECT =
   "*, agent_bundles(bundle_id, knowledge_bundles(documents(id,name,size,created_at,document_chunks(count))))";
+
+/**
+ * The two tuning settings, on both schemas.
+ *
+ * Nullable as well as optional, and the difference is the whole feature:
+ * *absent* means "do not change this", *null* means "put it back on Auto". A
+ * field that could only be absent or a number would let somebody set a
+ * temperature and never unset one.
+ *
+ * The bounds are the same as migration 0048's check constraint, stated twice on
+ * purpose — the database is what guarantees it, and this is what turns a
+ * violation into a 400 naming the field instead of a 500 naming a constraint.
+ */
+const tuningFields = {
+  temperature: z.number().min(0).max(2).nullable().optional(),
+  reasoningEffort: z.enum(REASONING_EFFORTS).nullable().optional(),
+};
 
 const createAgentSchema = z.object({
   name: z.string().min(1),
@@ -16,6 +34,7 @@ const createAgentSchema = z.object({
   model: z.string().optional(),
   persona: z.string().optional(),
   mode: z.enum(["normal", "brainstorm"]).optional(),
+  ...tuningFields,
 });
 
 const updateAgentSchema = z
@@ -25,10 +44,37 @@ const updateAgentSchema = z
     model: z.string().optional(),
     persona: z.string().optional(),
     mode: z.enum(["normal", "brainstorm"]).optional(),
+    ...tuningFields,
   })
   .refine((body) => Object.keys(body).length > 0, {
     message: "at least one field is required",
   });
+
+/**
+ * The validated body as database columns.
+ *
+ * This route used to hand `parsed.data` straight to `.update()`, which worked
+ * only because every field it accepted happened to be spelled the same way in
+ * both places. `reasoningEffort` is the first one that is not, and the failure
+ * that would have caused is not a type error — it is PostgREST refusing a
+ * column named `reasoningEffort` at runtime, on the one request the user
+ * actually cares about. `routes/workspace.ts` has mapped `defaultModel` by hand
+ * for the same reason since 0014.
+ *
+ * Only keys that were sent are copied, so "absent" stays absent and a PATCH of
+ * one field remains a PATCH of one field.
+ */
+function agentColumns(body: z.infer<typeof updateAgentSchema>): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+  if ("name" in body) patch.name = body.name;
+  if ("emoji" in body) patch.emoji = body.emoji;
+  if ("model" in body) patch.model = body.model;
+  if ("persona" in body) patch.persona = body.persona;
+  if ("mode" in body) patch.mode = body.mode;
+  if ("temperature" in body) patch.temperature = body.temperature;
+  if ("reasoningEffort" in body) patch.reasoning_effort = body.reasoningEffort;
+  return patch;
+}
 
 // GET /agents
 agents.get("/agents", async (c) => {
@@ -68,7 +114,7 @@ agents.post("/agents", async (c) => {
     return c.json({ error: "no workspace found for user" }, 400);
   }
 
-  const { name, emoji, model, persona, mode } = parsed.data;
+  const { name, emoji, model, persona, mode, temperature, reasoningEffort } = parsed.data;
 
   const { data, error } = await db
     .from("agents")
@@ -79,6 +125,10 @@ agents.post("/agents", async (c) => {
       model: model ?? null,
       persona: persona ?? null,
       mode: mode ?? "normal",
+      // Null is the default and means the mode decides, which is what every
+      // agent created before 0048 has.
+      temperature: temperature ?? null,
+      reasoning_effort: reasoningEffort ?? null,
       created_by: user.id,
     })
     .select("*")
@@ -101,7 +151,10 @@ agents.patch("/agents/:id", async (c) => {
     return c.json({ error: parsed.error.flatten() }, 400);
   }
 
-  const { error: updateError } = await db.from("agents").update(parsed.data).eq("id", id);
+  const { error: updateError } = await db
+    .from("agents")
+    .update(agentColumns(parsed.data))
+    .eq("id", id);
 
   if (updateError) {
     return c.json({ error: "failed to update agent" }, 500);

--- a/worker/src/routes/chat.test.ts
+++ b/worker/src/routes/chat.test.ts
@@ -176,6 +176,8 @@ function appWith(spec: {
   providerEnv?: { OPENAI_API_KEY: string; ANTHROPIC_API_KEY?: string };
   /** The agent's stored model. Defaults to `AGENT.model` (null → the default). */
   agentModel?: string | null;
+  /** The agent's own tuning (0048). Undefined leaves both on Auto. */
+  agentTuning?: { temperature?: number | null; reasoning_effort?: string | null };
 }) {
   const documents = spec.documents ?? [];
   const rows = [...(spec.history ?? []), { role: "user", content: spec.question }].map((m, i) => ({
@@ -185,7 +187,11 @@ function appWith(spec: {
     created_at: `2026-09-0${i + 1}T10:00:00Z`,
   }));
 
-  const agent = spec.agentModel !== undefined ? { ...AGENT, model: spec.agentModel } : AGENT;
+  const agent = {
+    ...AGENT,
+    ...(spec.agentModel !== undefined ? { model: spec.agentModel } : {}),
+    ...(spec.agentTuning ?? {}),
+  };
 
   const dbSpec: FakeDbSpec = {
     tables: {
@@ -595,6 +601,62 @@ describe("saying so when a Claude pick is dropped (Task 9)", () => {
     const { body } = await ask(app);
 
     expect(body).not.toContain('"type":"notice"');
+  });
+});
+
+describe("the agent's own tuning", () => {
+  const requestBody = () => completionCreate.mock.calls.find((c) => c[0].stream)![0];
+
+  it("sends the temperature the agent was given", async () => {
+    const { app } = appWith({ question: "Hi", agentTuning: { temperature: 0.2 } });
+
+    await ask(app);
+
+    expect(requestBody().temperature).toBe(0.2);
+  });
+
+  it("sends 0, which is a setting and not an absence", async () => {
+    const { app } = appWith({ question: "Hi", agentTuning: { temperature: 0 } });
+
+    await ask(app);
+
+    expect(requestBody().temperature).toBe(0);
+  });
+
+  it("leaves the mode in charge when the agent is on Auto", async () => {
+    // Every agent is on Auto until somebody moves the dial, so this is the
+    // behaviour of the whole product and it must be the behaviour it had before
+    // the column existed: normal chat sends no temperature at all.
+    const { app } = appWith({ question: "Hi" });
+
+    await ask(app);
+
+    expect(requestBody()).not.toHaveProperty("temperature");
+    expect(requestBody()).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("asks a reasoning model for the effort the agent named", async () => {
+    const { app } = appWith({
+      question: "Hi",
+      agentModel: "gpt-5-mini",
+      agentTuning: { reasoning_effort: "high" },
+    });
+
+    await ask(app);
+
+    expect(requestBody().reasoning_effort).toBe("high");
+  });
+
+  it("says nothing about reasoning to a model that does not reason", async () => {
+    const { app } = appWith({
+      question: "Hi",
+      agentModel: "gpt-4o",
+      agentTuning: { reasoning_effort: "high" },
+    });
+
+    await ask(app);
+
+    expect(requestBody()).not.toHaveProperty("reasoning_effort");
   });
 });
 

--- a/worker/src/routes/chat.ts
+++ b/worker/src/routes/chat.ts
@@ -7,7 +7,7 @@ import { resolveModel, modelSpec, titleModelFor } from "../lib/models";
 import { streamCompletion, type CompletionMessage } from "../lib/completion";
 import { retrieveForAgent } from "../lib/retrieval";
 import { selectHistory } from "../lib/history";
-import { buildSystemPrefix, temperatureFor, maxTokensFor } from "../lib/prompt";
+import { buildSystemPrefix, temperatureFor, maxTokensFor, reasoningEffortFor } from "../lib/prompt";
 import { effectiveMode } from "../lib/session-mode";
 import { generateSessionTitle } from "../lib/session-title";
 import { deferred } from "../lib/defer";
@@ -319,7 +319,8 @@ chat.post("/chat/stream", async (c) => {
             model,
             messages,
             maxTokens: maxTokensFor(mode),
-            temperature: temperatureFor(mode),
+            temperature: temperatureFor(mode, agent.temperature),
+            reasoningEffort: reasoningEffortFor(agent.reasoning_effort),
           },
           { signal },
         );

--- a/worker/src/routes/me.ts
+++ b/worker/src/routes/me.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { AppEnv } from "../types";
 import type { MeDTO } from "../lib/dto";
 import { getActiveWorkspaceId } from "../lib/workspace";
-import { availableModels } from "../lib/models";
+import { availableModels, modelSpecsFor } from "../lib/models";
 
 const me = new Hono<AppEnv>();
 
@@ -132,6 +132,7 @@ me.get("/me", async (c) => {
     },
     members,
     models: availableModels(c.env),
+    modelSpecs: modelSpecsFor(availableModels(c.env)),
     onboarding: {
       completed: Boolean(onboardingRow?.completed_at),
       answers: {


### PR DESCRIPTION
## What problem does this solve?

Two settings that existed in the code and nowhere a user could reach. `mode` decided the temperature — 0.9 for a brainstorm agent, nothing at all for a normal one — and `reasoning_effort` was sent only by the three callers whose task is shaping rather than thinking, always as `minimal`. A team that wanted its support agent to answer the same way twice, or its analyst to think longer before answering, had one control between them, and it moved four behaviours at once.

**Nothing changes for an existing agent.** Both columns are nullable and null is what every agent has. Null does not mean "no temperature" or "no thinking" — it means the mode decides, which is exactly today's behaviour. Applying `0048` changes no reply; the dial appears and nobody is moved by it. `null` and `0` stay different answers all the way down, which is why `temperatureFor` checks against null rather than falsiness, and why the API takes `null` as well as absent: absent means "leave it alone", null means "put it back on Auto".

**Reasoning effort widens** from the single literal `"minimal"` to the four the API knows, and the flat `REASONING_HEADROOM` becomes a function of which one was asked for — 0 / 2048 / 4096 / 8192. The unset case keeps the measured 4096 exactly, so nothing that runs today moves. The scaling is not decoration: a ceiling a `"high"` turn exhausts before it writes a word is not a shorter answer, it is an empty one with `finish_reason: "length"`, which is the failure `lib/models.ts` was already written to explain.

**The settings reach every surface the agent answers on** — chat, Slack, and a routine's report. Making that true meant the Slack path finally going through the completion seam instead of building its own request, which fixes three 400s it has been returning all along for agents that answer perfectly well in the chat screen: `max_tokens` is the parameter the GPT-5 family does not take, a temperature is what that family rejects outright, and a Claude id was being handed to the OpenAI client.

`routes/agents.ts` also stops handing the parsed body straight to `.update()`. That worked while every field it accepted was spelled the same in the API and in the database; `reasoningEffort` is the first that is not, and the failure would have been PostgREST refusing a column at runtime rather than anything `tsc` would catch. The route has a test file now, which it did not before.

## ⚠️ The migration has to be applied before the hosted mirror merges

`0048` adds columns that the settings page writes on every save and that the Slack and routine paths name in their `select`. Against a database without them, a save is a 500. Same class as `0039`: merge here freely (this repo deploys nothing), hold the covan-cloud mirror as a draft until `docker/migrate.sh` has run.

## Checks

- [x] The commands above pass

## If you touched the database

- [x] The change is a **new** migration in `supabase/migrations/`, not an edit to an applied one
- [x] No new table — `agents_update_workspace_member` (0021) is a row policy and already governs who may write these columns. Check constraints only.

## If you touched `serviceClient()` or the service-role key

Not touched.

## If you touched UI

- [x] It follows [`DESIGN.md`](../DESIGN.md) — squared amber slider thumb, no new accent, no shadow, controls inside the existing `disabled` fieldset so a viewer is gated automatically. No new dependency: the range input is native rather than a Radix slider.

---

By opening this pull request you agree to the contributor license agreement in
[`CONTRIBUTING.md`](../CONTRIBUTING.md#contributor-license-agreement).