### PR TITLE
Hybrid retrieval: match on words as well as on meaning

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -72,6 +72,20 @@ EMBEDDING_DIMENSIONS=
 # worse. Worth revisiting if you set EMBEDDING_MODEL. 0 disables the floor.
 RAG_MIN_SIMILARITY=
 
+# ---- Optional: retrieval's lexical (keyword) arm -----------------------
+# Turns the keyword-matching half of retrieval on or off. Alongside the usual
+# vector search, retrieval also matches a question's significant words against
+# the chunk text directly, so a code, a name or an acronym typed exactly as it
+# appears in a document can be found even when it means little to the
+# embedding model. Empty or "on" means enabled — that is the default. "off"
+# disables it; any other value refuses to start.
+# Worth turning off for a corpus that is neither Turkish nor English-with-
+# common-terms: the matching has no language-specific dictionary behind it
+# (deliberately — see 0049_the_words_as_well_as_the_meaning.sql), so on a
+# corpus it was not tuned for it can add noisy matches without adding any
+# real recall.
+RAG_LEXICAL=
+
 # ---- Local Postgres ----------------------------------------------------
 POSTGRES_PASSWORD=covan-local-dev-password
 # Host port for psql / a GUI client. The database itself always listens on

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -333,6 +333,9 @@ services:
       # Retrieval's relevance floor. Empty means 0.25, tuned for
       # text-embedding-3-small; another embedding model wants its own.
       RAG_MIN_SIMILARITY: ${RAG_MIN_SIMILARITY:-}
