### PR TITLE
Stop making the most expensive model the default by accident

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -89,7 +89,9 @@ ones (`claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-haiku-4-5`) on an
 install whose operator set `ANTHROPIC_API_KEY`. Anything the API does not
 recognise — an id from an older list, or a Claude one on an install with no key
 for it — resolves to `gpt-4o`, which is what keeps every agent answering across
-a change to either list. The mode is
+a change to either list. A _new_ agent starts on `gpt-4.1-mini` instead, unless
+the workspace names a default of its own: roughly a sixth of the price, and the
+one most people never change. The mode is
 `normal` or `brainstorm`, and brainstorm layers a facilitation instruction block
 on top of the persona rather than replacing it.
 

--- a/src/components/create-agent-dialog.tsx
+++ b/src/components/create-agent-dialog.tsx
@@ -17,7 +17,7 @@ import {
 import { Upload, X, FileText, ChevronRight, ChevronLeft, Sparkles } from "lucide-react";
 import { useAgentsStore } from "@/lib/agents-store";
 import { GeneratePersonaButton } from "@/components/generate-persona-button";
-import { EMOJIS, MODELS, PERSONA_TEMPLATES, modelsFor } from "@/lib/agent-meta";
+import { EMOJIS, DEFAULT_NEW_AGENT_MODEL, PERSONA_TEMPLATES, modelsFor } from "@/lib/agent-meta";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 
@@ -62,7 +62,7 @@ function CreateAgentForm({ onDone }: { onDone: () => void }) {
   const navigate = useNavigate();
   // Shares the cache the dashboard already filled, so this costs no request.
   const { data: me } = useQuery({ queryKey: ["me"], queryFn: () => api.me() });
-  const startingModel = me?.workspace.defaultModel ?? MODELS[0];
+  const startingModel = me?.workspace.defaultModel ?? DEFAULT_NEW_AGENT_MODEL;
   const [saving, setSaving] = useState(false);
   const [step, setStep] = useState<1 | 2>(1);
   const [name, setName] = useState("");

--- a/src/lib/agent-meta.test.ts
+++ b/src/lib/agent-meta.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { EMOJIS, MODELS, PERSONA_TEMPLATES, modelsFor, specFor } from "./agent-meta";
+import {
+  EMOJIS,
+  MODELS,
+  PERSONA_TEMPLATES,
+  modelsFor,
+  specFor,
+  DEFAULT_NEW_AGENT_MODEL,
+} from "./agent-meta";
 
 /**
  * Two invariants that nothing else would catch, because both fail silently.
@@ -94,5 +101,33 @@ describe("specFor", () => {
   it("answers the same way before /me has said anything at all", () => {
     expect(specFor(undefined, "gpt-5-mini")).toEqual({ temperature: true, reasoning: false });
     expect(specFor(specs, null)).toEqual({ temperature: true, reasoning: false });
+  });
+});
+
+describe("the model a new agent starts on", () => {
+  it("is one this build knows", () => {
+    expect(MODELS).toContain(DEFAULT_NEW_AGENT_MODEL);
+  });
+
+  it("is one every deployment can actually serve", () => {
+    // The real invariant, and the one that would fail silently. A Claude id
+    // here would seed an unserveable model on every install without an
+    // ANTHROPIC_API_KEY: `resolveModel` would quietly drop it, and the agent
+    // would answer on something other than what its own settings page shows.
+    expect(DEFAULT_NEW_AGENT_MODEL.startsWith("claude-")).toBe(false);
+  });
+
+  it("is not simply the first thing in the picker", () => {
+    // What it was until this was named: `MODELS[0]`. That tuple is ordered for
+    // reading — flagships first — and the head of a display order is not a
+    // statement about what a new agent should cost. Coupling the two made the
+    // most expensive model in the list the default by accident.
+    expect(DEFAULT_NEW_AGENT_MODEL).not.toBe(MODELS[0]);
+  });
+
+  it("is not more expensive than the templates people pick instead", () => {
+    // A default nobody changes should not cost more than the curated starting
+    // points beside it. gpt-4o is the id this is moving away from.
+    expect(PERSONA_TEMPLATES.some((t) => t.model === "gpt-4o")).toBe(false);
   });
 });

--- a/src/lib/agent-meta.ts
+++ b/src/lib/agent-meta.ts
@@ -35,6 +35,31 @@ export const MODELS = [
 ] as const;
 
 /**
+ * Where the model picker starts for a new agent, when the workspace has named
+ * no preference of its own.
+ *
+ * This used to be `MODELS[0]`, which is `gpt-4o`, and that coupling was the
+ * whole problem: the tuple is ordered for *reading* — flagships first, so an
+ * unchanged install finds them — and the first item of a display order is not
+ * a statement about what anybody should be spending. Nothing said so, so the
+ * most expensive model in the list was the default by accident.
+ *
+ * And it is the default that decides, because most people accept it. The model
+ * it seeds is written to the agent row explicitly, so those agents are not
+ * "on the default" in any way a later change could reach — they are on
+ * `gpt-4o`, by name, forever. Which is also why this only affects agents made
+ * from here on, and why nothing retroactively moves an agent somebody is
+ * already talking to.
+ *
+ * `gpt-4.1-mini` rather than something cheaper still: it is roughly a sixth of
+ * `gpt-4o` and newer, it **accepts a temperature** — `gpt-5-mini` does not, and
+ * would have made the per-agent temperature setting inert on every new agent —
+ * and it does not bill thinking against the answer's ceiling. Cheaper is
+ * available (`gpt-4o-mini`) and one Select away for anyone who wants it.
+ */
+export const DEFAULT_NEW_AGENT_MODEL = "gpt-4.1-mini";
+
+/**
  * What a model picker should list: what this install offers, plus whatever the
  * thing being edited is already on.
  *
@@ -126,7 +151,7 @@ export const PERSONA_TEMPLATES: PersonaTemplate[] = [
     id: "coding",
     label: "Coding Assistant",
     emoji: "🧑‍💻",
-    model: "gpt-4o",
+    model: "gpt-4.1-mini",
     persona:
       "You are a senior software engineer. Give correct, idiomatic code that matches the team's existing conventions. Explain trade-offs briefly, prefer small focused changes, and point out edge cases. Reference the team's docs when relevant.",
   },
@@ -134,7 +159,7 @@ export const PERSONA_TEMPLATES: PersonaTemplate[] = [
     id: "gtm",
     label: "GTM Strategist",
     emoji: "🚀",
-    model: "gpt-4o",
+    model: "gpt-4.1-mini",
     persona:
       "You are a go-to-market strategist. Help the team with positioning, messaging, and launch planning grounded in our product docs. Be sharp and specific, avoid generic marketing fluff, and always tie advice back to the target customer.",
   },
@@ -142,7 +167,7 @@ export const PERSONA_TEMPLATES: PersonaTemplate[] = [
     id: "tutor",
     label: "Knowledge Tutor",
     emoji: "🎓",
-    model: "gpt-4o",
+    model: "gpt-4.1-mini",
     persona:
       "You are a patient tutor. Explain concepts from the team's documents clearly, adapting to the learner's level. Use examples and analogies, check understanding with a short question, and never invent facts outside the knowledge base.",
   },
@@ -150,7 +175,7 @@ export const PERSONA_TEMPLATES: PersonaTemplate[] = [
     id: "writer",
     label: "Content Writer",
     emoji: "✍️",
-    model: "gpt-4o",
+    model: "gpt-4.1-mini",
     persona:
       "You are a skilled content writer who matches the team's brand voice. Draft clear, engaging copy grounded in our docs. Offer a couple of variations when useful, keep it tight, and flag anything that needs a fact-check.",
   },

--- a/worker/src/lib/models.test.ts
+++ b/worker/src/lib/models.test.ts
@@ -53,6 +53,11 @@ describe("acceptsTemperature", () => {
 
   it("allows one everywhere else, unknown endpoints included", () => {
     expect(acceptsTemperature("gpt-4o")).toBe(true);
+    // The model new agents start on (`DEFAULT_NEW_AGENT_MODEL`, frontend). It
+    // was chosen partly for this: gpt-5-mini is cheaper on input and rejects a
+    // temperature, which would have made the per-agent temperature setting
+    // inert on every agent created from the picker's default.
+    expect(acceptsTemperature("gpt-4.1-mini")).toBe(true);
     expect(acceptsTemperature("claude-sonnet-4-6")).toBe(true);
     expect(acceptsTemperature("llama3.3:70b")).toBe(true);
   });


### PR DESCRIPTION
## What problem does this solve?

A new agent started on `gpt-4o` — **$2.50 / $10.00 per million, the most expensive id in the list** — and nothing had decided that. The create dialog seeded `MODELS[0]`, and that tuple is ordered for *reading*: flagships first, so an unchanged install finds them. The head of a display order is not a statement about what anyone should spend; coupling the two made it one silently.

It matters because **the default is what people take.** And the model it seeds is written to the agent row by name — so those agents are not "on the default" in any sense a later change can reach. They are on `gpt-4o`, explicitly, for good. Four of the seven starter templates named it outright as well, and the welcome flow creates an agent from a template for **every new account**.

`DEFAULT_NEW_AGENT_MODEL` names the decision instead, at `gpt-4.1-mini` — roughly a sixth of the price, and a newer model.

## Why not something cheaper

| | in / out per M | vs gpt-4o | |
|---|---|---|---|
| `gpt-4o` (was) | $2.50 / $10.00 | — | |
| **`gpt-4.1-mini`** | $0.40 / $1.60 | **~6× cheaper** | ✅ chosen |
| `gpt-5-mini` | $0.25 / $2.00 | cheaper input | ❌ **rejects a temperature** |
| `gpt-4o-mini` | $0.15 / $0.60 | ~16× cheaper | older; stays one Select away |

`gpt-5-mini` is the trap. It is cheaper on input and it rejects any temperature but its own — so choosing it would have made the per-agent temperature setting (#131, shipped yesterday) **inert on every agent created from the default**, a feature switched off by a pricing decision in a way nobody would ever connect back to this line. `worker/src/lib/models.test.ts` now pins that reason next to `acceptsTemperature`.

## Scope

- ✅ New agents, from the dialog and from templates
- ❌ **Nothing retroactive.** `DEFAULT_MODEL` in the worker is untouched — that is the fallback for an agent whose `model` is null, and moving it would change how existing agents answer without anyone asking.
- `analyst` keeps `gpt-4.1`; that one is a judgement about the work rather than an accident of ordering. `support` and `onboarding` were already on `gpt-4o-mini`.

Workspaces that set their own default under Settings → Preferences are unaffected either way — that still wins.

## Checks

- [x] The commands above pass

## If you touched the database

Not touched.

## If you touched `serviceClient()` or the service-role key

Not touched.

## If you touched UI

- [x] No visual change — one seeded value and four template models.

---

By opening this pull request you agree to the contributor license agreement in
[`CONTRIBUTING.md`](../CONTRIBUTING.md#contributor-license-agreement).