### PR TITLE
Do not pay to cache a prefix nobody will ask for again

### DIFF
--- a/worker/src/lib/completion.test.ts
+++ b/worker/src/lib/completion.test.ts
@@ -331,10 +331,9 @@ describe("complete, on Anthropic", () => {
     const call = anthropicCreate.mock.calls[0][0];
     expect(call.model).toBe("claude-sonnet-4-5");
     // A block rather than a string, because that is the only shape a cache
-    // breakpoint can ride on — see the cache tests below.
-    expect(call.system).toEqual([
-      { type: "text", text: "You are Ada.", cache_control: { type: "ephemeral" } },
-    ]);
+    // breakpoint can ride on — but unmarked here, because one question with no
+    // history behind it has nothing to cache. See the cache tests below.
+    expect(call.system).toEqual([{ type: "text", text: "You are Ada." }]);
     expect(call.messages).toEqual([{ role: "user", content: "Hello" }]);
     expect(call.max_tokens).toBe(DEFAULT_MAX_TOKENS);
   });
@@ -367,6 +366,42 @@ describe("complete, on Anthropic", () => {
       content: "KNOWLEDGE: the handbook says Tuesdays.",
     });
     expect(call.messages[3]).toEqual({ role: "user", content: "And Wednesdays?" });
+  });
+
+  it("marks nothing on a turn whose prefix will not be asked for again", async () => {
+    // The first turn of a conversation, and the regression this pins. With no
+    // prior turns the retrieved block folds into `system`, and the next turn's
+    // `system` is the persona alone — the two never match, so the entry would
+    // be written, charged at 1.25x, and never read.
+    await complete(env, {
+      model: "claude-sonnet-4-6",
+      messages: [
+        { role: "system", content: "You are Ada." },
+        { role: "system", content: "KNOWLEDGE: the handbook says Tuesdays." },
+        { role: "user", content: "What does the handbook say?" },
+      ],
+    });
+
+    const call = anthropicCreate.mock.calls[0][0];
+    expect(call.system[0]).not.toHaveProperty("cache_control");
+    expect(call.messages.every((m: { content: unknown }) => typeof m.content === "string")).toBe(
+      true,
+    );
+  });
+
+  it("marks nothing for a one-shot caller that will never ask twice", async () => {
+    // Titling, persona drafting and a routine's summary all send one system
+    // message and one question. There is no second turn to read the cache back.
+    await complete(env, {
+      model: "claude-haiku-4-5",
+      messages: [
+        { role: "system", content: "Name this conversation." },
+        { role: "user", content: "How many vacation days do I get?" },
+      ],
+      json: true,
+    });
+
+    expect(anthropicCreate.mock.calls[0][0].system[0]).not.toHaveProperty("cache_control");
   });
 
   it("honours a ceiling the caller did name", async () => {

--- a/worker/src/lib/completion.ts
+++ b/worker/src/lib/completion.ts
@@ -290,6 +290,21 @@ export function toAnthropicMessages(messages: CompletionMessage[]): {
  * A prefix shorter than the model's minimum (1024 tokens, 2048 on Haiku) is not
  * cached and the request is not refused; a short chat simply pays what it pays
  * today.
+ *
+ * **Both markers are set together or not at all**, which is `cacheIndex`'s
+ * second job. A cache write is not free on this provider — Anthropic charges
+ * 1.25x input for the tokens it stores, as `lib/pricing.ts` says — so a marker
+ * on a prefix that will never be read back is a bill, not a saving. That is
+ * exactly what the first turn of a conversation is: with no prior turns,
+ * `toAnthropicMessages` folds the retrieved block into `system` (nothing
+ * precedes it, so by this function's own rule it is a leading system message),
+ * and the next turn's `system` is the persona alone. The two do not match, the
+ * entry is never read, and the write was paid for.
+ *
+ * `cacheIndex` is null in precisely that case and in the one-shot callers
+ * (titling, persona drafting, a routine's summary) which send one system
+ * message and one question and never ask twice. So it is the right condition
+ * for both: mark nothing until there is repeated history to mark.
  */
 const CACHE_CONTROL = { type: "ephemeral" as const };
 
@@ -319,7 +334,15 @@ function anthropicParams(
         : messages.map((m, i) => (i === cacheIndex ? withCacheBreakpoint(m) : m)),
     max_tokens: req.maxTokens ?? DEFAULT_MAX_TOKENS,
     ...(systemText
-      ? { system: [{ type: "text" as const, text: systemText, cache_control: CACHE_CONTROL }] }
+      ? {
+          system: [
+            {
+              type: "text" as const,
+              text: systemText,
+              ...(cacheIndex === null ? {} : { cache_control: CACHE_CONTROL }),
+            },
+          ],
+        }
       : {}),
     ...(req.temperature !== undefined && acceptsTemperature(req.model)
       ? { temperature: req.temperature }


### PR DESCRIPTION
## What problem does this solve?

Follow-up to #130, which put a `cache_control` marker on the Anthropic system block unconditionally. On the **first turn of a conversation** that is the wrong block to cache, and it costs money rather than saving it.

A cache write is not free on this provider: Anthropic charges **1.25× input** for the tokens it stores. `lib/pricing.ts` says so in a comment and then deliberately does not model it, which is exactly why this was easy to miss.

The first turn is the case. With no prior turns there is nothing in front of the retrieved block, so `toAnthropicMessages` folds it into `system` by its own leading-system rule — the stored block is `persona + this question's excerpts`. The next turn *does* have prior turns, so its `system` is the persona alone. The two never match, the entry is never read, and the premium was paid for nothing. A one- or two-turn conversation paid it every time and got nothing back.

`cacheIndex` already answers the question. It is null when there is no repeated history — the first turn, and every one-shot caller (titling, the persona drafter, a routine's summary), none of which ask twice. So both markers are now set together or not at all, and the condition reads as what it means: **mark nothing until there is something to re-read.**

The message-level breakpoint is untouched, and it is the one doing the work regardless — it caches the entire prefix up to that turn, system block included, and grows with the conversation.

Found by tracing the change through a real first turn rather than through the tests, which only ever exercised a conversation that already had history.

## Checks

- [x] The commands above pass

## If you touched the database

Not touched.

## If you touched `serviceClient()` or the service-role key

Not touched.

## If you touched UI

Not touched.

---

By opening this pull request you agree to the contributor license agreement in
[`CONTRIBUTING.md`](../CONTRIBUTING.md#contributor-license-agreement).