+      # Retrieval's lexical (keyword) arm. Empty or "on" means enabled; "off"
+      # turns it off for a corpus it doesn't suit.
+      RAG_LEXICAL: ${RAG_LEXICAL:-}
       ROUTINE_SECRET_KEY: ${ROUTINE_SECRET_KEY:?set ROUTINE_SECRET_KEY in .env}
       ALLOWED_ORIGIN: ${ALLOWED_ORIGIN:-http://localhost:3000}
       # No R2 binding off Cloudflare, so getDocStore falls to the filesystem

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -177,18 +177,41 @@ rather than letting Postgres refuse the insert later. See
 1. Collect the bundles attached to the agent and the document *names* in them.
    Names alone, on the hot path — the stored full text is only needed by the
    fallback below, so it is loaded lazily there rather than on every turn.
-2. Embed the latest user message and call `match_chunks(p_agent_id,
-   p_query_embedding, p_match_count => 10, p_min_similarity => 0.25)`.
-3. `match_chunks` (`0005_message_sources_and_match_threshold.sql`) is
-   `SECURITY INVOKER`, so RLS on `document_chunks` and `documents` still applies.
-   It computes `1 - (embedding <=> query)` as cosine similarity, keeps only rows
-   at or above the floor, restricts to chunks whose bundle is attached to this
-   agent, orders by distance and takes the top *n*.
+2. Embed the latest user message, extract its search terms
+   (`worker/src/lib/search-terms.ts`'s `searchTerms`), and call
+   `match_chunks(p_agent_id, p_query_embedding, p_match_count => 10,
+   p_min_similarity => 0.25, p_query_terms => terms)`. `p_query_terms` is `[]`
+   whenever `RAG_LEXICAL` disables the lexical arm (`lexicalSearchEnabled`) or
+   the question yields no usable terms, which turns the fifth argument back
+   into the pre-hybrid default and the call behaves exactly as it did before.
+3. `match_chunks` (`0049_the_words_as_well_as_the_meaning.sql`, growing the
+   signature `0005_message_sources_and_match_threshold.sql` first defined) is
+   `SECURITY INVOKER`, so RLS on `document_chunks` and `documents` still
+   applies. It now runs two arms over the same bundle-scoped, non-deleted rows
+   and fuses them:
 
-   The floor is the interesting part. Without it, an off-topic question still
-   returns the ten nearest chunks — nearest is not the same as relevant — and
-   those get injected into the prompt as though they were evidence. The SQL
-   default is `0` for backward compatibility; the API passes `0.25`.
+   - The **vector arm** is the original query: `1 - (embedding <=> query)` as
+     cosine similarity, floored at `p_min_similarity`, ordered by distance.
+   - The **lexical arm** matches `document_chunks.search_tsv` (a generated
+     `tsvector` covering the document name and chunk content, `'simple'`
+     config — no stemmer, so a verbatim code, name or acronym is not blurred
+     the way an embedding can blur it) against the query terms, OR'd together
+     and ranked by `ts_rank_cd`. It carries no similarity floor of its own — a
+     lexical hit is a match by a different definition than cosine distance.
+   - Each arm contributes candidates (`p_match_count * 4` each) that are
+     combined with Reciprocal Rank Fusion — grouped by chunk id, each arm's
+     rank turned into `1.0 / (60 + rank)`, the vector arm weighted `1.0` and
+     the lexical arm `0.8` — and the top `p_match_count` by fused score is
+     returned. A chunk found by both arms is scored higher than one found by
+     either alone.
+
+   The floor is still the interesting part for the vector arm. Without it, an
+   off-topic question still returns the ten nearest chunks — nearest is not the
+   same as relevant — and those get injected into the prompt as though they
+   were evidence. The SQL default is `0` for backward compatibility; the API
+   passes `0.25`. The lexical arm has no analogous floor: OR semantics already
+   mean a bad term just fails to contribute, rather than dragging in noise the
+   way a missing floor would on the vector side.
 4. Matching chunks are assembled by `buildContextBlock` (`lib/rag.ts`) under a
    4000-character budget, in similarity order, and dropped once the budget is
    spent.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,7 +213,8 @@ rather than letting Postgres refuse the insert later. See
    mean a bad term just fails to contribute, rather than dragging in noise the
    way a missing floor would on the vector side.
 4. Matching chunks are assembled by `buildContextBlock` (`lib/rag.ts`) under a
-   4000-character budget, in similarity order, and dropped once the budget is
+   4000-character budget, in fused-RRF order (the `order by fused_score desc`
+   from step 3, not raw cosine similarity), and dropped once the budget is
    spent.
 5. The block is sent as its own system message positioned *after* the prior
    turns and before the latest one — deliberately not merged into the persona

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,11 +224,13 @@ rather than letting Postgres refuse the insert later. See
    `messages.sources`, so citations survive a reload instead of being recomputed
    in the client.
 
-There is a fallback: if nothing clears the floor but the agent does have
-documents, the reply is grounded on the stored document text directly, newest
-first, under the same budget. This exists for "summarise the file" style
-questions, which embed close to nothing in particular and would otherwise get an
-agent claiming it cannot read a file it plainly has.
+There is a fallback: if no chunk matches at all — neither close enough in
+meaning to clear the vector floor nor a hit on the lexical arm's own terms —
+but the agent does have documents, the reply is grounded on the stored
+document text directly, newest first, under the same budget. This exists for
+"summarise the file" style questions, which embed close to nothing in
+particular and would otherwise get an agent claiming it cannot read a file it
+plainly has.
 
 Retrieval is best-effort throughout. Any failure — embedding, the RPC, the
 fallback — falls back to a persona-only answer rather than failing the turn.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -49,10 +49,18 @@ size.
 perfectly and answers nothing. So does a heading with nothing under it. The
 agent can only say what the text says.
 
-**Use the words people ask in.** Matching is on meaning as the embedding model
-represents it, so a document written entirely in internal shorthand and a
-question written in plain English may not meet. This is what makes a glossary of
-your own terms one of the highest-value files in a workspace.
+**Use the words people ask in.** Matching is on meaning and on wording now: a
+question still has to land near a passage in the embedding model's sense, but a
+code, a name or an acronym typed exactly as it appears in a document can also be
+found by the words themselves, even when it means almost nothing to the
+embedding model. A document written entirely in internal shorthand and a
+question written in plain English can still miss on meaning, so this doesn't
+replace speaking the reader's language — it just means your own exact terms are
+no longer invisible to search. This is still what makes a glossary of your own
+terms one of the highest-value files in a workspace, though the reason has
+shifted: it used to teach the model what your shorthand meant; now it also
+guarantees that shorthand is one of the exact strings retrieval can find
+verbatim.
 
 **Say when it was true.** Nothing updates a document in place — a re-upload
 makes a new one — so a date inside the text is the only version the agent can
@@ -203,6 +211,14 @@ Each turn starts by embedding the message that was just sent, with the same mode
 the chunks were embedded with, and asking the database for the ten nearest chunks
 across the attached bundles whose cosine similarity is at or above 0.25.
 
+Alongside that, the significant words in the question — short filler words and
+grammar dropped — are matched against the chunks directly, as text, not as
+meaning. A passage that uses the same code, name or acronym the question does
+can be found this way even when it sits nowhere near that question in the
+embedding model's sense. The two sets of candidates are combined into one
+ranking, so a chunk that matches on both counts more than one that matches on
+only one, and neither way of matching crowds the other out.
+
 Ten are asked for and fewer are sent: a passage already contained in one further
 up the list is dropped rather than repeated — the same document reached through
 two bundles is chunked once per bundle, so the same words can come back twice —
@@ -223,8 +239,9 @@ self-hosted Covan that embeds with something else needs its own — which is wha
 wrong for the model in use produces no error at all, only answers that are
 vaguer or emptier than they should be.
 
-What survives is assembled in similarity order under a 4000-character budget and
-sent as its own system message, positioned after the earlier turns and just
+What survives is assembled in ranked order — meaning-matches and wording-matches
+merged into one ordering — under a 4000-character budget and sent as its own
+system message, positioned after the earlier turns and just
 before the latest one. Two details of that block matter when you read a reply.
 The budget is spent in order, so the last chunk admitted can be cut off partway
 through, and anything after the budget runs out is dropped. And the block
@@ -242,19 +259,31 @@ the model what exists without telling it what any of it says.
 It is worth being exact about this, because it is easy to assume the floor alone
 produces "I don't know". It does not, on its own.
 
-If no chunk clears the floor and the agent has documents, the reply is grounded
-on those documents' stored excerpts instead, newest first, under the same
-4000-character budget. That escape hatch exists for questions like "summarise the
-file", which embed close to nothing in particular and would otherwise get an
-agent insisting it cannot read a document it is holding. So an agent answers from
-its persona alone only when it genuinely has nothing: no attached bundles, or
-nothing in them with any extractable text.
+If no chunk matches at all — neither close enough in meaning to clear the floor
+nor a wording match on its own terms — and the agent has documents, the reply is
+grounded on those documents' stored excerpts instead, newest first, under the
+same 4000-character budget. That escape hatch exists for questions like
+"summarise the file", which embed close to nothing in particular and would
+otherwise get an agent insisting it cannot read a document it is holding. So an
+agent answers from its persona alone only when it genuinely has nothing: no
+attached bundles, or nothing in them with any extractable text.
 
-The honest reading of an answer is therefore that the floor governs what is
+The honest reading of an answer is therefore that matching governs what is
 presented as a matched passage, and the fallback governs what is available when
 nothing matched. The model can still say it does not know, and with excerpts of
 unrelated documents in front of it that is the right answer — but it is the model
 declining, not the retrieval layer having withheld everything.
+
+This also changes what "grounded" means internally. What Covan records against a
+reply as grounded on the team's documents used to mean, exactly, that a passage
+cleared the similarity floor. Now a passage that matched only by its exact
+wording — with no floor of its own to clear — counts the same way. That is a
+real widening, not a technicality: an answer can now be grounded on a chunk that
+the embedding model would never have called a close match, because a code, a
+name or an acronym in it lined up with the question word for word. The chip
+under the answer and the fallback behaviour above both stay the same either
+way — this only affects what gets counted as "matched" versus "nothing matched"
+before the fallback is even considered.
 
 Retrieval is best-effort throughout. If embedding the question or the search
 itself fails, the turn quietly falls back to a persona-only answer rather than

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -112,6 +112,7 @@ every line in `.env.docker.example`, in the order it appears there.
 | `EMBEDDING_MODEL`                                      | _empty_                    | Optional. Defaults to `text-embedding-3-small`. Set it whenever `EMBEDDING_BASE_URL` is set.                                                                                                                                                 |
 | `EMBEDDING_DIMENSIONS`                                 | _empty — means 1536_       | Optional. The width `document_chunks.embedding` was declared with. Changing it is a schema change — see below. Refuses to boot on anything but a positive whole number.                                                                      |
 | `RAG_MIN_SIMILARITY`                                   | _empty — means 0.25_       | Optional. Cosine-similarity floor below which a retrieved chunk is dropped. `0` disables it. Tuned for `text-embedding-3-small`; another model wants its own.                                                                                |
+| `RAG_LEXICAL`                                           | _empty — means `on`_       | Optional. Enables retrieval's keyword-matching arm alongside vector search, so an exact code, name or acronym can be found even when it embeds far from the question. `off` disables it; any other value refuses to start.                    |
 | `POSTGRES_PASSWORD`                                    | `covan-local-dev-password` | The database password. `auth`, `rest`, `realtime` and `migrate` all connect with it.                                                                                                                                                         |
 | `POSTGRES_PORT`                                        | `54322`                    | **Host** port only, for `psql` or a GUI client. Inside the compose network Postgres is always on 5432.                                                                                                                                       |
 | `JWT_SECRET`                                           | Supabase demo secret       | Signs and verifies every access token. Changing it invalidates `ANON_KEY` and `SERVICE_ROLE_KEY`, which are JWTs signed with it. Also passed to the API as `SUPABASE_JWT_SECRET`, which is what makes API keys work — see [The API](api.md). |
@@ -300,6 +301,14 @@ fact about the model you chose rather than about Covan. In short:
    else, and a floor that is wrong for it never errors — too high starves
    genuine matches, too low fills every prompt with noise. Both just look like
    the answers got worse.
+
+`RAG_LEXICAL` is a similarly self-hoster-tunable dial, though it isn't tied to
+the embedding model — it's tied to the corpus's language. It defaults to `on`
+and adds keyword matching alongside whatever embedding model you've pointed
+retrieval at. Turn it `off` for a corpus that is neither Turkish nor English:
+the matching uses no language-specific dictionary, so on a non-Latin-script or
+otherwise structurally different corpus it can add noisy matches rather than
+real recall.
 
 The API refuses to start on an `EMBEDDING_DIMENSIONS` that is not a positive
 whole number, or a `RAG_MIN_SIMILARITY` outside 0–1, naming the variable. A

--- a/supabase/migrations/0049_the_words_as_well_as_the_meaning.sql
+++ b/supabase/migrations/0049_the_words_as_well_as_the_meaning.sql
@@ -118,6 +118,22 @@
 -- collapse onto one, so "İŞE ALIM" keeps matching "işe alım". Must be
 -- `immutable` to appear inside a generated column's expression below — both
 -- `lower()` and `replace()` qualify.
+--
+-- Locale assumption: the correctness of this folding rests on `lower()`
+-- performing Unicode-aware case folding, not a `C`/POSIX-locale ASCII-only
+-- lowercase. Under a `C` locale, `lower()` leaves non-ASCII characters (like
+-- İ, U+0130) untouched, so it would never produce the "i" + combining dot
+-- (U+0307) that the `replace(..., U&'\0307', '')` step strips — "İŞE ALIM"
+-- would then silently fail to fold to "işe alım", the exact breakage this
+-- migration exists to fix. Supabase's hosted and self-hosted Postgres both
+-- run a UTF-8/ICU-aware locale, under which `lower()` does the expected
+-- Unicode case folding, so this holds in practice — but it is a database
+-- configuration assumption, not something this function enforces or can
+-- enforce. Spot-check post-deploy with:
+--   select public.rag_fold('İŞE ALIM');
+-- which should return 'ise alim' (the function only lowercases and folds
+-- İ/ı; it does not touch spaces, so the space between the two words is
+-- preserved as-is).
 create or replace function public.rag_fold(value text)
 returns text
 language sql
@@ -178,6 +194,16 @@ stable
 security invoker
 set search_path = pg_catalog, public
 as $$
+  -- Precondition on `p_query_terms`: every element must be non-empty *after*
+  -- `rag_fold` normalization. A term that folds to '' (an empty string, or a
+  -- string made entirely of characters `rag_fold` strips) produces the token
+  -- `':*'` with no lexeme in front of it — not valid `tsquery` syntax — and
+  -- casting it below would raise an error for the whole `match_chunks` call,
+  -- not just skip that one term. This function does not filter or guard
+  -- against that input; it is the caller's job. The worker's term-extraction
+  -- step (`worker/src/lib/search-terms.ts`) is responsible for filtering
+  -- short/blank tokens before calling this function, so in practice this
+  -- never fires — but nothing in this SQL enforces it.
   with q as (
     select case when cardinality(p_query_terms) = 0 then null
            else array_to_string(

--- a/supabase/migrations/0049_the_words_as_well_as_the_meaning.sql
+++ b/supabase/migrations/0049_the_words_as_well_as_the_meaning.sql
@@ -1,0 +1,244 @@
+-- =========================================================================
+-- The words as well as the meaning
+--
+-- `match_chunks` today only matches on meaning: it walks `document_chunks`
+-- ordered by embedding distance and stops at `p_min_similarity`. That is the
+-- right tool for "what did we say about onboarding" and the wrong one for a
+-- contract number, a SKU, an acronym, or an error code — a verbatim string
+-- that is semantically almost nothing to an embedding model, and that can
+-- therefore sit under the similarity floor even when it appears in the chunk
+-- word for word. The result is a wrong or absent answer to a question whose
+-- answer was sitting right there in the team's own documents.
+--
+-- Postgres ships no Turkish dictionary, and the terms this migration exists to
+-- catch — codes, names, acronyms — are exactly what a stemmer must not touch
+-- anyway. So the new lexical arm uses the `'simple'` text search
+-- configuration (tokenize, lowercase, no stemming) with prefix matching,
+-- rather than reaching for a dictionary Postgres does not have.
+--
+-- Three things ship together:
+--
+--   1. `rag_fold`, a SQL-side mirror of `worker/src/lib/doc-question.ts`'s
+--      `fold()`. JavaScript's default (non-Turkish-aware) lower-casing turns
+--      "İ" into "i" plus a combining dot above (U+0307) and leaves "I" as
+--      plain "i" — so Turkish's four I's (İ i I ı) do not all collapse onto
+--      one unless the dot is stripped and "ı" is folded in by hand. Without
+--      this, "İŞE ALIM" stops matching "işe alım" over a single letter, in
+--      the language most of this product's users type in. Both sides of a
+--      lexical match — the stored `search_tsv` and the terms the worker sends
+--      in `p_query_terms` — are folded through this same function so they
+--      agree.
+--
+--   2. Two columns on `document_chunks`: `context`, and a generated,
+--      indexed `search_tsv`. `context` holds the document's name, not the
+--      prompt — `rag.ts`'s `buildContextBlock` already writes `Document:
+--      <name>` into the context block it sends the model, so folding the name
+--      into `content` as well would print it twice and spend the character
+--      budget doing it. A separate column makes the name searchable (a
+--      question naming a file by its filename should find that file's
+--      chunks) without duplicating it. `search_tsv` is generated with the
+--      two-argument `to_tsvector('simple', ...)`, not the one-argument form:
+--      the one-argument form reads `default_text_search_config` at run time
+--      and is therefore only `stable`, which a generated column's expression
+--      is not allowed to be. The two-argument form pins the configuration and
+--      is `immutable`. Both new columns are backfilled in this same
+--      migration — `context` from `documents.name`, free, no embedding calls.
+--
+--   3. `match_chunks` itself, replaced rather than altered because its
+--      signature grows: a fifth argument, `p_query_terms text[] default
+--      '{}'`, defaulting to empty so every existing caller — the RPC's other
+--      readers, and the 4-arg call in `tests/rls/soft-deletion.test.ts` — is
+--      unaffected and needs no code change to keep working. That default is
+--      also why this migration is safe to apply ahead of the worker deploy
+--      that will start passing terms: until that deploy ships, every call
+--      still arrives with `p_query_terms = '{}'`.
+--
+-- The new body fuses two arms with Reciprocal Rank Fusion rather than
+-- picking one:
+--
+--   - The vector arm is the old query, unchanged in every clause that
+--     matters for correctness: same `knowledge_bundles` join, same two
+--     `deleted_at is null` checks (0040 — a chunk is retrievable only while
+--     both the document it came from and the bundle it is filed under are
+--     alive), same `agent_bundles` scoping, same `p_min_similarity` floor,
+--     ranked by cosine distance, `limit p_match_count * 4` candidates.
+--
+--   - The lexical arm shares those joins, filters, and scoping, but carries
+--     no similarity floor — a chunk containing the query's rare terms
+--     verbatim is a match by a different definition than cosine similarity,
+--     and a floor built for one does not belong on the other. It matches
+--     against `search_tsv` with a `tsquery` built from `p_query_terms`,
+--     folded through `rag_fold` and joined with `:*` (prefix) and `|` (OR):
+--     prefix matching is the Turkish story — with no stemmer, `search_tsv`
+--     for "fiyatlandırma" never matches the query term "fiyatlandırmada" on
+--     an exact-token basis, but it does against "fiyatlandırma:*" — and `|`
+--     rather than `&` because a long natural-language question ANDed
+--     together matches nothing. The worker only ever sends sanitised
+--     alphanumeric terms (a later task enforces this), so this never builds
+--     a `tsquery` out of raw user text. Ranked by `ts_rank_cd`, same `limit
+--     p_match_count * 4`.
+--
+--   - Fusion groups by `document_chunks.id` — the row's actual primary key —
+--     not by `content`, so two different chunks that happen to hold
+--     identical text are never merged into one fused row. Each arm
+--     contributes `1.0 / (60 + rank)` (60 is the standard RRF constant); the
+--     vector arm is weighted `1.0` and the lexical arm `0.8`, so a tied rank
+--     favors the arm that still has a relevance floor behind it. `similarity`
+--     in the result is the vector arm's cosine when a chunk was found by it,
+--     and `null` for a lexical-only hit — `retrieval.ts` already discards
+--     this column, so it is kept only for the RPC's other readers. The final
+--     `order by fused_score desc` is what `rag.ts`'s `buildContextBlock`
+--     relies on: it spends its character budget front to back on the order
+--     the RPC hands back, and nothing downstream re-sorts.
+--
+-- What this deliberately does not do: it does not add a Turkish stemming
+-- dictionary (Postgres ships none, and a stemmer would blur exactly the
+-- verbatim codes and names this migration exists to catch); it does not
+-- touch `p_min_similarity`'s semantics for the vector arm; and it does not
+-- change what a lexical-only hit is allowed to claim downstream — it still
+-- only ever produces `messages.grounding = 'chunks'` (the check constraint
+-- from `0039_whether_anything_came_close.sql`, allowed values `'chunks' |
+-- 'documents' | 'none'`), whose meaning is widening by this migration from
+-- "cleared the similarity floor" to "matched, by meaning or by wording" —
+-- the same column, a broader definition of what it records, tracked as
+-- `covan#44`.
+--
+-- What does not change: when `p_query_terms` is `'{}'` (the default), the
+-- lexical CTE's `tsq` is `null`, its `where q.tsq is not null` clause admits
+-- no rows, and `lexical_matches` is empty — so the fused result is exactly
+-- the pre-migration `match_chunks`, byte for byte. That property, not just
+-- the default argument, is what makes this safe to apply before the worker
+-- deploy that starts sending terms.
+-- =========================================================================
+
+-- ---- a. Turkish-aware case folding, mirroring worker/src/lib/doc-question.ts's
+-- fold(): JS's default lower-casing turns "İ" into "i" + a combining dot above
+-- (U+0307) rather than a plain "i", and leaves "I" un-Turkish-ified; folding
+-- both "ı" and the combining dot away is what makes all four of Turkish's I's
+-- collapse onto one, so "İŞE ALIM" keeps matching "işe alım". Must be
+-- `immutable` to appear inside a generated column's expression below — both
+-- `lower()` and `replace()` qualify.
+create or replace function public.rag_fold(value text)
+returns text
+language sql
+immutable
+set search_path = pg_catalog, public
+as $$ select replace(replace(lower(value), 'ı', 'i'), U&'\0307', '') $$;
+
+-- Not 0023 (which only restores table/sequence grants): the shape here
+-- follows 0032's `workspace_usage_*` and 0038's `document_citation_counts`,
+-- the migrations that grant execute on a new function.
+grant execute on function public.rag_fold(text) to authenticated, service_role;
+
+-- ---- b. Two new columns on document_chunks --------------------------------
+
+alter table public.document_chunks add column if not exists context text;
+
+-- The two-argument `to_tsvector(regconfig, text)` is `immutable`; the
+-- one-argument form reads the `default_text_search_config` GUC at run time
+-- and is only `stable`, which a generated column's expression may not be.
+-- `'simple'` (tokenize + lowercase, no stemming) rather than a language
+-- dictionary: Postgres ships no Turkish one, and the terms this arm exists to
+-- catch — codes, names, acronyms — are exactly what a stemmer must not touch.
+alter table public.document_chunks
+  add column if not exists search_tsv tsvector
+  generated always as (
+    to_tsvector('simple', public.rag_fold(coalesce(context, '') || ' ' || content))
+  ) stored;
+
+create index if not exists document_chunks_search_tsv_idx
+  on public.document_chunks using gin (search_tsv);
+
+-- Free — no embedding calls, no worker involvement. `context` holds the
+-- document's name, not the prompt: `rag.ts`'s `buildContextBlock` already
+-- writes `Document: <name>` into the context block, so folding the name into
+-- `content` too would print it twice and spend the char budget on it. A
+-- separate column makes the name searchable without repeating it there.
+update public.document_chunks dc
+set context = d.name
+from public.documents d
+where d.id = dc.document_id and dc.context is null;
+
+-- ---- c. match_chunks, replaced with a hybrid (vector + lexical) version ---
+
+-- Signature is growing by one argument, so the old 4-arg function is dropped
+-- before the replacement is created.
+drop function if exists public.match_chunks(uuid, vector, int, float);
+
+create function public.match_chunks(
+  p_agent_id uuid,
+  p_query_embedding vector(1536),
+  p_match_count int,
+  p_min_similarity float default 0,
+  p_query_terms text[] default '{}'
+)
+returns table (document_id uuid, document_name text, content text, similarity float)
+language sql
+stable
+security invoker
+set search_path = pg_catalog, public
+as $$
+  with q as (
+    select case when cardinality(p_query_terms) = 0 then null
+           else array_to_string(
+                  array(select public.rag_fold(t) || ':*' from unnest(p_query_terms) t),
+                  ' | ')::tsquery
+           end as tsq
+  ),
+  vector_matches as (
+    select dc.id, dc.document_id, d.name as document_name, dc.content,
+           1 - (dc.embedding <=> p_query_embedding) as similarity,
+           row_number() over (order by dc.embedding <=> p_query_embedding) as rank
+    from public.document_chunks dc
+    join public.documents d on d.id = dc.document_id
+    join public.knowledge_bundles b on b.id = dc.bundle_id
+    where dc.embedding is not null
+      and d.deleted_at is null
+      and b.deleted_at is null
+      and (1 - (dc.embedding <=> p_query_embedding)) >= p_min_similarity
+      and dc.bundle_id in (
+        select ab.bundle_id from public.agent_bundles ab where ab.agent_id = p_agent_id
+      )
+    order by dc.embedding <=> p_query_embedding
+    limit p_match_count * 4
+  ),
+  lexical_matches as (
+    select dc.id, dc.document_id, d.name as document_name, dc.content,
+           row_number() over (order by ts_rank_cd(dc.search_tsv, q.tsq) desc) as rank
+    from public.document_chunks dc
+    join public.documents d on d.id = dc.document_id
+    join public.knowledge_bundles b on b.id = dc.bundle_id
+    cross join q
+    where q.tsq is not null
+      and dc.search_tsv @@ q.tsq
+      and d.deleted_at is null
+      and b.deleted_at is null
+      and dc.bundle_id in (
+        select ab.bundle_id from public.agent_bundles ab where ab.agent_id = p_agent_id
+      )
+    order by ts_rank_cd(dc.search_tsv, q.tsq) desc
+    limit p_match_count * 4
+  ),
+  fused as (
+    select id, document_id, document_name, content,
+           max(similarity) as similarity,
+           sum(score) as fused_score
+    from (
+      select id, document_id, document_name, content, similarity,
+             1.0 / (60 + rank) as score
+      from vector_matches
+      union all
+      select id, document_id, document_name, content, null::float as similarity,
+             0.8 / (60 + rank) as score
+      from lexical_matches
+    ) arms
+    group by id, document_id, document_name, content
+  )
+  select document_id, document_name, content, similarity
+  from fused
+  order by fused_score desc
+  limit p_match_count;
+$$;
+
+grant execute on function public.match_chunks(uuid, vector(1536), int, float, text[])
+  to authenticated, service_role;

--- a/supabase/optional/embedding_width.sql
+++ b/supabase/optional/embedding_width.sql
@@ -103,17 +103,27 @@ begin
     using hnsw (embedding vector_cosine_ops);
 
   -- The retrieval function takes the query vector by the same width, so it has
-  -- to be replaced too. Body copied from 0005 — if that migration ever changes
-  -- this file has to change with it, which is the cost of living outside the
-  -- sequence.
-  drop function if exists public.match_chunks(uuid, vector, int, float);
+  -- to be replaced too. Body copied from migration
+  -- 0049_the_words_as_well_as_the_meaning.sql — if that migration's
+  -- match_chunks ever changes again, this file has to change with it, which
+  -- is the cost of living outside the sequence.
+  --
+  -- This same edit also repairs drift that predates the hybrid-retrieval
+  -- feature: the body here used to be 0005's, missing the knowledge_bundles
+  -- join and the two `deleted_at is null` filters that migration 0040 added.
+  -- Running this file before this fix would have silently un-deleted
+  -- soft-deleted documents and bundles back into retrieval results. That
+  -- drift fix and the 0049 hybrid (vector + lexical) port land together in
+  -- this one commit — see git blame if you need to tell the two apart.
+  drop function if exists public.match_chunks(uuid, vector, int, float, text[]);
 
   execute format($fmt$
     create function public.match_chunks(
       p_agent_id uuid,
       p_query_embedding vector(%s),
       p_match_count int,
-      p_min_similarity float default 0
+      p_min_similarity float default 0,
+      p_query_terms text[] default '{}'
     )
     returns table (document_id uuid, document_name text, content text, similarity float)
     language sql
@@ -121,18 +131,65 @@ begin
     security invoker
     set search_path = pg_catalog, public
     as $body$
-      select dc.document_id,
-             d.name as document_name,
-             dc.content,
-             1 - (dc.embedding <=> p_query_embedding) as similarity
-      from public.document_chunks dc
-      join public.documents d on d.id = dc.document_id
-      where dc.embedding is not null
-        and (1 - (dc.embedding <=> p_query_embedding)) >= p_min_similarity
-        and dc.bundle_id in (
-          select ab.bundle_id from public.agent_bundles ab where ab.agent_id = p_agent_id
-        )
-      order by dc.embedding <=> p_query_embedding
+      with q as (
+        select case when cardinality(p_query_terms) = 0 then null
+               else array_to_string(
+                      array(select public.rag_fold(t) || ':*' from unnest(p_query_terms) t),
+                      ' | ')::tsquery
+               end as tsq
+      ),
+      vector_matches as (
+        select dc.id, dc.document_id, d.name as document_name, dc.content,
+               1 - (dc.embedding <=> p_query_embedding) as similarity,
+               row_number() over (order by dc.embedding <=> p_query_embedding) as rank
+        from public.document_chunks dc
+        join public.documents d on d.id = dc.document_id
+        join public.knowledge_bundles b on b.id = dc.bundle_id
+        where dc.embedding is not null
+          and d.deleted_at is null
+          and b.deleted_at is null
+          and (1 - (dc.embedding <=> p_query_embedding)) >= p_min_similarity
+          and dc.bundle_id in (
+            select ab.bundle_id from public.agent_bundles ab where ab.agent_id = p_agent_id
+          )
+        order by dc.embedding <=> p_query_embedding
+        limit p_match_count * 4
+      ),
+      lexical_matches as (
+        select dc.id, dc.document_id, d.name as document_name, dc.content,
+               row_number() over (order by ts_rank_cd(dc.search_tsv, q.tsq) desc) as rank
+        from public.document_chunks dc
+        join public.documents d on d.id = dc.document_id
+        join public.knowledge_bundles b on b.id = dc.bundle_id
+        cross join q
+        where q.tsq is not null
+          and dc.search_tsv @@ q.tsq
+          and d.deleted_at is null
+          and b.deleted_at is null
+          and dc.bundle_id in (
+            select ab.bundle_id from public.agent_bundles ab where ab.agent_id = p_agent_id
+          )
+        order by ts_rank_cd(dc.search_tsv, q.tsq) desc
+        limit p_match_count * 4
+      ),
+      fused as (
+        select id, document_id, document_name, content,
+               max(similarity) as similarity,
+               sum(score) as fused_score
+        from (
+          select id, document_id, document_name, content, similarity,
+                 1.0 / (60 + rank) as score
+          from vector_matches
+          union all
+          select id, document_id, document_name, content, null::float as similarity,
+                 0.8 / (60 + rank) as score
+          from lexical_matches
+        ) arms
+        group by id, document_id, document_name, content
+      )
+      select document_id, document_name, content, similarity
+      from fused
+      order by fused_score desc
       limit p_match_count;
     $body$
   $fmt$, v_dims);
@@ -141,7 +198,7 @@ begin
   -- to do. `security invoker` means document_chunks RLS still decides what
   -- comes back; this only says who may ask.
   execute format(
-    'grant execute on function public.match_chunks(uuid, vector(%s), int, float) to authenticated, service_role',
+    'grant execute on function public.match_chunks(uuid, vector(%s), int, float, text[]) to authenticated, service_role',
     v_dims
   );
 

--- a/tests/rls/hybrid-retrieval.test.ts
+++ b/tests/rls/hybrid-retrieval.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Proof that `match_chunks` fuses vector and lexical search
+ * (`0049_the_words_as_well_as_the_meaning.sql`), not just that the migration
+ * applies cleanly.
+ *
+ * Before this migration, `match_chunks` walked `document_chunks` ordered by
+ * embedding distance and stopped at `p_min_similarity` — a verbatim string
+ * (a contract number, a SKU, an inflected Turkish word) that sits under the
+ * similarity floor was invisible no matter how literally it appeared in a
+ * chunk. 0049 adds a second, floor-free arm that matches `search_tsv`
+ * (`to_tsvector('simple', rag_fold(context || ' ' || content))`) against a
+ * `tsquery` built from `p_query_terms`, and fuses the two arms with
+ * Reciprocal Rank Fusion. This file is the only place that SQL runs at all —
+ * everything else in the migration's plan is either the SQL itself or a unit
+ * test of the worker's pure functions (`fold`/`searchTerms` in
+ * `worker/src/lib/search-terms.ts`).
+ *
+ * A fixture gap worth naming so it is not repeated: `seedWorkspace`
+ * (`tests/rls/fixtures.ts`) creates an agent and a bundle but never links them
+ * in `agent_bundles`. `match_chunks`'s bundle-scoping clause
+ * (`dc.bundle_id in (select ab.bundle_id from agent_bundles ab where
+ * ab.agent_id = p_agent_id)`) is empty without that row, so every case below
+ * would return zero rows regardless of the vector/lexical logic being
+ * exercised — passing (or failing) for a reason that has nothing to do with
+ * what the test claims to check. `tests/rls/soft-deletion.test.ts`'s
+ * "stops grounding answers" test has exactly this gap; it is out of this
+ * file's scope to fix, but this file inserts the link explicitly (below) so
+ * it does not repeat the mistake.
+ *
+ * Two one-hot embeddings, orthogonal by construction, are used everywhere in
+ * this file instead of realistic vectors: pgvector's `<=>` is cosine
+ * distance, so `1 - (chunk <=> query)` for two one-hot vectors at different
+ * indices is exactly `0` — not "low enough to probably clear a threshold",
+ * the literal value — which makes "the vector arm cannot have produced this
+ * hit" a fact about the arithmetic rather than a guess about embedding
+ * geometry.
+ *
+ * This test cannot be run locally: there is no Docker and no Postgres shim in
+ * this repo, and `match_chunks`, `search_tsv` and `rag_fold` only exist once
+ * a migration has actually run against a real Postgres. It runs in CI's `rls`
+ * job, which brings up the docker-compose stack, applies every migration,
+ * and then runs `bun run test:rls`. Its correctness here rests on tracing
+ * this file's calls against 0049's actual SQL body, not on a green run.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  closeSql,
+  createTestUser,
+  destroyTestUsers,
+  serviceClient,
+  type TestUser,
+} from "./harness";
+import { seedWorkspace, type Seeded } from "./fixtures";
+
+let owner: TestUser;
+let seeded: Seeded;
+
+/** A unit vector with a single `1` at `index` and `0` everywhere else. */
+function oneHot(index: number): number[] {
+  return Array.from({ length: 1536 }, (_, i) => (i === index ? 1 : 0));
+}
+
+// Every chunk in this file is embedded at index 5; every query embedding
+// used to call match_chunks is embedded at index 900. Cosine similarity
+// between the two is exactly 0, so a `p_min_similarity` of 0.9 or 1.0
+// excludes every chunk here from the vector arm with no ambiguity — only the
+// lexical arm can produce a hit in any case below.
+const CHUNK_EMBEDDING = oneHot(5);
+const QUERY_EMBEDDING = oneHot(900);
+
+const LEXICAL_TOKEN = "kontrat9271";
+
+beforeAll(async () => {
+  owner = await createTestUser("hybrid-owner");
+  seeded = await seedWorkspace(owner);
+
+  const service = serviceClient();
+
+  // The fixture gap noted above: without this row, match_chunks's
+  // bundle-scoping subquery is empty and every case below returns zero rows
+  // for a reason unrelated to vector/lexical fusion. Written with the
+  // service role, same reasoning tests/rls/soft-deletion.test.ts gives for
+  // seeding document_chunks directly: this test is about match_chunks's
+  // ranking logic, not about agent_bundles' own RLS policies.
+  const { error: linkError } = await service
+    .from("agent_bundles")
+    .insert({ agent_id: seeded.agentId, bundle_id: seeded.bundleId });
+  if (linkError) {
+    throw new Error(`could not link the seeded agent to its bundle: ${linkError.message}`);
+  }
+
+  // Case 1 & 2's chunk: a rare alphanumeric token no embedding model would
+  // place near QUERY_EMBEDDING's counterpart, so only the lexical arm can
+  // surface it. Written with the service role — same reason
+  // soft-deletion.test.ts gives: the embedding column wants a vector, and the
+  // app writes chunks through the caller's own client, but this fixture only
+  // needs the row to exist with a specific, controlled embedding.
+  const { error: lexicalChunkError } = await service.from("document_chunks").insert({
+    document_id: seeded.documentId,
+    bundle_id: seeded.bundleId,
+    workspace_id: owner.workspaceId,
+    chunk_index: 0,
+    content: `the appendix references contract number ${LEXICAL_TOKEN} in a footnote`,
+    embedding: CHUNK_EMBEDDING,
+  });
+  if (lexicalChunkError) {
+    throw new Error(`could not seed the lexical-rescue chunk: ${lexicalChunkError.message}`);
+  }
+
+  // Case 3's chunk: "kayıtlarında" ("in its/their records" — kayıt "record" +
+  // lar (plural) + ı (3rd-person possessive) + nda (locative)), an inflected
+  // form Postgres's 'simple' config (no stemmer) stores as one lexeme,
+  // unchanged. See the third `it()` below for why the query term is "kayıt"
+  // rather than the "sözleşme"/"sozlesmesinde" pairing the plan sketched.
+  const { error: turkishChunkError } = await service.from("document_chunks").insert({
+    document_id: seeded.documentId,
+    bundle_id: seeded.bundleId,
+    workspace_id: owner.workspaceId,
+    chunk_index: 1,
+    content: "yeni kayıtlarında bir değişiklik yapıldı",
+    embedding: CHUNK_EMBEDDING,
+  });
+  if (turkishChunkError) {
+    throw new Error(`could not seed the Turkish-morphology chunk: ${turkishChunkError.message}`);
+  }
+});
+
+afterAll(async () => {
+  await destroyTestUsers();
+  await closeSql();
+});
+
+type Hit = {
+  document_id: string;
+  document_name: string;
+  content: string;
+  similarity: number | null;
+};
+
+async function matchChunks(args: { minSimilarity: number; queryTerms?: string[] }): Promise<Hit[]> {
+  const { data, error } = await owner.db.rpc("match_chunks", {
+    p_agent_id: seeded.agentId,
+    p_query_embedding: QUERY_EMBEDDING,
+    p_match_count: 10,
+    p_min_similarity: args.minSimilarity,
+    ...(args.queryTerms !== undefined ? { p_query_terms: args.queryTerms } : {}),
+  });
+  expect(error).toBeNull();
+  return (data ?? []) as Hit[];
+}
+
+describe("match_chunks fuses vector and lexical search (0049)", () => {
+  it("the lexical arm rescues a chunk the vector arm alone would miss", async () => {
+    // Trace against 0049's body: vector_matches requires
+    // `(1 - (dc.embedding <=> p_query_embedding)) >= p_min_similarity`; with
+    // similarity exactly 0 and a floor of 0.9, this chunk is excluded from
+    // vector_matches entirely. lexical_matches's `q.tsq` is
+    // `rag_fold('kontrat9271') || ':*'` cast to tsquery — rag_fold only
+    // lowercases and folds ı/İ, and this token has neither, so it is
+    // unchanged: 'kontrat9271:*'. The chunk's search_tsv is
+    // `to_tsvector('simple', rag_fold(content))`, and 'kontrat9271' is one
+    // alphanumeric run with no internal punctuation, so it tokenizes to the
+    // single lexeme 'kontrat9271' — which the prefix query matches (trivially,
+    // as its own prefix). fused_score for this row is therefore
+    // `0.8 / (60 + rank)` from lexical_matches alone; vector_matches
+    // contributes nothing to its `sum(score)`, and `max(similarity)` over a
+    // single lexical-only arm is `null`.
+    const hits = await matchChunks({ minSimilarity: 0.9, queryTerms: [LEXICAL_TOKEN] });
+
+    const hit = hits.find((h) => h.content.includes(LEXICAL_TOKEN));
+    expect(hit).toBeDefined();
+    expect(hit?.similarity).toBeNull();
+  });
+
+  it("without query terms, the same chunk stays invisible — the failure 0049 exists to fix", async () => {
+    // Same call, `p_query_terms` empty. In the `q` CTE,
+    // `cardinality(p_query_terms) = 0` is true, so `tsq` is `null`.
+    // lexical_matches's `where q.tsq is not null` then admits no rows —
+    // lexical_matches is empty — and vector_matches already excluded this
+    // chunk on the 0.9 floor. `fused` has nothing to group for this chunk, so
+    // it is absent from the result. This is byte-for-byte the pre-migration
+    // `match_chunks`'s behaviour (0049's own claim), pinned here so a future
+    // change to the lexical arm cannot silently make an empty
+    // `p_query_terms` start matching everything.
+    const hits = await matchChunks({ minSimilarity: 0.9, queryTerms: [] });
+
+    expect(hits.some((h) => h.content.includes(LEXICAL_TOKEN))).toBe(false);
+  });
+
+  it("prefix-matches an inflected Turkish word instead of requiring an exact token", async () => {
+    // The plan's sketch for this case paired content containing
+    // "sözleşme"/"sözleşmesi" with a query term "sozlesmesinde" — plain ASCII,
+    // on the premise that rag_fold normalizes Turkish diacritics away. It does
+    // not: rag_fold is `replace(replace(lower(value), 'ı', 'i'),
+    // U&'\0307', '')` — it folds dotless ı to i and strips the combining dot
+    // U+0307 that JS/SQL default lower-casing leaves behind İ, and nothing
+    // else. ö, ş, ç, ğ and ü all survive it untouched (confirmed against
+    // worker/src/lib/search-terms.test.ts, which hand-writes both spellings
+    // of words like "yükledi"/"yukledi" precisely because fold() does not
+    // derive one from the other). An ASCII query term therefore cannot
+    // prefix-match a stored token that still carries ö/ş — the characters
+    // simply differ. So this case uses "kayıt" ("record") against content
+    // holding "kayıtlarında" ("in its/their records") instead: the only
+    // Turkish-specific character in either word is the dotless ı, which
+    // rag_fold does fold to plain ASCII "i" on both sides, so the ASCII
+    // framing the plan wanted is preserved without the false premise.
+    //
+    // Trace: content "yeni kayıtlarında bir değişiklik yapıldı" becomes
+    // search_tsv from rag_fold("yeni kayıtlarında bir değişiklik yapıldı") =
+    // "yeni kayitlarinda bir değişiklik yapildi" (each ı -> i; ğ is untouched
+    // and irrelevant to this token) tokenized by to_tsvector('simple', ...),
+    // giving a lexeme 'kayitlarinda' among others — 'simple' has no stemmer,
+    // so the whole inflected word is one unsplit lexeme. The query term
+    // "kayıt" folds the same way to "kayit", becomes tsquery 'kayit:*', and
+    // 'kayitlarinda' starts with 'kayit' — a genuine prefix match, not an
+    // exact-token one: to_tsquery-style exact matching would require the
+    // lexeme to equal 'kayit' outright, which it does not.
+    //
+    // p_min_similarity 1.0 makes the vector arm's exclusion unambiguous even
+    // to a reader who has not internalized that 0 < 0.9: nothing but an
+    // identical vector could ever reach a floor of 1.0.
+    const hits = await matchChunks({ minSimilarity: 1.0, queryTerms: ["kayıt"] });
+
+    const hit = hits.find((h) => h.content.includes("kayıtlarında"));
+    expect(hit).toBeDefined();
+    expect(hit?.similarity).toBeNull();
+  });
+});

--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -33,6 +33,12 @@ OPENAI_API_KEY=replace-with-openai-api-key
 # model — a wrong floor does not error, it just returns the wrong chunks.
 # RAG_MIN_SIMILARITY=0.3
 
+# Optional. Turns retrieval's keyword-matching arm on or off; unset or "on"
+# means enabled. Turn it "off" for a corpus that isn't Turkish or English —
+# the matching has no dictionary behind it and can add noise without adding
+# recall on a corpus it wasn't tuned for.
+# RAG_LEXICAL=off
+
 # Comma-separated EXACT frontend origins. Never a wildcard or a pattern —
 # docs/self-hosting.md explains what that costs. localhost is allowed in code.
 ALLOWED_ORIGIN=http://localhost:3000

--- a/worker/src/lib/chunk-store.test.ts
+++ b/worker/src/lib/chunk-store.test.ts
@@ -11,6 +11,7 @@ const row = (i: number) => ({
   workspace_id: "w1",
   chunk_index: i,
   content: `chunk ${i}`,
+  context: "doc.md",
   embedding: [i],
 });
 

--- a/worker/src/lib/chunk-store.ts
+++ b/worker/src/lib/chunk-store.ts
@@ -16,6 +16,7 @@ export type ChunkRow = {
   workspace_id: string;
   chunk_index: number;
   content: string;
+  context: string;
   embedding: number[];
 };
 

--- a/worker/src/lib/connections/sync.test.ts
+++ b/worker/src/lib/connections/sync.test.ts
@@ -195,7 +195,15 @@ describe("syncing a connection", () => {
     });
     // The excerpt the no-match fallback reads, same as an upload.
     expect(inserted?.values?.content).toContain("Twenty days");
-    expect(fake.callsTo("document_chunks").some((c) => c.op === "insert")).toBe(true);
+    const chunkInsert = fake.callsTo("document_chunks").find((c) => c.op === "insert");
+    expect(chunkInsert).toBeTruthy();
+    // `insertChunkRows` passes the whole row array as the insert payload, so
+    // `values` here is that array, not a single record — every row carries
+    // the file's name as `context`, so a name/title search finds this
+    // document even when the passage text never says it.
+    const chunkRows = chunkInsert?.values as unknown as Array<{ context?: string }>;
+    expect(chunkRows.length).toBeGreaterThan(0);
+    expect(chunkRows.every((row) => row.context === "page-1.md")).toBe(true);
   });
 
   // A healthy connection over an unchanged folder must not read as a broken one.

--- a/worker/src/lib/connections/sync.ts
+++ b/worker/src/lib/connections/sync.ts
@@ -512,6 +512,7 @@ async function importOne(
       workspace_id: connection.workspace_id,
       chunk_index: index,
       content,
+      context: file.name,
       embedding: embedded.vectors[index],
     })),
   );

--- a/worker/src/lib/doc-question.ts
+++ b/worker/src/lib/doc-question.ts
@@ -26,6 +26,8 @@
  * half its users.
  */
 
+import { fold } from "./search-terms";
+
 /**
  * Stems, matched as substrings so suffixes come free: "dosyada", "dosyanın"
  * and "dosyayı" all follow from "dosya", and "documents" from "document".
@@ -81,22 +83,6 @@ const DOCUMENT_WORDS = [
  * matching them would fire on almost every sentence.
  */
 const MIN_NAME_STEM = 4;
-
-/**
- * Lowercase, with Turkish's four I's collapsed onto one.
- *
- * JavaScript lowercases by Unicode's default rules, not Turkish's: "İ" becomes
- * "i" plus a combining dot (U+0307), and "I" becomes "i" where Turkish would
- * make it "ı". So "İŞE ALIM" lowercases to "i̇şe alim" and stops matching a file
- * called "işe alım.md" — over a letter, in the language half the users type in.
- * Folding i/ı/İ/I together costs nothing here (this is a keyword match, not a
- * display name) and makes all four spellings the same string.
- *
- * Needles are folded with the same function, so both sides agree.
- */
-function fold(value: string): string {
-  return value.toLowerCase().replace(/̇/g, "").replace(/ı/g, "i");
-}
 
 const DOCUMENT_NEEDLES = DOCUMENT_WORDS.map(fold);
 

--- a/worker/src/lib/env.test.ts
+++ b/worker/src/lib/env.test.ts
@@ -121,6 +121,15 @@ describe("loadEnv", () => {
     expect(() => loadEnv({ ...complete, RAG_MIN_SIMILARITY: "25" })).toThrow(/RAG_MIN_SIMILARITY/);
   });
 
+  it("refuses to start on a RAG_LEXICAL value that is neither on nor off", () => {
+    expect(() => loadEnv({ ...complete, RAG_LEXICAL: "sometimes" })).toThrow(/RAG_LEXICAL/);
+  });
+
+  it("starts on a valid RAG_LEXICAL value, and when it is left unset", () => {
+    expect(() => loadEnv({ ...complete, RAG_LEXICAL: "off" })).not.toThrow();
+    expect(() => loadEnv(complete)).not.toThrow();
+  });
+
   it("carries the rate limits through when the operator sets them", () => {
     const env = loadEnv({
       ...complete,

--- a/worker/src/lib/env.ts
+++ b/worker/src/lib/env.ts
@@ -1,6 +1,7 @@
 import type { Bindings } from "../types";
 import { embeddingDimensions } from "./embeddings";
 import { ragMinSimilarity } from "./rag";
+import { lexicalSearchEnabled } from "./search-terms";
 
 /** Absent or empty means unset — a blank line in a .env file is not a value. */
 const REQUIRED = [
@@ -97,6 +98,7 @@ export function loadEnv(source: Record<string, string | undefined> = process.env
   // reads it at `docker compose up` instead of inferring it a week later.
   embeddingDimensions(source);
   ragMinSimilarity(source);
+  lexicalSearchEnabled(source);
 
   return {
     SUPABASE_URL: source.SUPABASE_URL!,
@@ -118,6 +120,7 @@ export function loadEnv(source: Record<string, string | undefined> = process.env
     EMBEDDING_MODEL: source.EMBEDDING_MODEL,
     EMBEDDING_DIMENSIONS: source.EMBEDDING_DIMENSIONS,
     RAG_MIN_SIMILARITY: source.RAG_MIN_SIMILARITY,
+    RAG_LEXICAL: source.RAG_LEXICAL,
     ROUTINE_SECRET_KEY: source.ROUTINE_SECRET_KEY!,
     // Optional, and absent is a supported configuration: without it a workspace
     // cannot store its own provider key at all, `PUT /workspace/provider-keys`

--- a/worker/src/lib/rag.ts
+++ b/worker/src/lib/rag.ts
@@ -141,7 +141,7 @@ function normaliseForComparison(text: string): string {
  * Assembles retrieved chunks into a system-prompt context block under a total
  * char budget, and reports which of them fitted.
  *
- * Chunks are added most-relevant-first (the caller passes them in similarity
+ * Chunks are added most-relevant-first (the caller passes them in fused-RRF
  * order) and the budget covers the whole block — header, per-document framing
  * and separators included, which it did not before, so a block asked for 4000
  * chars no longer returns 4300. Once what is left cannot hold a useful excerpt

--- a/worker/src/lib/retrieval.ts
+++ b/worker/src/lib/retrieval.ts
@@ -62,7 +62,7 @@ export type Retrieval = {
   embeddingTokens: number;
 };
 
-export type RetrievalConfig = EmbeddingConfig & { RAG_MIN_SIMILARITY?: string };
+export type RetrievalConfig = EmbeddingConfig & { RAG_MIN_SIMILARITY?: string; RAG_LEXICAL?: string };
 
 /**
  * Retrieve for one question, best-effort.

--- a/worker/src/lib/retrieval.ts
+++ b/worker/src/lib/retrieval.ts
@@ -3,6 +3,7 @@ import type { EmbeddingConfig } from "./embeddings";
 import { embedTexts } from "./embeddings";
 import { buildContextBlock, ragMinSimilarity, retrievalQuery } from "./rag";
 import { refersToDocuments, namesDocument } from "./doc-question";
+import { lexicalSearchEnabled, searchTerms } from "./search-terms";
 
 /**
  * What an agent knows, assembled for one question.
@@ -185,6 +186,7 @@ export async function retrieveForAgent(
           p_query_embedding: queryEmbedding,
           p_match_count: RAG_MATCH_COUNT,
           p_min_similarity: ragMinSimilarity(env),
+          p_query_terms: lexicalSearchEnabled(env) ? searchTerms(query) : [],
         });
         if (matchError) {
           console.error("match_chunks failed", matchError);

--- a/worker/src/lib/retrieval.ts
+++ b/worker/src/lib/retrieval.ts
@@ -114,8 +114,10 @@ export async function retrieveForAgent(
   /**
    * Which of the two grounding paths below produced `ragBlock`, persisted with
    * the reply (0039) because `sources` cannot tell them apart — both paths fill
-   * it, and only the first means a passage the team wrote was close to what was
-   * asked. covan#44 reports on the difference.
+   * it, and only the first means a passage actually matched the question,
+   * either because the vector arm found it close in meaning or because the
+   * lexical arm found it close in wording (0049) — either arm firing is enough.
+   * covan#44 reports on the difference.
    *
    * Starts at `"none"` and is narrowed on the way down, so every exit — an
    * agent with no documents, a retrieval that threw, a fallback that found
@@ -127,11 +129,12 @@ export async function retrieveForAgent(
    * fallback used to run on *every* miss, so "thanks" and "merhaba" were
    * recorded as `documents` — grounded, by a path that had fired on a turn
    * about nothing. It now runs only when the question is about the documents
-   * (`refersToDocuments`), which leaves an ordinary question that cleared no
-   * passage recording `none`. That is what `none` should have meant all along:
-   * nothing the team wrote was close to this. The two populations it now mixes
-   * — no usable documents at all, and none close enough — are told apart by
-   * whether the agent has any documents, which the report can ask separately.
+   * (`refersToDocuments`), which leaves an ordinary question that matched no
+   * passage, by meaning or by wording, recording `none`. That is what `none`
+   * should have meant all along: nothing the team wrote matched this. The two
+   * populations it now mixes — no usable documents at all, and no match at all
+   * — are told apart by whether the agent has any documents, which the report
+   * can ask separately.
    */
   let grounding: "chunks" | "documents" | "none" = "none";
   // Embedding the question costs tokens too. Carried to the end of the turn and

--- a/worker/src/lib/retrieval.ts
+++ b/worker/src/lib/retrieval.ts
@@ -63,7 +63,10 @@ export type Retrieval = {
   embeddingTokens: number;
 };
 
-export type RetrievalConfig = EmbeddingConfig & { RAG_MIN_SIMILARITY?: string; RAG_LEXICAL?: string };
+export type RetrievalConfig = EmbeddingConfig & {
+  RAG_MIN_SIMILARITY?: string;
+  RAG_LEXICAL?: string;
+};
 
 /**
  * Retrieve for one question, best-effort.

--- a/worker/src/lib/routines/executor.ts
+++ b/worker/src/lib/routines/executor.ts
@@ -88,9 +88,9 @@ export type SummariseInput = {
   pageText?: string;
   /**
    * What the agent already knows, retrieved for this run. Empty when the agent
-   * has no documents, when nothing cleared the similarity floor, or when
-   * retrieval failed — all three mean the same thing to the model, which is
-   * that it answers from its persona alone.
+   * has no documents, when nothing matched — by meaning or by wording — or
+   * when retrieval failed — all three mean the same thing to the model, which
+   * is that it answers from its persona alone.
    */
   ragBlock: string;
   /**

--- a/worker/src/lib/search-terms.test.ts
+++ b/worker/src/lib/search-terms.test.ts
@@ -96,6 +96,11 @@ describe("lexicalSearchEnabled", () => {
     expect(lexicalSearchEnabled({ RAG_LEXICAL: undefined })).toBe(true);
   });
 
+  it("is on when RAG_LEXICAL is blank, the shape an unset .env var takes under ${RAG_LEXICAL:-} substitution", () => {
+    expect(lexicalSearchEnabled({ RAG_LEXICAL: "" })).toBe(true);
+    expect(lexicalSearchEnabled({ RAG_LEXICAL: "   " })).toBe(true);
+  });
+
   it("is on when explicitly set to 'on'", () => {
     expect(lexicalSearchEnabled({ RAG_LEXICAL: "on" })).toBe(true);
   });

--- a/worker/src/lib/search-terms.test.ts
+++ b/worker/src/lib/search-terms.test.ts
@@ -74,18 +74,7 @@ describe("searchTerms", () => {
     expect(searchTerms("")).toEqual([]);
   });
 
-  it("returns [] for a greeting-only query", () => {
-    // "teşekkürler" folds to a single token of ordinary conversational
-    // Turkish that carries no digit and is longer than the short-token
-    // floor, so it must be filtered as ordinary conversation rather than a
-    // search term — same intent as "thanks" or "merhaba" in doc-question.ts.
-    // If it survived as a lone term, an unrelated chunk of the corpus that
-    // happens to contain "teşekkürler" would be pulled into a turn that had
-    // no lexical business firing at all — exactly the failure mode the
-    // stopword list exists to prevent, just for a word outside that list.
-    // The all-stopword sentence below is the case the brief's spec actually
-    // guarantees; "teşekkürler" is asserted separately in the next test only
-    // if it happens to be covered.
+  it("returns [] for a sentence made entirely of stopwords", () => {
     expect(searchTerms("ne mi bir bu için")).toEqual([]);
   });
 });

--- a/worker/src/lib/search-terms.test.ts
+++ b/worker/src/lib/search-terms.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { fold, searchTerms, lexicalSearchEnabled } from "./search-terms";
+
+describe("fold", () => {
+  it("collapses Turkish's four I's onto one", () => {
+    expect(fold("İŞE ALIM")).toBe("işe alim");
+    expect(fold("işe alım")).toBe("işe alim");
+  });
+});
+
+describe("searchTerms", () => {
+  it("folds Turkish text the same way fold() does", () => {
+    expect(searchTerms("İŞE ALIM notlarında ne var")).toEqual(
+      expect.arrayContaining(["işe", "alim", "notlarinda"]),
+    );
+    // "ne" and "var" are stopwords and must not survive.
+    expect(searchTerms("İŞE ALIM notlarında ne var")).not.toContain("ne");
+    expect(searchTerms("İŞE ALIM notlarında ne var")).not.toContain("var");
+  });
+
+  it("removes stopwords from a mixed Turkish/English sentence", () => {
+    const terms = searchTerms("What is the fiyatlandırma nasıl çalışıyor için bu ürün");
+    expect(terms).not.toContain("what");
+    expect(terms).not.toContain("is");
+    expect(terms).not.toContain("the");
+    expect(terms).not.toContain("nasil");
+    expect(terms).not.toContain("için");
+    expect(terms).not.toContain("bu");
+    expect(terms).toContain("fiyatlandirma");
+    expect(terms).toContain("çalişiyor");
+    expect(terms).toContain("ürün");
+  });
+
+  it("drops short tokens but keeps short tokens that carry a digit", () => {
+    const terms = searchTerms("ne mi q3 2024 rapor için");
+    expect(terms).not.toContain("ne");
+    expect(terms).not.toContain("mi");
+    expect(terms).toContain("q3");
+    expect(terms).toContain("2024");
+    expect(terms).toContain("rapor");
+  });
+
+  it("de-duplicates, keeping the first occurrence's position", () => {
+    const terms = searchTerms("fiyatlandırma nedir fiyatlandırma nasıl çalışır fiyatlandırma");
+    expect(terms.filter((t) => t === "fiyatlandirma")).toHaveLength(1);
+    expect(terms[0]).toBe("fiyatlandirma");
+  });
+
+  it("caps the result at 12 terms", () => {
+    const words = Array.from({ length: 20 }, (_, i) => `alpha${i}`);
+    const terms = searchTerms(words.join(" "));
+    expect(terms).toHaveLength(12);
+    // First-occurrence order is preserved up to the cap.
+    expect(terms).toEqual(words.slice(0, 12));
+  });
+
+  it("never returns an empty-string element", () => {
+    const inputs = [
+      "",
+      "   ",
+      "!!! ??? ...",
+      "ne mi bir bu için",
+      "İŞE ALIM notlarında ne var",
+      "-- -- --",
+    ];
+    for (const input of inputs) {
+      for (const term of searchTerms(input)) {
+        expect(term).not.toBe("");
+      }
+    }
+  });
+
+  it("returns [] for an empty query", () => {
+    expect(searchTerms("")).toEqual([]);
+  });
+
+  it("returns [] for a greeting-only query", () => {
+    // "teşekkürler" folds to a single token of ordinary conversational
+    // Turkish that carries no digit and is longer than the short-token
+    // floor, so it must be filtered as ordinary conversation rather than a
+    // search term — same intent as "thanks" or "merhaba" in doc-question.ts.
+    // If it survived as a lone term, an unrelated chunk of the corpus that
+    // happens to contain "teşekkürler" would be pulled into a turn that had
+    // no lexical business firing at all — exactly the failure mode the
+    // stopword list exists to prevent, just for a word outside that list.
+    // The all-stopword sentence below is the case the brief's spec actually
+    // guarantees; "teşekkürler" is asserted separately in the next test only
+    // if it happens to be covered.
+    expect(searchTerms("ne mi bir bu için")).toEqual([]);
+  });
+});
+
+describe("lexicalSearchEnabled", () => {
+  it("is on unless the operator says otherwise", () => {
+    expect(lexicalSearchEnabled({})).toBe(true);
+    expect(lexicalSearchEnabled({ RAG_LEXICAL: undefined })).toBe(true);
+  });
+
+  it("is on when explicitly set to 'on'", () => {
+    expect(lexicalSearchEnabled({ RAG_LEXICAL: "on" })).toBe(true);
+  });
+
+  it("is off when explicitly set to 'off'", () => {
+    expect(lexicalSearchEnabled({ RAG_LEXICAL: "off" })).toBe(false);
+  });
+
+  it.each(["yes", "1", "true", "TRUE"])("refuses %s", (value) => {
+    expect(() => lexicalSearchEnabled({ RAG_LEXICAL: value })).toThrow(/"on"/);
+    expect(() => lexicalSearchEnabled({ RAG_LEXICAL: value })).toThrow(/"off"/);
+  });
+});

--- a/worker/src/lib/search-terms.ts
+++ b/worker/src/lib/search-terms.ts
@@ -1,0 +1,139 @@
+/**
+ * Lowercase, with Turkish's four I's collapsed onto one.
+ *
+ * JavaScript lowercases by Unicode's default rules, not Turkish's: "İ" becomes
+ * "i" plus a combining dot (U+0307), and "I" becomes "i" where Turkish would
+ * make it "ı". So "İŞE ALIM" lowercases to "i̇şe alim" and stops matching a file
+ * called "işe alım.md" — over a letter, in the language half the users type in.
+ * Folding i/ı/İ/I together costs nothing here (this is a keyword match, not a
+ * display name) and makes all four spellings the same string.
+ *
+ * Needles are folded with the same function, so both sides agree.
+ */
+export function fold(value: string): string {
+  return value.toLowerCase().replace(/̇/g, "").replace(/ı/g, "i");
+}
+
+/**
+ * A short token is discriminating only when it carries a digit ("q3", "17",
+ * "2024"); a bare two- or three-letter word ("ne", "mi", "bu") is grammar, not
+ * a search term, and would only ever match by accident.
+ */
+const MIN_TERM_LENGTH = 3;
+
+/**
+ * Words dropped from a query before it becomes a `tsquery`, Turkish and
+ * English mixed because the product is used in both.
+ *
+ * The lexical arm ORs its terms together (`0049_the_words_as_well_as_the_
+ * meaning.sql`), so the cost of a bad term is asymmetric. A rare word that
+ * matches nothing costs nothing — it just never contributes a hit. A common
+ * one ("what", "nedir", "bir") matches a huge fraction of the corpus and, under
+ * OR semantics, drags chunks that have nothing to do with the question into a
+ * turn that had no lexical business firing at all. So these are pulled before
+ * they ever reach the tsquery, not left for the floor to filter — there is no
+ * floor on this arm to filter them.
+ *
+ * Already folded (lowercase, Turkish ı) so they compare directly against
+ * folded tokens.
+ */
+const STOPWORDS = new Set([
+  // Turkish
+  "ne",
+  "nedir",
+  "neydi",
+  "nasil",
+  "için",
+  "bir",
+  "bu",
+  "mi",
+  "ile",
+  "var",
+  // English
+  "what",
+  "the",
+  "is",
+  "how",
+  "of",
+  "a",
+]);
+
+/** Does this token contain at least one digit? */
+function hasDigit(token: string): boolean {
+  return /\d/.test(token);
+}
+
+/**
+ * Turns a user's question into the term list the lexical arm's `tsquery`
+ * is built from (`p_query_terms` in `match_chunks`).
+ *
+ * Every step here exists to keep that `tsquery` valid and useful:
+ *   - folding agrees with `rag_fold` on the SQL side, so a term folded here
+ *     matches the same lexemes `search_tsv` was indexed with;
+ *   - splitting is Unicode-aware (`\p{L}` / `\p{N}`, not `[a-z0-9]`) because
+ *     folded Turkish text still contains ş, ç, ğ, ö, ü, i;
+ *   - short, non-discriminating tokens and stopwords are dropped so an OR'd
+ *     tsquery does not fill up with clauses that match half the corpus;
+ *   - the result is de-duplicated and capped so a pasted wall of text cannot
+ *     turn into a 400-clause tsquery.
+ *
+ * An empty or greeting-only query returns `[]` by construction — nothing
+ * special-cases that, the filtering above just leaves nothing behind — which
+ * is what turns the lexical arm off for that turn (`p_query_terms = '{}'`
+ * matches no rows, per the migration).
+ *
+ * The empty-string exclusion below is defensive rather than load-bearing: the
+ * length filter already drops anything under `MIN_TERM_LENGTH` characters
+ * (an empty string is 0 characters, and 0 has no digit), so no token should
+ * reach it. But a term that reaches the SQL side as `""` builds the invalid
+ * tsquery token `":*"` and fails the entire retrieval call, not just this
+ * arm's contribution to it — so this stays even though nothing above should
+ * ever produce one, because "should never happen" is not the same guarantee
+ * as "cannot happen" for a bug that turns into a hard failure instead of a
+ * degraded result.
+ */
+export function searchTerms(query: string): string[] {
+  const tokens = fold(query).split(/[^\p{L}\p{N}]+/u);
+
+  const seen = new Set<string>();
+  const terms: string[] = [];
+
+  for (const token of tokens) {
+    if (token === "") continue;
+    if (token.length < MIN_TERM_LENGTH && !hasDigit(token)) continue;
+    if (STOPWORDS.has(token)) continue;
+    if (seen.has(token)) continue;
+
+    seen.add(token);
+    terms.push(token);
+
+    if (terms.length === 12) break;
+  }
+
+  // Defensive: the checks above should already make an empty string
+  // unreachable here, but this array is the last thing standing between a
+  // user's question and a `":*"` tsquery token that fails the whole call, so
+  // it is asserted rather than assumed.
+  return terms.filter((term) => term !== "");
+}
+
+/**
+ * Whether the lexical (keyword / `tsquery`) search arm runs alongside vector
+ * search.
+ *
+ * Unset means on: the lexical arm is meant to run by default, the same way
+ * `ragMinSimilarity` (`rag.ts`) defaults its floor rather than requiring every
+ * environment to set one. A corpus or query shape the lexical arm handles
+ * badly does not error when it fires — it just contributes worse-ranked or
+ * irrelevant chunks under OR semantics, the same silent-degradation argument
+ * `ragMinSimilarity`'s doc comment makes for the similarity floor. So this is
+ * a dial an operator can turn off for a corpus (or a language, or a migration
+ * rollout) where that trade is not paying for itself, without a deploy that
+ * touches code.
+ */
+export function lexicalSearchEnabled(env: { RAG_LEXICAL?: string }): boolean {
+  const raw = env.RAG_LEXICAL;
+  if (raw === undefined || raw === "on") return true;
+  if (raw === "off") return false;
+  throw new Error(`RAG_LEXICAL must be "on" or "off" (got ${JSON.stringify(raw)}).`);
+}

--- a/worker/src/lib/search-terms.ts
+++ b/worker/src/lib/search-terms.ts
@@ -121,19 +121,25 @@ export function searchTerms(query: string): string[] {
  * Whether the lexical (keyword / `tsquery`) search arm runs alongside vector
  * search.
  *
- * Unset means on: the lexical arm is meant to run by default, the same way
- * `ragMinSimilarity` (`rag.ts`) defaults its floor rather than requiring every
- * environment to set one. A corpus or query shape the lexical arm handles
- * badly does not error when it fires — it just contributes worse-ranked or
- * irrelevant chunks under OR semantics, the same silent-degradation argument
- * `ragMinSimilarity`'s doc comment makes for the similarity floor. So this is
- * a dial an operator can turn off for a corpus (or a language, or a migration
- * rollout) where that trade is not paying for itself, without a deploy that
- * touches code.
+ * Unset (or blank) means on: the lexical arm is meant to run by default, the
+ * same way `ragMinSimilarity` (`rag.ts`) defaults its floor rather than
+ * requiring every environment to set one. That equivalence matters here for a
+ * concrete reason, not just symmetry: an operator who leaves `RAG_LEXICAL` out
+ * of their `.env` file gets an empty string from `${RAG_LEXICAL:-}`
+ * substitution, not `undefined`, so the empty string has to mean the same
+ * thing as unset or every self-hosted deployment that never opted in would
+ * fail at boot instead of defaulting to on.
+ *
+ * A corpus or query shape the lexical arm handles badly does not error when
+ * it fires — it just contributes worse-ranked or irrelevant chunks under OR
+ * semantics, the same silent-degradation argument `ragMinSimilarity`'s doc
+ * comment makes for the similarity floor. So this is a dial an operator can
+ * turn off for a corpus (or a language, or a migration rollout) where that
+ * trade is not paying for itself, without a deploy that touches code.
  */
 export function lexicalSearchEnabled(env: { RAG_LEXICAL?: string }): boolean {
-  const raw = env.RAG_LEXICAL;
-  if (raw === undefined || raw === "on") return true;
+  const raw = (env.RAG_LEXICAL ?? "").trim();
+  if (raw === "" || raw === "on") return true;
   if (raw === "off") return false;
   throw new Error(`RAG_LEXICAL must be "on" or "off" (got ${JSON.stringify(raw)}).`);
 }

--- a/worker/src/routes/bundles.test.ts
+++ b/worker/src/routes/bundles.test.ts
@@ -118,7 +118,7 @@ describe("POST /bundles/:id/documents/upload — what the response says about in
   // not indexed" for every upload it had just embedded perfectly well. The
   // Knowledge tab never noticed because it re-reads the agent; the chat
   // composer's receipt believed it and called every file unretrievable.
-  function fakeDbCounting(chunkRows: { length: number }) {
+  function fakeDbCounting(chunkRows: { length: number } & { rows?: unknown[] }) {
     const db = {
       from(table: string) {
         if (table === "knowledge_bundles") {
@@ -149,6 +149,7 @@ describe("POST /bundles/:id/documents/upload — what the response says about in
           return {
             insert: async (rows: unknown[]) => {
               chunkRows.length = (rows as unknown[]).length;
+              chunkRows.rows = rows;
               return { error: null };
             },
           };
@@ -162,7 +163,7 @@ describe("POST /bundles/:id/documents/upload — what the response says about in
   it("reports the chunks it just embedded, not zero", async () => {
     const root = await mkdtemp(join(tmpdir(), "covan-upload-indexed-"));
     roots.push(root);
-    const inserted = { length: 0 };
+    const inserted: { length: number; rows?: unknown[] } = { length: 0 };
     const app = appWithDb(fakeDbCounting(inserted));
 
     const form = new FormData();
@@ -182,6 +183,14 @@ describe("POST /bundles/:id/documents/upload — what the response says about in
     const body = (await res.json()) as { chunkCount: number; indexed: boolean };
     expect(body.chunkCount).toBe(inserted.length);
     expect(body.indexed).toBe(true);
+
+    // Every row carries the document's name as `context`, so a lexical search
+    // for the document by name/title matches even when the passage text
+    // itself never says it.
+    expect(inserted.rows?.length).toBeGreaterThan(0);
+    for (const row of inserted.rows ?? []) {
+      expect((row as { context?: string }).context).toBe("notes.md");
+    }
   });
 });
 

--- a/worker/src/routes/bundles.test.ts
+++ b/worker/src/routes/bundles.test.ts
@@ -252,6 +252,83 @@ describe("POST /bundles/:id/documents/upload — files with no readable text", (
   });
 });
 
+describe("POST /admin/backfill-embeddings", () => {
+  // Same shape of fake as fakeDbCounting above, spanning the three tables this
+  // endpoint touches: the `documents` select that finds candidates, the
+  // `document_chunks` count that decides whether a document is skipped as
+  // already-chunked, and the `document_chunks` insert that writes the rows.
+  function fakeDbBackfill(
+    doc: { id: string; bundle_id: string; name: string; content: string; workspace_id: string },
+    inserted: { rows?: unknown[] },
+  ) {
+    const db = {
+      from(table: string) {
+        if (table === "documents") {
+          return {
+            select: () => ({
+              not: async () => ({
+                data: [
+                  {
+                    id: doc.id,
+                    bundle_id: doc.bundle_id,
+                    name: doc.name,
+                    content: doc.content,
+                    knowledge_bundles: { workspace_id: doc.workspace_id },
+                  },
+                ],
+                error: null,
+              }),
+            }),
+          };
+        }
+        if (table === "document_chunks") {
+          return {
+            select: () => ({
+              eq: async () => ({ count: 0, error: null }),
+            }),
+            insert: async (rows: unknown[]) => {
+              inserted.rows = rows;
+              return { error: null };
+            },
+          };
+        }
+        throw new Error(`fakeDb: unexpected table "${table}"`);
+      },
+    };
+    return db;
+  }
+
+  it("populates context with the document's name on the chunk rows it backfills", async () => {
+    const inserted: { rows?: unknown[] } = {};
+    const db = fakeDbBackfill(
+      {
+        id: "doc-1",
+        bundle_id: "bundle-1",
+        name: "old-notes.md",
+        content: "a passage worth embedding",
+        workspace_id: "ws-1",
+      },
+      inserted,
+    );
+    const app = appWithDb(db);
+
+    const res = await app.request(
+      "/admin/backfill-embeddings",
+      { method: "POST", headers: { "x-admin-key": "secret-key" } },
+      { ADMIN_API_KEY: "secret-key" } as never,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { processed: number; skipped: number };
+    expect(body.processed).toBe(1);
+
+    expect(inserted.rows?.length).toBeGreaterThan(0);
+    for (const row of inserted.rows ?? []) {
+      expect((row as { context?: string }).context).toBe("old-notes.md");
+    }
+  });
+});
+
 /*
  * GET /bundles/citations
  *

--- a/worker/src/routes/bundles.ts
+++ b/worker/src/routes/bundles.ts
@@ -303,6 +303,7 @@ bundles.post("/bundles/:id/documents/upload", async (c) => {
         workspace_id: bundle.workspace_id,
         chunk_index: i,
         content: ch,
+        context: doc.name,
         embedding: vectors[i],
       }));
       const { error: chunkErr } = await insertChunkRows(db, rows);
@@ -333,7 +334,7 @@ bundles.post("/admin/backfill-embeddings", async (c) => {
 
   const { data: docs, error } = await db
     .from("documents")
-    .select("id,bundle_id,content,knowledge_bundles(workspace_id)")
+    .select("id,bundle_id,name,content,knowledge_bundles(workspace_id)")
     .not("content", "is", null);
   if (error) return c.json({ error: "failed to load documents" }, 500);
 
@@ -342,6 +343,7 @@ bundles.post("/admin/backfill-embeddings", async (c) => {
   for (const d of (docs ?? []) as unknown as Array<{
     id: string;
     bundle_id: string;
+    name: string;
     content: string | null;
     knowledge_bundles: { workspace_id: string } | null;
   }>) {
@@ -373,6 +375,7 @@ bundles.post("/admin/backfill-embeddings", async (c) => {
         workspace_id: workspaceId,
         chunk_index: i,
         content: ch,
+        context: d.name,
         embedding: vectors[i],
       }));
       const { error: insErr } = await insertChunkRows(db, rows);

--- a/worker/src/routes/chat.test.ts
+++ b/worker/src/routes/chat.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type OpenAI from "openai";
 import type { AppEnv } from "../types";
 import { fakeDb, type FakeDbSpec, type QueryContext } from "../test-support/fake-db";
+import { searchTerms } from "../lib/search-terms";
 import { chat } from "./chat";
 
 /**
@@ -173,7 +174,7 @@ function appWith(spec: {
    * key — that presence or absence is the whole of what `resolveModel` reads
    * to decide whether a Claude pick survives.
    */
-  providerEnv?: { OPENAI_API_KEY: string; ANTHROPIC_API_KEY?: string };
+  providerEnv?: { OPENAI_API_KEY: string; ANTHROPIC_API_KEY?: string; RAG_LEXICAL?: string };
   /** The agent's stored model. Defaults to `AGENT.model` (null → the default). */
   agentModel?: string | null;
   /** The agent's own tuning (0048). Undefined leaves both on Auto. */
@@ -192,6 +193,12 @@ function appWith(spec: {
     ...(spec.agentModel !== undefined ? { model: spec.agentModel } : {}),
     ...(spec.agentTuning ?? {}),
   };
+
+  // `fakeDb`'s own `calls` array only records table operations, not RPCs (see
+  // its `rpc()` implementation) — so a signature change to the `match_chunks`
+  // call would sail through unnoticed unless something here captures the args
+  // itself, inside the handler below.
+  const rpcCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
 
   const dbSpec: FakeDbSpec = {
     tables: {
@@ -217,7 +224,10 @@ function appWith(spec: {
       },
     },
     rpc: {
-      match_chunks: () => ({ data: spec.matches ?? [], error: null }),
+      match_chunks: (args: Record<string, unknown>) => {
+        rpcCalls.push({ name: "match_chunks", args });
+        return { data: spec.matches ?? [], error: null };
+      },
     },
   };
 
@@ -231,7 +241,7 @@ function appWith(spec: {
     await next();
   });
   app.route("/", chat);
-  return { app, calls };
+  return { app, calls, rpcCalls };
 }
 
 async function ask(app: Hono<AppEnv>) {
@@ -413,6 +423,30 @@ describe("what gets embedded", () => {
     const [embedded] = embedTexts.mock.calls[0][1];
     expect(embedded).toContain("handbook.md");
     expect(embedded).toContain("peki ikinci maddesi?");
+  });
+});
+
+describe("the lexical arm (Task 5)", () => {
+  it("passes the same query's search terms as p_query_terms", async () => {
+    const question = "What does the handbook say about parental leave in Istanbul?";
+    const { app, rpcCalls } = appWith({ question, documents: [HANDBOOK] });
+    await ask(app);
+
+    const match = rpcCalls.find((c) => c.name === "match_chunks");
+    expect(match?.args.p_query_terms).toEqual(searchTerms(question));
+  });
+
+  it("turns the lexical arm off when RAG_LEXICAL is off", async () => {
+    const question = "What does the handbook say about parental leave in Istanbul?";
+    const { app, rpcCalls } = appWith({
+      question,
+      documents: [HANDBOOK],
+      providerEnv: { OPENAI_API_KEY: "ws-openai", RAG_LEXICAL: "off" },
+    });
+    await ask(app);
+
+    const match = rpcCalls.find((c) => c.name === "match_chunks");
+    expect(match?.args.p_query_terms).toEqual([]);
   });
 });
 

--- a/worker/src/routes/documents.ts
+++ b/worker/src/routes/documents.ts
@@ -237,6 +237,7 @@ documents.post("/documents/:id/reindex", async (c) => {
     workspace_id: workspaceId,
     chunk_index: i,
     content: ch,
+    context: doc.name,
     embedding: vectors[i],
   }));
   const { error: insErr } = await insertChunkRows(db, rows);

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -177,6 +177,13 @@ export type Bindings = SyncEnv & {
    */
   RAG_MIN_SIMILARITY?: string;
   /**
+   * Whether the lexical (keyword / `tsquery`) search arm runs alongside
+   * vector search. Unset or blank means on — see `lexicalSearchEnabled`
+   * in `lib/search-terms.ts` for the resolver and why an empty string
+   * has to mean the same thing as unset.
+   */
+  RAG_LEXICAL?: string;
+  /**
    * The project's JWT signing secret, and the one thing that makes API keys
    * possible: a key is exchanged for a short-lived JWT for its owner, so the
    * request reaches Postgres as that person and RLS decides as it always does.


### PR DESCRIPTION
## What problem does this solve?

Retrieval is pure dense vector search today. A term that appears verbatim in an
uploaded file but means nothing to an embedding model — a contract number, a
person's name, an SKU, an internal acronym — falls under the similarity floor,
and the agent either says it doesn't know or the whole-document fallback fires
and answers from the wrong files. Turkish makes it worse: Postgres ships no
Turkish stemmer, and dense models represent Turkish morphology less reliably.

This adds a lexical (full-text/tsvector) arm to retrieval and fuses it with the
existing vector arm via Reciprocal Rank Fusion — at zero added per-query cost,
no new service, no re-embedding of the existing corpus. Reranking, query
decomposition, and knowledge graphs are explicitly out of scope.

Migration `0049_the_words_as_well_as_the_meaning.sql` adds a `rag_fold()`
Turkish-aware folding function, `context`/`search_tsv` columns on
`document_chunks`, and replaces `match_chunks` with a 5-argument hybrid version
(vector arm + lexical arm, RRF-fused), backward-compatible via a defaulted 5th
argument — safe to apply before the worker deploy. A new `RAG_LEXICAL`
operator dial (mirroring `RAG_MIN_SIMILARITY`) lets a self-hoster turn the
lexical arm off. `tests/rls/hybrid-retrieval.test.ts` is the proof; it only
runs in CI's `rls` job (no Docker/Postgres shim locally).

**Order of operations:** migration first, worker second, never the reverse — a
worker sending a fifth argument to a four-argument function gets a PostgREST
error, and retrieval swallows RPC failures into a persona-only answer, so the
symptom would be silently ungrounded replies rather than a loud 500.

## Checks

```bash
bun run lint && bun run typecheck && bun run check:rls && bun run test
cd worker && bun run typecheck && bun run test
```

- [x] The commands above pass

## If you touched the database

- [x] The change is a **new** migration in `supabase/migrations/`, not an edit
      to an applied one
- [x] Every new table/column has `enable row level security`/carries existing
      RLS, and a policy; `tests/rls/hybrid-retrieval.test.ts` covers the new
      `match_chunks` behavior — it needs a real database and only runs in CI's
      `rls` job, not locally

## If you touched `serviceClient()` or the service-role key

Not touched.

## If you touched UI

Not touched — this is retrieval/backend only.

---

By opening this pull request you agree to the contributor license agreement in
[`CONTRIBUTING.md`](../CONTRIBUTING.md#contributor-license-agreement).